### PR TITLE
samtools view bug fix

### DIFF
--- a/bam_aux.c
+++ b/bam_aux.c
@@ -141,8 +141,10 @@ int bam_parse_region(bam_header_t *header, const char *str, int *ref_id, int *be
 			} else s[name_end] = ':', name_end = l;
 		}
 	} else iter = kh_get(s, h, str);
-        if (iter == kh_end(h))
-          free(s); return -1;
+        if (iter == kh_end(h)) {
+          free(s); 
+          return -1;
+        }
 	*ref_id = kh_val(h, iter);
 	// parse the interval
 	if (name_end < l) {


### PR DESCRIPTION
I noticed that using `samtools view file.bam blahblah` returns some alignments, when it should explicitly error out and say `blahblah` is an unknown reference name. This is due to the lack of `iter` being checked with `kh_end(h)`. 

Edit: sorry this is two commits; I didn't want to change history, and in my haste to add `free()`, I forgot to add braces (d'oh).
