### PR TITLE
Added block size parameter for reduced I/O operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,15 @@ CFLAGS=		-g -Wall -O2
 #LDFLAGS=		-Wl,-rpath,\$$ORIGIN/../lib
 DFLAGS=		-D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -D_USE_KNETFILE -D_CURSES_LIB=1
 KNETFILE_O=	knetfile.o
-LOBJS=		globals.o bgzf.o kstring.o bam_aux.o bam.o bam_import.o sam.o bam_index.o	\
+LOBJS=		bgzf.o kstring.o bam_aux.o bam.o bam_import.o sam.o bam_index.o	\
 			bam_pileup.o bam_lpileup.o bam_md.o razf.o faidx.o bedidx.o \
-			$(KNETFILE_O) bam_sort.o sam_header.o bam_reheader.o kprobaln.o bam_cat.o
-AOBJS=		globals.o bam_tview.o bam_plcmd.o sam_view.o \
+			$(KNETFILE_O) bam_sort.o sam_header.o bam_reheader.o kprobaln.o \
+			bam_cat.o globals.o 
+AOBJS=		bam_tview.o bam_plcmd.o sam_view.o \
 			bam_rmdup.o bam_rmdupse.o bam_mate.o bam_stat.o bam_color.o \
 			bamtk.o kaln.o bam2bcf.o bam2bcf_indel.o errmod.o sample.o \
-			cut_target.o phase.o bam2depth.o padding.o bedcov.o bamshuf.o
+			cut_target.o phase.o bam2depth.o padding.o bedcov.o bamshuf.o \
+			globals.o 
 PROG=		samtools
 INCLUDES=	-I.
 SUBDIRS=	. bcftools misc

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ CFLAGS=		-g -Wall -O2
 #LDFLAGS=		-Wl,-rpath,\$$ORIGIN/../lib
 DFLAGS=		-D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -D_USE_KNETFILE -D_CURSES_LIB=1
 KNETFILE_O=	knetfile.o
-LOBJS=		bgzf.o kstring.o bam_aux.o bam.o bam_import.o sam.o bam_index.o	\
+LOBJS=		globals.o bgzf.o kstring.o bam_aux.o bam.o bam_import.o sam.o bam_index.o	\
 			bam_pileup.o bam_lpileup.o bam_md.o razf.o faidx.o bedidx.o \
 			$(KNETFILE_O) bam_sort.o sam_header.o bam_reheader.o kprobaln.o bam_cat.o
-AOBJS=		bam_tview.o bam_plcmd.o sam_view.o \
+AOBJS=		globals.o bam_tview.o bam_plcmd.o sam_view.o \
 			bam_rmdup.o bam_rmdupse.o bam_mate.o bam_stat.o bam_color.o \
 			bamtk.o kaln.o bam2bcf.o bam2bcf_indel.o errmod.o sample.o \
 			cut_target.o phase.o bam2depth.o padding.o bedcov.o bamshuf.o
@@ -72,6 +72,7 @@ bam2bcf_indel.o:bam2bcf.h
 errmod.o:errmod.h
 phase.o:bam.h khash.h ksort.h
 bamtk.o:bam.h
+globals.o:globals.h
 
 faidx.o:faidx.h razf.h khash.h
 faidx_main.o:faidx.h razf.h

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,11 @@ DFLAGS=		-D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -D_USE_KNETFILE -D_CURSES_
 KNETFILE_O=	knetfile.o
 LOBJS=		bgzf.o kstring.o bam_aux.o bam.o bam_import.o sam.o bam_index.o	\
 			bam_pileup.o bam_lpileup.o bam_md.o razf.o faidx.o bedidx.o \
-			$(KNETFILE_O) bam_sort.o sam_header.o bam_reheader.o kprobaln.o \
-			bam_cat.o globals.o 
+			$(KNETFILE_O) bam_sort.o sam_header.o bam_reheader.o kprobaln.o bam_cat.o globals.o
 AOBJS=		bam_tview.o bam_plcmd.o sam_view.o \
 			bam_rmdup.o bam_rmdupse.o bam_mate.o bam_stat.o bam_color.o \
 			bamtk.o kaln.o bam2bcf.o bam2bcf_indel.o errmod.o sample.o \
-			cut_target.o phase.o bam2depth.o padding.o bedcov.o bamshuf.o \
-			globals.o 
+			cut_target.o phase.o bam2depth.o padding.o bedcov.o bamshuf.o globals.o
 PROG=		samtools
 INCLUDES=	-I.
 SUBDIRS=	. bcftools misc

--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -5,11 +5,12 @@ DFLAGS=		-D_USE_KNETFILE -D_CURSES_LIB=2
 KNETFILE_O=	knetfile.o
 LOBJS=		bgzf.o kstring.o bam_aux.o bam.o bam_import.o sam.o bam_index.o	\
 			bam_pileup.o bam_lpileup.o bam_md.o razf.o faidx.o \
-			$(KNETFILE_O) bam_sort.o sam_header.o bam_reheader.o kprobaln.o bedidx.o
+			$(KNETFILE_O) bam_sort.o sam_header.o bam_reheader.o kprobaln.o \
+			bedidx.o globals.o
 AOBJS=		bam_tview.o bam_plcmd.o sam_view.o \
 			bam_rmdup.o bam_rmdupse.o bam_mate.o bam_stat.o bam_color.o	\
 			bamtk.o kaln.o bam2bcf.o bam2bcf_indel.o errmod.o sample.o \
