### PR TITLE
Fix creation of example.bai filename from example.bam

### DIFF
--- a/bam_index.c
+++ b/bam_index.c
@@ -402,12 +402,16 @@ bam_index_t *bam_index_load_local(const char *_fn)
 	strcpy(fnidx, fn); strcat(fnidx, ".bai");
 	fp = fopen(fnidx, "rb");
 	if (fp == 0) { // try "{base}.bai"
-		char *s = strstr(fn, "bam");
-		if (s == fn + strlen(fn) - 3) {
+		if (strlen(fn) > 4 && 0==strcmp(".bam", fn + strlen(fn)-4)) {
 			strcpy(fnidx, fn);
+			// Change *.bam into *.bai by swapping m to i
 			fnidx[strlen(fn)-1] = 'i';
+			fprintf(stderr, "[bam_index_load] Trying fall back index file %s\n", fnidx);
 			fp = fopen(fnidx, "rb");
 		}
+	}
+	if (fp == 0) {
+		fprintf(stderr, "[bam_index_load] Neither %s.bai nor %s found\n", fn, fnidx);
 	}
 	free(fnidx); free(fn);
 	if (fp) {


### PR DESCRIPTION
Old code would edit the first 'bam' in the filename,
thus example_bam_file.bam --> example_bai_file.bam,
and so not find the index file example_bam_file.bai
(if the prefered example_bam_file.bam.bai were missing).

Bug reported on the samtools-help mailing list:
https://sourceforge.net/mailarchive/message.php?msg_id=29820839

This commit also adds a stderr message listing the two
BAI filenames tried if the index is not found.