### PR TITLE
Adding -f flag to samtools sort to give output name directly.

### DIFF
--- a/samtools.1
+++ b/samtools.1
@@ -328,7 +328,7 @@ which enables fast BAM concatenation.
 
 .TP
 .B sort
-samtools sort [-no] [-m maxMem] <in.bam> <out.prefix>
+samtools sort [-nof] [-m maxMem] <in.bam> <out.prefix>
 
 Sort alignments by leftmost coordinates. File
 .I <out.prefix>.bam
@@ -345,6 +345,13 @@ Output the final alignment to the standard output.
 .TP
 .B -n
 Sort by read names rather than by chromosomal coordinates
+.TP
+.B -f
+Use
+.I <out.prefix>
+as the full output path and do not append
+.I .bam
+suffix.
 .TP
 .BI -m \ INT
 Approximately the maximum required memory. [500000000]


### PR DESCRIPTION
This is very useful in workflow engines that expect the tools to use the paths passed to them and not modifying the paths.