-			cut_target.o phase.o bam_cat.o bam2depth.o
+			cut_target.o phase.o bam_cat.o bam2depth.o globals.o
 BCFOBJS=	bcftools/bcf.o bcftools/fet.o bcftools/bcf2qcall.o bcftools/bcfutils.o \
 			bcftools/call1.o bcftools/index.o bcftools/kfunc.o bcftools/em.o \
 			bcftools/kmin.o bcftools/prob1.o bcftools/vcf.o bcftools/mut.o
@@ -55,6 +56,7 @@ bcf.o:bcftools/bcf.h
 bam2bcf.o:bam2bcf.h errmod.h bcftools/bcf.h
 bam2bcf_indel.o:bam2bcf.h
 errmod.o:errmod.h
+globals.o:globals.h
 
 faidx.o:faidx.h razf.h khash.h
 faidx_main.o:faidx.h razf.h

--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -5,8 +5,7 @@ DFLAGS=		-D_USE_KNETFILE -D_CURSES_LIB=2
 KNETFILE_O=	knetfile.o
 LOBJS=		bgzf.o kstring.o bam_aux.o bam.o bam_import.o sam.o bam_index.o	\
 			bam_pileup.o bam_lpileup.o bam_md.o razf.o faidx.o \
-			$(KNETFILE_O) bam_sort.o sam_header.o bam_reheader.o kprobaln.o \
-			bedidx.o globals.o
+			$(KNETFILE_O) bam_sort.o sam_header.o bam_reheader.o kprobaln.o bedidx.o globals.o
 AOBJS=		bam_tview.o bam_plcmd.o sam_view.o \
 			bam_rmdup.o bam_rmdupse.o bam_mate.o bam_stat.o bam_color.o	\
 			bamtk.o kaln.o bam2bcf.o bam2bcf_indel.o errmod.o sample.o \

--- a/bam_import.c
+++ b/bam_import.c
@@ -13,6 +13,7 @@
 #include "sam_header.h"
 #include "kseq.h"
 #include "khash.h"
+#include "globals.h"
 
 KSTREAM_INIT(gzFile, gzread, 16384)
 KHASH_MAP_INIT_STR(ref, uint64_t)
@@ -74,6 +75,8 @@ char **__bam_get_lines(const char *fn, int *_n) // for bam_plcmd.c only
 	char **list = 0, *s;
 	int n = 0, dret, m = 0;
 	gzFile fp = (strcmp(fn, "-") == 0)? gzdopen(fileno(stdin), "r") : gzopen(fn, "r");
+	if (g_block_size > 0)
+		gzbuffer(fp, g_block_size * 1024);
 	kstream_t *ks;
 	kstring_t *str;
 	str = (kstring_t*)calloc(1, sizeof(kstring_t));
@@ -125,6 +128,8 @@ bam_header_t *sam_header_read2(const char *fn)
 	if (fn == 0) return 0;
 	fp = (strcmp(fn, "-") == 0)? gzdopen(fileno(stdin), "r") : gzopen(fn, "r");
 	if (fp == 0) return 0;
+	if (g_block_size > 0)
+		gzbuffer(fp, g_block_size * 1024);
 	hash = kh_init(ref);
 	ks = ks_init(fp);
 	str = (kstring_t*)calloc(1, sizeof(kstring_t));
@@ -471,6 +476,8 @@ tamFile sam_open(const char *fn)
 	tamFile fp;
 	gzFile gzfp = (strcmp(fn, "-") == 0)? gzdopen(fileno(stdin), "rb") : gzopen(fn, "rb");
 	if (gzfp == 0) return 0;
+	if (g_block_size > 0)
+		gzbuffer(gzfp, g_block_size * 1024);
 	fp = (tamFile)calloc(1, sizeof(struct __tamFile_t));
 	fp->str = (kstring_t*)calloc(1, sizeof(kstring_t));
 	fp->fp = gzfp;

--- a/bam_import.c
+++ b/bam_import.c
@@ -76,7 +76,7 @@ char **__bam_get_lines(const char *fn, int *_n) // for bam_plcmd.c only
 	int n = 0, dret, m = 0;
 	gzFile fp = (strcmp(fn, "-") == 0)? gzdopen(fileno(stdin), "r") : gzopen(fn, "r");
 	if (g_block_size > 0)
-		gzbuffer(fp, g_block_size * 1024);
+		gzbuffer(fp, g_block_size << 10);
 	kstream_t *ks;
 	kstring_t *str;
 	str = (kstring_t*)calloc(1, sizeof(kstring_t));
@@ -129,7 +129,7 @@ bam_header_t *sam_header_read2(const char *fn)
 	fp = (strcmp(fn, "-") == 0)? gzdopen(fileno(stdin), "r") : gzopen(fn, "r");
 	if (fp == 0) return 0;
 	if (g_block_size > 0)
-		gzbuffer(fp, g_block_size * 1024);
+		gzbuffer(fp, g_block_size << 10);
 	hash = kh_init(ref);
 	ks = ks_init(fp);
 	str = (kstring_t*)calloc(1, sizeof(kstring_t));
@@ -477,7 +477,7 @@ tamFile sam_open(const char *fn)
 	gzFile gzfp = (strcmp(fn, "-") == 0)? gzdopen(fileno(stdin), "rb") : gzopen(fn, "rb");
 	if (gzfp == 0) return 0;
 	if (g_block_size > 0)
