### PR TITLE
Update MPOS/PNEXT during 'samtools depad'

### DIFF
--- a/padding.c
+++ b/padding.c
@@ -166,7 +166,7 @@ int bam_pad2unpad(samfile_t *in, samfile_t *out, faidx_t *fai)
 		uint32_t *cigar = bam1_cigar(b);
 		n2 = 0;
 		if (b->core.pos == 0 && b->core.tid >= 0 && strcmp(bam1_qname(b), h->target_name[b->core.tid]) == 0) {
-			// fprintf(stderr, "[depad] Found embedded reference %s\n", bam1_qname(b));
+			// fprintf(stderr, "[depad] Found embedded reference '%s'\n", bam1_qname(b));
 			r_tid = b->core.tid;
 			unpad_seq(b, &r);
 			if (h->target_len[r_tid] != r.l) {
@@ -202,6 +202,7 @@ int bam_pad2unpad(samfile_t *in, samfile_t *out, faidx_t *fai)
 				return -1;
 			} else if (b->core.tid == r_tid) {
 				; // good case, reference available
+				//fprintf(stderr, "[depad] Have ref '%s' for read '%s'\n", h->target_name[b->core.tid], bam1_qname(b));
 			} else if (fai) {
 				if (load_unpadded_ref(fai, h->target_name[b->core.tid], h->target_len[b->core.tid], &r)) {
 					fprintf(stderr, "[depad] ERROR: Failed to load '%s' from reference FASTA\n", h->target_name[b->core.tid]);
@@ -271,13 +272,20 @@ int bam_pad2unpad(samfile_t *in, samfile_t *out, faidx_t *fai)
 			n2 = k;
 			replace_cigar(b, n2, cigar2);
 			b->core.pos = posmap[b->core.pos];
-			if (b->core.mpos < 0) {
+			if (b->core.mtid < 0 || b->core.mpos < 0) {
 				/* Nice case, no mate to worry about*/
+				// fprintf(stderr, "[depad] Read '%s' mate not mapped\n", bam1_qname(b));
+				/* TODO - Warning if FLAG says mate should be mapped? */
+				/* Clean up funny input where mate position is given but mate reference is missing: */
+				b->core.mtid = -1;
+				b->core.mpos = -1;
 			} else if (b->core.mtid == b->core.tid) {
 				/* Nice case, same reference */
+				// fprintf(stderr, "[depad] Read '%s' mate mapped to same ref\n", bam1_qname(b));
 				b->core.mpos = posmap[b->core.mpos];
 			} else {
 				/* Nasty case, Must load alternative posmap */
+				// fprintf(stderr, "[depad] Loading reference '%s' temporarily\n", h->target_name[b->core.mtid]);
 				if (!fai) {
 					fprintf(stderr, "[depad] ERROR: Needed reference %s sequence for mate (and no FASTA file)\n", h->target_name[b->core.mtid]);
 					return -1;


### PR DESCRIPTION
This branch extends 'samtools depad' to update the mate positions (field MPOS aka PNEXT). This currently requires the user to provide a FASTA reference file (via the -T argument). Without this work you'd have to run a mate-fixing script to clean up any paired-end data processed using 'samtools depad'. 

There is scope for optimising the runtime at the expense of higher memory usage by holding another mapping array in memory. If need be a more memory efficient structure for the mapping array could be used (rather than simply storing one integer for each base of the reference).
