### PR TITLE
Changes to bam1_core_t and bam1_t documentation

### DIFF
--- a/bam.h
+++ b/bam.h
@@ -168,7 +168,6 @@ typedef struct {
   @abstract Structure for core alignment information.
   @field  tid     chromosome ID, defined by bam_header_t
   @field  pos     0-based leftmost coordinate
-  @field  strand  strand; 0 for forward and 1 otherwise
   @field  bin     bin calculated by bam_reg2bin()
   @field  qual    mapping quality
   @field  l_qname length of the query name
@@ -193,13 +192,15 @@ typedef struct {
   @field  l_aux      length of auxiliary data
   @field  data_len   current length of bam1_t::data
   @field  m_data     maximum length of bam1_t::data
-  @field  data       all variable-length data, concatenated; structure: cigar-qname-seq-qual-aux
+  @field  data       all variable-length data, concatenated; structure: qname-cigar-seq-qual-aux
 
   @discussion Notes:
  
    1. qname is zero tailing and core.l_qname includes the tailing '\0'.
    2. l_qseq is calculated from the total length of an alignment block
       on reading or from CIGAR.
+   3. cigar data is encoded 4 bytes per CIGAR operation.
+   4. seq is nybble-encoded according to bam_nt16_table.
  */
 typedef struct {
 	bam1_core_t core;


### PR DESCRIPTION
Hello samtools devs,

Please consider these changes to bam.h.

I have updated the documentation associated with bam1_core_t and bam1_t to bring it into line with the code behaviour.
- Query strand is no longer represented by a field of its own.
- The order of segments in data appears to have changed.
- Added notes about encoding of cigar and seq data in the bam1_t.data byte array.

thank you