-		gzbuffer(gzfp, g_block_size * 1024);
+		gzbuffer(gzfp, g_block_size << 10);
 	fp = (tamFile)calloc(1, sizeof(struct __tamFile_t));
 	fp->str = (kstring_t*)calloc(1, sizeof(kstring_t));
 	fp->fp = gzfp;

--- a/bam_index.c
+++ b/bam_index.c
@@ -519,14 +519,14 @@ int bam_index_build(const char *fn)
 int bam_index(int argc, char *argv[])
 {
 	int c;
-	while ((c = getopt(argc, argv, "d:")) >= 0) {
+	while ((c = getopt(argc, argv, "z:")) >= 0) {
 		switch (c) {
-		case 'd': g_block_size = atoi(optarg); break;
+		case 'z': g_block_size = atoi(optarg); break;
 		}
 	}
 	if (argc < 2) {
 		fprintf(stderr, "Usage: samtools index [options] <in.bam> [out.index]\n");
-		fprintf(stderr, "Options: -d INT   specify I/O buffer size in kB\n\n");
+		fprintf(stderr, "Options: -z INT   specify I/O buffer size in kB\n\n");
 		return 1;
 	}
 	if (argc > optind + 1) bam_index_build2(argv[optind], argv[optind + 1]);

--- a/bam_index.c
+++ b/bam_index.c
@@ -499,8 +499,8 @@ int bam_index_build2(const char *fn, const char *_fnidx)
 	}
 	char *buffer = 0;
 	if (g_block_size > 0) {
-		buffer = malloc(g_block_size * 1024);
-		setvbuf(fpidx, buffer, _IOFBF, g_block_size * 1024);
+		buffer = malloc(g_block_size << 10);
+		setvbuf(fpidx, buffer, _IOFBF, g_block_size << 10);
 	}
 	bam_index_save(idx, fpidx);
 	bam_index_destroy(idx);

--- a/bam_index.c
+++ b/bam_index.c
@@ -529,7 +529,7 @@ int bam_index(int argc, char *argv[])
 		fprintf(stderr, "Options: -d INT   specify I/O buffer size in kB\n\n");
 		return 1;
 	}
-	if (argc >= 3) bam_index_build2(argv[optind], argv[optind + 1]);
+	if (argc > optind + 1) bam_index_build2(argv[optind], argv[optind + 1]);
 	else bam_index_build(argv[optind]);
 	return 0;
 }

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -144,7 +144,7 @@ int bam_merge_core2(int by_qname, const char *out, const char *headers, int n, c
 			return -1;
 		}
 		if (g_block_size > 0)
