### PR TITLE
Raise error if give @HD SO:coordinate to 'samtools fixmate'

### DIFF
--- a/bam_mate.c
+++ b/bam_mate.c
@@ -40,6 +40,18 @@ void bam_mating_core(bamFile in, bamFile out, int remove_reads)
 
 	str.l = str.m = 0; str.s = 0;
 	header = bam_header_read(in);
+	// Accept unknown, unsorted, or queryname sort order, but error on coordinate sorted.
+	if ((header->l_text > 3) && (strncmp(header->text, "@HD", 3) == 0)) {
+		char *p, *q;
+		p = strstr(header->text, "\tSO:coordinate");
+		q = strchr(header->text, '\n');
+		// Looking for SO:coordinate within the @HD line only
+		// (e.g. must ignore in a @CO comment line later in header)
+		if ((p != 0) && (p < q)) {
+			fprintf(stderr, "[bam_mating_core] ERROR: Coordinate sorted, require grouped/sorted by queryname.\n");
+			exit(1);
+		}
+	}
 	bam_header_write(out, header);
 
 	b[0] = bam_init1();
@@ -102,10 +114,13 @@ void bam_mating_core(bamFile in, bamFile out, int remove_reads)
 
 void usage()
 {
-    fprintf(stderr,"Usage: samtools fixmate <in.nameSrt.bam> <out.nameSrt.bam>\n");
-    fprintf(stderr,"Options:\n");
-    fprintf(stderr,"       -r    remove unmapped reads and secondary alignments\n");
-    exit(1);
+	fprintf(stderr,"Usage: samtools fixmate <in.nameSrt.bam> <out.nameSrt.bam>\n\n");
+	fprintf(stderr,"Options:\n");
+	fprintf(stderr,"       -r    remove unmapped reads and secondary alignments\n\n");
+	fprintf(stderr,"As elsewhere in samtools, use '-' as the filename for stdin/stdout. The input\n");
+	fprintf(stderr,"file must be grouped by read name (e.g. sorted by name). Coordinated sorted\n");
+	fprintf(stderr,"input is not accepted.\n");
+	exit(1);
 }
 
 int bam_mating(int argc, char *argv[])


### PR DESCRIPTION
The (minimal) documentation does tell you 'samtools fixmate' requires query name sorted reads (in fact grouped by query name is enough), but doesn't actually raise an error if given coordinate sorted reads (it just silently fails to fix them).

This change raises an explicit error if the @HD line contains SO:coordinate, and expands the usage text slightly.
