### PR TITLE
Fixed several small memory leaks.

### DIFF
--- a/bam_index.c
+++ b/bam_index.c
@@ -464,6 +464,7 @@ bam_index_t *bam_index_load(const char *fn)
 		strcat(strcpy(fnidx, fn), ".bai");
 		fprintf(stderr, "[bam_index_load] attempting to download the remote index file.\n");
 		download_from_remote(fnidx);
+        free(fnidx);
 		idx = bam_index_load_local(fn);
 	}
 	if (idx == 0) fprintf(stderr, "[bam_index_load] fail to load BAM index.\n");
@@ -494,6 +495,7 @@ int bam_index_build2(const char *fn, const char *_fnidx)
 	if (fpidx == 0) {
 		fprintf(stderr, "[bam_index_build2] fail to create the index file.\n");
 		free(fnidx);
+        bam_index_destroy(idx);
 		return -1;
 	}
 	bam_index_save(idx, fpidx);

--- a/bcftools/index.c
+++ b/bcftools/index.c
@@ -259,6 +259,7 @@ int bcf_idx_build2(const char *fn, const char *_fnidx)
 	if (fpidx == 0) {
 		fprintf(stderr, "[bcf_idx_build2] fail to create the index file.\n");
 		free(fnidx);
+        bcf_idx_destroy(idx);
 		return -1;
 	}
 	bcf_idx_save(idx, fpidx);

--- a/bcftools/vcf.c
+++ b/bcftools/vcf.c
@@ -30,7 +30,12 @@ bcf_hdr_t *vcf_hdr_read(bcf_t *bp)
 	memset(&smpl, 0, sizeof(kstring_t));
 	while (ks_getuntil(v->ks, '\n', &v->line, &dret) >= 0) {
 		if (v->line.l < 2) continue;
-		if (v->line.s[0] != '#') return 0; // no sample line
+		if (v->line.s[0] != '#') {
+            free(meta.s);
+            free(smpl.s);
+            free(h);
+            return 0; // no sample line
+        }
 		if (v->line.s[0] == '#' && v->line.s[1] == '#') {
 			kputsn(v->line.s, v->line.l, &meta); kputc('\n', &meta);
 		} else if (v->line.s[0] == '#') {

--- a/sam_header.c
+++ b/sam_header.c
@@ -366,6 +366,7 @@ static HeaderLine *sam_header_line_parse(const char *headerLine)
     while (*to && *to=='\t') to++;
     if ( to-from != 1 ) {
         debug("[sam_header_line_parse] multiple tabs on line [%s] (%d)\n", headerLine,(int)(to-from));
+        free(hline);
 		return 0;
 	}
     from = to;


### PR DESCRIPTION
- When downloading a remote FASTA index
- When indexing a BAM, we can't open the FAI file
- When indexing a BCF, we can't open the index file
- Parsing a VCF header with no sample line
- Encountering multiple adjacent tabs in a SAM header