-			gzbuffer(fp[i], g_block_size * 1024);
+			gzbuffer(fp[i], g_block_size << 10);
 
 		hin = bam_header_read(fp[i]);
 		if (i == 0) { // the first BAM
@@ -383,7 +383,7 @@ static void write_buffer(const char *fn, const char *mode, size_t l, bam1_p *buf
 	fp = strcmp(fn, "-")? bam_open(fn, mode) : bam_dopen(fileno(stdout), mode);
 	if (fp == 0) return;
 	if (g_block_size > 0)
-		gzbuffer(fp, g_block_size * 1024);
+		gzbuffer(fp, g_block_size << 10);
 	bam_header_write(fp, h);
 	if (n_threads > 1) bgzf_mt(fp, n_threads, 256);
 	for (i = 0; i < l; ++i)
@@ -467,7 +467,7 @@ void bam_sort_core_ext(int is_by_qname, const char *fn, const char *prefix, size
 		return;
 	}
 	if (g_block_size > 0)
-		gzbuffer(fp, g_block_size * 1024);
+		gzbuffer(fp, g_block_size << 10);
 	header = bam_header_read(fp);
 	if (is_by_qname) change_SO(header, "queryname");
 	else change_SO(header, "coordinate");

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -143,7 +143,6 @@ int bam_merge_core2(int by_qname, const char *out, const char *headers, int n, c
 			// FIXME: possible memory leak
 			return -1;
 		}
-
 		hin = bam_header_read(fp[i]);
 		if (i == 0) { // the first BAM
 			hout = hin;

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -143,8 +143,6 @@ int bam_merge_core2(int by_qname, const char *out, const char *headers, int n, c
 			// FIXME: possible memory leak
 			return -1;
 		}
-		if (g_block_size > 0)
-			gzbuffer(fp[i], g_block_size << 10);
 
 		hin = bam_header_read(fp[i]);
 		if (i == 0) { // the first BAM
@@ -382,8 +380,6 @@ static void write_buffer(const char *fn, const char *mode, size_t l, bam1_p *buf
 	bamFile fp;
 	fp = strcmp(fn, "-")? bam_open(fn, mode) : bam_dopen(fileno(stdout), mode);
 	if (fp == 0) return;
-	if (g_block_size > 0)
-		gzbuffer(fp, g_block_size << 10);
 	bam_header_write(fp, h);
 	if (n_threads > 1) bgzf_mt(fp, n_threads, 256);
 	for (i = 0; i < l; ++i)
@@ -466,8 +462,6 @@ void bam_sort_core_ext(int is_by_qname, const char *fn, const char *prefix, size
 		fprintf(stderr, "[bam_sort_core] fail to open file %s\n", fn);
 		return;
 	}
-	if (g_block_size > 0)
-		gzbuffer(fp, g_block_size << 10);
 	header = bam_header_read(fp);
 	if (is_by_qname) change_SO(header, "queryname");
 	else change_SO(header, "coordinate");

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -271,7 +271,7 @@ int bam_merge(int argc, char *argv[])
 	int c, is_by_qname = 0, flag = 0, ret = 0, n_threads = 0, level = -1;
 	char *fn_headers = NULL, *reg = 0;
 
-	while ((c = getopt(argc, argv, "h:nru1R:f@:l:d:")) >= 0) {
+	while ((c = getopt(argc, argv, "h:nru1R:f@:l:z:")) >= 0) {
 		switch (c) {
 		case 'r': flag |= MERGE_RG; break;
 		case 'f': flag |= MERGE_FORCE; break;
@@ -282,7 +282,7 @@ int bam_merge(int argc, char *argv[])
 		case 'R': reg = strdup(optarg); break;
 		case 'l': level = atoi(optarg); break;
 		case '@': n_threads = atoi(optarg); break;
-		case 'd': g_block_size = atoi(optarg); break;
+		case 'z': g_block_size = atoi(optarg); break;
 		}
 	}
 	if (optind + 2 >= argc) {
@@ -297,7 +297,7 @@ int bam_merge(int argc, char *argv[])
 		fprintf(stderr, "         -@ INT   number of BAM compression threads [0]\n");
 		fprintf(stderr, "         -R STR   merge file in the specified region STR [all]\n");
 		fprintf(stderr, "         -h FILE  copy the header in FILE to <out.bam> [in1.bam]\n");
-		fprintf(stderr, "         -d INT   specify I/O buffer size in kB\n\n");
+		fprintf(stderr, "         -z INT   specify I/O buffer size in kB\n\n");
 		fprintf(stderr, "Note: Samtools' merge does not reconstruct the @RG dictionary in the header. Users\n");
 		fprintf(stderr, "      must provide the correct header with -h, or uses Picard which properly maintains\n");
 		fprintf(stderr, "      the header dictionary in merging.\n\n");
@@ -544,7 +544,7 @@ int bam_sort(int argc, char *argv[])
 {
 	size_t max_mem = 768<<20; // 512MB
 	int c, is_by_qname = 0, is_stdout = 0, n_threads = 0, level = -1;
-	while ((c = getopt(argc, argv, "nom:@:l:d:")) >= 0) {
+	while ((c = getopt(argc, argv, "nom:@:l:z:")) >= 0) {
 		switch (c) {
 		case 'o': is_stdout = 1; break;
 		case 'n': is_by_qname = 1; break;
@@ -558,7 +558,7 @@ int bam_sort(int argc, char *argv[])
 			}
 		case '@': n_threads = atoi(optarg); break;
 		case 'l': level = atoi(optarg); break;
-		case 'd': g_block_size = atoi(optarg); break;
+		case 'z': g_block_size = atoi(optarg); break;
 		}
 	}
 	if (optind + 2 > argc) {
@@ -569,7 +569,7 @@ int bam_sort(int argc, char *argv[])
 		fprintf(stderr, "         -l INT    compression level, from 0 to 9 [-1]\n");
 		fprintf(stderr, "         -@ INT    number of sorting and compression threads [1]\n");
 		fprintf(stderr, "         -m INT    max memory per thread; suffix K/M/G recognized [768M]\n");
-		fprintf(stderr, "         -d INT    specify I/O buffer size in kB\n\n");
+		fprintf(stderr, "         -z INT    specify I/O buffer size in kB\n\n");
 		fprintf(stderr, "\n");
 		return 1;
 	}

--- a/bcftools/Makefile
+++ b/bcftools/Makefile
@@ -3,7 +3,7 @@ CFLAGS=		-g -Wall -O2 #-m64 #-arch ppc
 DFLAGS=		-D_FILE_OFFSET_BITS=64 -D_USE_KNETFILE
 LOBJS=		bcf.o vcf.o bcfutils.o prob1.o em.o kfunc.o kmin.o index.o fet.o mut.o bcf2qcall.o
 OMISC=		..
-AOBJS=		call1.o main.o $(OMISC)/kstring.o $(OMISC)/bgzf.o $(OMISC)/knetfile.o $(OMISC)/bedidx.o
+AOBJS=		call1.o main.o $(OMISC)/kstring.o $(OMISC)/bgzf.o $(OMISC)/knetfile.o $(OMISC)/bedidx.o $(OMISC)/globals.o
 PROG=		bcftools
 INCLUDES=	
 SUBDIRS=	.

--- a/bedcov.c
+++ b/bedcov.c
@@ -7,6 +7,7 @@
 #include "kstring.h"
 #include "bgzf.h"
 #include "bam.h"
+#include "globals.h"
 
 #include "kseq.h"
 KSTREAM_INIT(gzFile, gzread, 16384)
@@ -67,6 +68,8 @@ int main_bedcov(int argc, char *argv[])
 	cnt = calloc(n, 8);
 
 	fp = gzopen(argv[optind], "rb");
+	if (g_block_size > 0)
+		gzbuffer(fp, g_block_size * 1024);
 	ks = ks_init(fp);
 	n_plp = calloc(n, sizeof(int));
 	plp = calloc(n, sizeof(void*));

--- a/bedcov.c
+++ b/bedcov.c
@@ -69,7 +69,7 @@ int main_bedcov(int argc, char *argv[])
 
 	fp = gzopen(argv[optind], "rb");
 	if (g_block_size > 0)
-		gzbuffer(fp, g_block_size * 1024);
+		gzbuffer(fp, g_block_size << 10);
 	ks = ks_init(fp);
 	n_plp = calloc(n, sizeof(int));
 	plp = calloc(n, sizeof(void*));

--- a/bedidx.c
+++ b/bedidx.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <zlib.h>
+#include "globals.h"
 
 #ifdef _WIN32
 #define drand48() ((double)rand() / RAND_MAX)
@@ -106,6 +107,8 @@ void *bed_read(const char *fn)
 	// read the list
 	fp = strcmp(fn, "-")? gzopen(fn, "r") : gzdopen(fileno(stdin), "r");
 	if (fp == 0) return 0;
+	if (g_block_size > 0)
+		gzbuffer(fp, g_block_size * 1024);
 	str = calloc(1, sizeof(kstring_t));
 	ks = ks_init(fp);
 	while (ks_getuntil(ks, 0, str, &dret) >= 0) { // read the chr name

--- a/bedidx.c
+++ b/bedidx.c
@@ -108,7 +108,7 @@ void *bed_read(const char *fn)
 	fp = strcmp(fn, "-")? gzopen(fn, "r") : gzdopen(fileno(stdin), "r");
 	if (fp == 0) return 0;
 	if (g_block_size > 0)
-		gzbuffer(fp, g_block_size * 1024);
+		gzbuffer(fp, g_block_size << 10);
 	str = calloc(1, sizeof(kstring_t));
 	ks = ks_init(fp);
 	while (ks_getuntil(ks, 0, str, &dret) >= 0) { // read the chr name

--- a/bgzf.c
+++ b/bgzf.c
@@ -72,7 +72,6 @@ typedef FILE *_bgzf_file_t;
  +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
 */
 static const uint8_t g_magic[19] = "\037\213\010\4\0\0\0\0\0\377\6\0\102\103\2\0\0\0";
-// TODO: DON't FORGET TO CLEAN UP
 
 #ifdef BGZF_CACHE
 typedef struct {

--- a/bgzf.c
+++ b/bgzf.c
@@ -155,8 +155,8 @@ BGZF *bgzf_open(const char *path, const char *mode)
 		fp->fp = fpw;
 		if (g_block_size > 0)
 		{
-			fp->buffer = malloc(g_block_size * 1024);
-			setvbuf(fp->fp, fp->buffer, _IOFBF, g_block_size * 1024);
+			fp->buffer = malloc(g_block_size << 10);
+			setvbuf(fp->fp, fp->buffer, _IOFBF, g_block_size << 10);
 		}
 	}
 	return fp;

--- a/bgzf.h
+++ b/bgzf.h
@@ -50,6 +50,7 @@ typedef struct {
 	void *cache; // a pointer to a hash table
 	void *fp; // actual file handler; FILE* on writing; FILE* or knetFile* on reading
 	void *mt; // only used for multi-threading
+	char *buffer;
 } BGZF;
 
 #ifndef KSTRING_T

--- a/globals.c
+++ b/globals.c
@@ -1,0 +1,29 @@
+/* The MIT License
+
+   Copyright (c) 2008 by Genome Research Ltd (GRL).
+                 2010 by Attractive Chaos <attractor@live.co.uk>
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+#include "globals.h"
+
+int g_block_size = 0;

--- a/globals.h
+++ b/globals.h
@@ -1,0 +1,32 @@
+/* The MIT License
+
+   Copyright (c) 2008 by Genome Research Ltd (GRL).
+                 2010 by Attractive Chaos <attractor@live.co.uk>
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+#ifndef GLOBALS_H
+#define GLOBALS_H
+
+extern int g_block_size;
+
+#endif

--- a/knetfile.c
+++ b/knetfile.c
@@ -488,8 +488,8 @@ knetFile *knet_open(const char *fn, const char *mode)
 		fp->fd = -1;
 		fp->ctrl_fd = -1;
 		if (g_block_size > 0) {
-			fp->buffer = malloc(g_block_size * 1024);
-			setvbuf(fp->fp, fp->buffer, _IOFBF, g_block_size * 1024);
+			fp->buffer = malloc(g_block_size << 10);
+			setvbuf(fp->fp, fp->buffer, _IOFBF, g_block_size << 10);
 		}
 	}
 	if (fp && fp->type != KNF_TYPE_LOCAL && fp->fd == -1) {

--- a/knetfile.c
+++ b/knetfile.c
@@ -485,6 +485,7 @@ knetFile *knet_open(const char *fn, const char *mode)
 		fp = (knetFile*)calloc(1, sizeof(knetFile));
 		fp->type = KNF_TYPE_LOCAL;
 		fp->fp = fpf;
+		fp->fd = -1;
 		fp->ctrl_fd = -1;
 		if (g_block_size > 0) {
 			fp->buffer = malloc(g_block_size * 1024);
@@ -507,6 +508,7 @@ knetFile *knet_dopen(int fd, const char *mode)
 	knetFile *fp = (knetFile*)calloc(1, sizeof(knetFile));
 	fp->type = KNF_TYPE_LOCAL;
 	fp->fp = fdopen(fd, mode);
+	fp->fd = -1;
 	return fp;
 }
 

--- a/knetfile.c
+++ b/knetfile.c
@@ -43,6 +43,8 @@
 #include <sys/socket.h>
 #endif
 
+#include "globals.h"
+
 #include "knetfile.h"
 
 /* In winsock.h, the type of a socket is SOCKET, which is: "typedef
@@ -472,20 +474,28 @@ knetFile *knet_open(const char *fn, const char *mode)
 		/* In windows, O_BINARY is necessary. In Linux/Mac, O_BINARY may
 		 * be undefined on some systems, although it is defined on my
 		 * Mac and the Linux I have tested on. */
-		int fd = open(fn, O_RDONLY | O_BINARY);
+		FILE *fpf = fopen(fn, "rb");
 #else		
-		int fd = open(fn, O_RDONLY);
+		FILE *fpf = fopen(fn, "r");
 #endif
-		if (fd == -1) {
+		if (!fpf) {
 			perror("open");
 			return 0;
 		}
 		fp = (knetFile*)calloc(1, sizeof(knetFile));
 		fp->type = KNF_TYPE_LOCAL;
-		fp->fd = fd;
+		fp->fp = fpf;
 		fp->ctrl_fd = -1;
+		if (g_block_size > 0) {
+			fp->buffer = malloc(g_block_size * 1024);
+			setvbuf(fp->fp, fp->buffer, _IOFBF, g_block_size * 1024);
+		}
 	}
-	if (fp && fp->fd == -1) {
+	if (fp && fp->type != KNF_TYPE_LOCAL && fp->fd == -1) {
+		knet_close(fp);
+		return 0;
+	}
+	if (fp && fp->type == KNF_TYPE_LOCAL && !fp->fp) {
 		knet_close(fp);
 		return 0;
 	}
@@ -496,14 +506,18 @@ knetFile *knet_dopen(int fd, const char *mode)
 {
 	knetFile *fp = (knetFile*)calloc(1, sizeof(knetFile));
 	fp->type = KNF_TYPE_LOCAL;
-	fp->fd = fd;
+	fp->fp = fdopen(fd, mode);
 	return fp;
 }
 
 off_t knet_read(knetFile *fp, void *buf, off_t len)
 {
 	off_t l = 0;
-	if (fp->fd == -1) return 0;
+	if (fp->type == KNF_TYPE_LOCAL) {
+		if (!fp->fp) return 0;
+	} else {
+		if (fp->fd == -1) return 0;
+	}
 	if (fp->type == KNF_TYPE_FTP) {
 		if (fp->is_ready == 0) {
 			if (!fp->no_reconnect) kftp_reconnect(fp);
@@ -517,7 +531,7 @@ off_t knet_read(knetFile *fp, void *buf, off_t len)
 		off_t rest = len, curr;
 		while (rest) {
 			do {
-				curr = read(fp->fd, buf + l, rest);
+				curr = fread(buf + l, 1, rest, fp->fp);
 			} while (curr < 0 && EINTR == errno);
 			if (curr < 0) return -1;
 			if (curr == 0) break;
@@ -534,7 +548,7 @@ off_t knet_seek(knetFile *fp, int64_t off, int whence)
 	if (fp->type == KNF_TYPE_LOCAL) {
 		/* Be aware that lseek() returns the offset after seeking,
 		 * while fseek() returns zero on success. */
-		off_t offset = lseek(fp->fd, off, whence);
+		off_t offset = fseek(fp->fp, off, whence);
 		if (offset == -1) {
             // Be silent, it is OK for knet_seek to fail when the file is streamed
             // fprintf(stderr,"[knet_seek] %s\n", strerror(errno));
@@ -577,15 +591,22 @@ int knet_close(knetFile *fp)
 {
 	if (fp == 0) return 0;
 	if (fp->ctrl_fd != -1) netclose(fp->ctrl_fd); // FTP specific
-	if (fp->fd != -1) {
-		/* On Linux/Mac, netclose() is an alias of close(), but on
-		 * Windows, it is an alias of closesocket(). */
-		if (fp->type == KNF_TYPE_LOCAL) close(fp->fd);
-		else netclose(fp->fd);
+	if (fp->type == KNF_TYPE_LOCAL) {
+		if (fp->fp) {
+			fclose(fp->fp);
+		}
+	} else {
+		if (fp->fd != -1) {
+			/* On Linux/Mac, netclose() is an alias of close(), but on
+			* Windows, it is an alias of closesocket(). */
+			netclose(fp->fd);
+		}
 	}
 	free(fp->host); free(fp->port);
 	free(fp->response); free(fp->retr); // FTP specific
 	free(fp->path); free(fp->http_host); // HTTP specific
+	if (fp->buffer)
+		free(fp->buffer);
 	free(fp);
 	return 0;
 }

--- a/knetfile.h
+++ b/knetfile.h
@@ -1,6 +1,7 @@
 #ifndef KNETFILE_H
 #define KNETFILE_H
 
+#include <stdio.h>
 #include <stdint.h>
 #include <fcntl.h>
 
@@ -22,7 +23,10 @@
 #define KNF_TYPE_HTTP  3
 
 typedef struct knetFile_s {
-	int type, fd;
+	int type;
+	int fd;
+	FILE *fp;
+	char *buffer;
 	int64_t offset;
 	char *host, *port;
 

--- a/knetfile.h
+++ b/knetfile.h
@@ -23,8 +23,7 @@
 #define KNF_TYPE_HTTP  3
 
 typedef struct knetFile_s {
-	int type;
-	int fd;
+	int type, fd;
 	FILE *fp;
 	char *buffer;
 	int64_t offset;

--- a/phase.c
+++ b/phase.c
@@ -475,7 +475,7 @@ static khash_t(set64) *loadpos(const char *fn, bam_header_t *h)
 	str = calloc(1, sizeof(kstring_t));
 	fp = strcmp(fn, "-")? gzopen(fn, "r") : gzdopen(fileno(stdin), "r");
 	if (g_block_size > 0)
-		gzbuffer(fp, g_block_size * 1024);
+		gzbuffer(fp, g_block_size << 10);
 	ks = ks_init(fp);
 	while (ks_getuntil(ks, 0, str, &dret) >= 0) {
 		int tid = bam_get_tid(h, str->s);

--- a/phase.c
+++ b/phase.c
@@ -6,6 +6,7 @@
 #include <zlib.h>
 #include "bam.h"
 #include "errmod.h"
+#include "globals.h"
 
 #include "kseq.h"
 KSTREAM_INIT(gzFile, gzread, 16384)
@@ -473,6 +474,8 @@ static khash_t(set64) *loadpos(const char *fn, bam_header_t *h)
 	hash = kh_init(set64);
 	str = calloc(1, sizeof(kstring_t));
 	fp = strcmp(fn, "-")? gzopen(fn, "r") : gzdopen(fileno(stdin), "r");
+	if (g_block_size > 0)
+		gzbuffer(fp, g_block_size * 1024);
 	ks = ks_init(fp);
 	while (ks_getuntil(ks, 0, str, &dret) >= 0) {
 		int tid = bam_get_tid(h, str->s);

--- a/sam.c
+++ b/sam.c
@@ -113,19 +113,14 @@ samfile_t *samopen(const char *fn, const char *mode, const void *aux)
 			}
 		}
 	}
-	if (g_block_size > 0)
-	{
+	if (g_block_size > 0) {
 		if (fp->type & TYPE_BAM) {
-			fp->buffer = malloc(g_block_size * 1024);
-			setvbuf(fp->x.bam->fp, fp->buffer, _IOFBF, g_block_size * 1024);
-		}
-		else if (fp->type & TYPE_READ)
-		{
-		}
-		else
-		{
-			fp->buffer = malloc(g_block_size * 1024);
-			setvbuf(fp->x.tamw, fp->buffer, _IOFBF, g_block_size * 1024);
+			fp->buffer = malloc(g_block_size << 10);
+			setvbuf(fp->x.bam->fp, fp->buffer, _IOFBF, g_block_size << 10);
+		} else if (fp->type & TYPE_READ) {
+		} else {
+			fp->buffer = malloc(g_block_size << 10);
+			setvbuf(fp->x.tamw, fp->buffer, _IOFBF, g_block_size << 10);
 		}
 	}
 	return fp;

--- a/sam.c
+++ b/sam.c
@@ -2,6 +2,7 @@
 #include <unistd.h>
 #include "faidx.h"
 #include "sam.h"
+#include "globals.h"
 
 #define TYPE_BAM  1
 #define TYPE_READ 2
@@ -112,6 +113,21 @@ samfile_t *samopen(const char *fn, const char *mode, const void *aux)
 			}
 		}
 	}
+	if (g_block_size > 0)
+	{
+		if (fp->type & TYPE_BAM) {
+			fp->buffer = malloc(g_block_size * 1024);
+			setvbuf(fp->x.bam->fp, fp->buffer, _IOFBF, g_block_size * 1024);
+		}
+		else if (fp->type & TYPE_READ)
+		{
+		}
+		else
+		{
+			fp->buffer = malloc(g_block_size * 1024);
+			setvbuf(fp->x.tamw, fp->buffer, _IOFBF, g_block_size * 1024);
+		}
+	}
 	return fp;
 
 open_err_ret:
@@ -126,6 +142,8 @@ void samclose(samfile_t *fp)
 	if (fp->type & TYPE_BAM) bam_close(fp->x.bam);
 	else if (fp->type & TYPE_READ) sam_close(fp->x.tamr);
 	else fclose(fp->x.tamw);
+	if (fp->buffer)
+		free(fp->buffer);
 	free(fp);
 }
 

--- a/sam.h
+++ b/sam.h
@@ -2,6 +2,7 @@
 #define BAM_SAM_H
 
 #include "bam.h"
+#include "globals.h"
 
 /*!
   @header
@@ -20,6 +21,7 @@
   @field  tamr  SAM file handler for reading; valid if type == 2
   @field  tamw  SAM file handler for writing; valid if type == 0
   @field  header  header struct
+  @field  buffer  a larger buffer for the file, if desired (to reduce number read/write syscalls)
  */
 typedef struct {
 	int type;
@@ -29,6 +31,7 @@ typedef struct {
 		FILE *tamw;
 	} x;
 	bam_header_t *header;
+	char* buffer;
 } samfile_t;
 
 #ifdef __cplusplus

--- a/sam_view.c
+++ b/sam_view.c
@@ -135,7 +135,7 @@ int main_samview(int argc, char *argv[])
 
 	/* parse command-line options */
 	strcpy(in_mode, "r"); strcpy(out_mode, "w");
-	while ((c = getopt(argc, argv, "SbBct:h1Ho:q:f:F:d:ul:r:xX?T:R:L:s:Q:@:m:")) >= 0) {
+	while ((c = getopt(argc, argv, "SbBct:h1Ho:q:f:F:z:ul:r:xX?T:R:L:s:Q:@:m:")) >= 0) {
 		switch (c) {
 		case 's':
 			if ((g_subsam_seed = strtol(optarg, &q, 10)) != 0) {
@@ -168,7 +168,7 @@ int main_samview(int argc, char *argv[])
 		case 'B': bam_no_B = 1; break;
 		case 'Q': g_qual_scale = atoi(optarg); break;
 		case '@': n_threads = strtol(optarg, 0, 0); break;
-		case 'd': g_block_size = strtol(optarg, 0, 0); break;
+		case 'z': g_block_size = strtol(optarg, 0, 0); break;
 		default: return usage(is_long_help);
 		}
 	}
@@ -319,7 +319,7 @@ static int usage(int is_long_help)
 	fprintf(stderr, "         -l STR   only output reads in library STR [null]\n");
 	fprintf(stderr, "         -r STR   only output reads in read group STR [null]\n");
 	fprintf(stderr, "         -s FLOAT fraction of templates to subsample; integer part as seed [-1]\n");
-	fprintf(stderr, "         -d INT   specify I/O buffer size in kB\n");
+	fprintf(stderr, "         -z INT   specify I/O buffer size in kB\n");
 	fprintf(stderr, "         -?       longer help\n");
 	fprintf(stderr, "\n");
 	if (is_long_help)

--- a/sam_view.c
+++ b/sam_view.c
@@ -8,6 +8,7 @@
 #include "faidx.h"
 #include "kstring.h"
 #include "khash.h"
+#include "globals.h"
 KHASH_SET_INIT_STR(rg)
 
 // When counting records instead of printing them,
@@ -134,7 +135,7 @@ int main_samview(int argc, char *argv[])
 
 	/* parse command-line options */
 	strcpy(in_mode, "r"); strcpy(out_mode, "w");
-	while ((c = getopt(argc, argv, "SbBct:h1Ho:q:f:F:ul:r:xX?T:R:L:s:Q:@:m:")) >= 0) {
+	while ((c = getopt(argc, argv, "SbBct:h1Ho:q:f:F:d:ul:r:xX?T:R:L:s:Q:@:m:")) >= 0) {
 		switch (c) {
 		case 's':
 			if ((g_subsam_seed = strtol(optarg, &q, 10)) != 0) {
@@ -167,6 +168,7 @@ int main_samview(int argc, char *argv[])
 		case 'B': bam_no_B = 1; break;
 		case 'Q': g_qual_scale = atoi(optarg); break;
 		case '@': n_threads = strtol(optarg, 0, 0); break;
+		case 'd': g_block_size = strtol(optarg, 0, 0); break;
 		default: return usage(is_long_help);
 		}
 	}
@@ -317,6 +319,7 @@ static int usage(int is_long_help)
 	fprintf(stderr, "         -l STR   only output reads in library STR [null]\n");
 	fprintf(stderr, "         -r STR   only output reads in read group STR [null]\n");
 	fprintf(stderr, "         -s FLOAT fraction of templates to subsample; integer part as seed [-1]\n");
+	fprintf(stderr, "         -d INT   specify I/O buffer size in kB\n");
 	fprintf(stderr, "         -?       longer help\n");
 	fprintf(stderr, "\n");
 	if (is_long_help)


### PR DESCRIPTION
## Summary

When running samtools on a cluster, the number of I/O syscalls becomes and important factor. An optional, larger buffer greatly improves overall speed because the number of filesystem calls can be reduced by a large amount when a slightly larger I/O buffer is used on each node.

For this purpose, I introduced a new option -z which can be used to specify the buffer size in kB for each input and output file. This currently only works with samtools view, sort and index. All remaining operations are not affected.

I measured the number of read/write syscalls using strace and a 126 MB SAM file, without and with a 4 MB buffer:

    $ strace -c ./samtools view [-z 4096] -Sbt hg19.fa A.sam > A-unsorted.bam 
    
            | read  write
    --------+------------
    default | 8040  3274
    -z 4096 |   25    11
    
    $ strace -c ../samtools sort [-z 4096] A-unsorted.bam A-sorted
    
            | read  write
    --------+------------
    default | 3285  3274
    -z 4096 |   17     7
    
    $ strace -c ../samtools index [-z 4096] A-sorted.bam 
    
            | read  write
    --------+------------
    default | 3290   231
    -z 4096 |   16     1

I also verified that the resulting checksums are the same with and without the -z option, as expected.

## Implementation details

In order to make the buffer size varibale (g_block_size) globally available, I added globals.c and global.h which currently serve the sole purpose of hosting the variable and making it accessible. I am aware that this is probably not the best solution, but considering the fact that the variable is required in many places throughout the code and this is C, I hope the solution is ok.

Whenever a gzip file is opened via gzopen or gzdopen, gzbuffer is used to set the buffer size. Whenever a file is opened via fopen, a buffer is allocated via malloc, assigned to the FILE* via setvbuf, and later freed again.

Finally, I had to change the underlying implementation in knetfile.c from using file descriptors to using FILE* because as far as I know, buffering is not possible using file descriptors. For this purpose, I added FILE *fp alongside the int fd to be used when a local file is being read.

Please don't hestitate to contact me with questions or comments at micha.specht@gmail.com.

Cheers,
Micha.