### PR TITLE
Fix missing declaration for getopt on Mac OS X

### DIFF
--- a/bam_mate.c
+++ b/bam_mate.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include "kstring.h"
 #include "bam.h"
 

--- a/bam_tview.c
+++ b/bam_tview.c
@@ -20,6 +20,7 @@
 #include <assert.h>
 #include <string.h>
 #include <math.h>
+#include <unistd.h>
 #include "bam.h"
 #include "faidx.h"
 #include "bam2bcf.h"

--- a/bedcov.c
+++ b/bedcov.c
@@ -3,6 +3,7 @@
 #include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include "kstring.h"
 #include "bgzf.h"
 #include "bam.h"


### PR DESCRIPTION
Several files are missing this include which prevents compilation on Mac OS X,
# include <unistd.h>

e.g.

$ make
...
gcc -c -g -Wall -O2 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -D_USE_KNETFILE -D_CURSES_LIB=1 -I. bam_tview.c -o bam_tview.o
bam_tview.c: In function ‘bam_tview_main’:
bam_tview.c:462: warning: implicit declaration of function ‘getopt’
bam_tview.c:464: error: ‘optarg’ undeclared (first use in this function)
bam_tview.c:464: error: (Each undeclared identifier is reported only once
bam_tview.c:464: error: for each function it appears in.)
bam_tview.c:468: error: ‘optind’ undeclared (first use in this function)
make[1]: **\* [bam_tview.o] Error 1
make: **\* [all-recur] Error 1
