### PR TITLE
Update 'samtools index' BIN verification code

### DIFF
--- a/bam_index.c
+++ b/bam_index.c
@@ -193,7 +193,11 @@ bam_index_t *bam_index_core(bamFile fp)
 			return NULL;
 		}
 		if (c->tid >= 0) {
-			recalculated_bin = bam_reg2bin(c->pos, bam_calend(c, bam1_cigar(b)));
+			if (c->n_cigar) {
+				recalculated_bin = bam_reg2bin(c->pos, bam_calend(c, bam1_cigar(b)));
+			} else {
+				recalculated_bin = bam_reg2bin(c->pos, c->pos + 1);
+			}
 			if (c->bin != recalculated_bin) {
 				fprintf(stderr, "[bam_index_core] read '%s' mapped to '%s' at POS %d to %d has BIN %d but should be %d\n",
 					bam1_qname(b), h->target_name[c->tid], c->pos + 1, bam_calend(c, bam1_cigar(b)), c->bin, recalculated_bin);


### PR DESCRIPTION
This is an update to my recently merged enhancement to 'samtools index' to verify the BIN value in each read:
https://github.com/samtools/samtools/commit/8e3b3f229a04cb81b680987ce06ae1507c9d8b69

This did not match the BIN behaviour of 'samtools view' for (unmapped) reads with no CIGAR string, addressed in this branch, which also includes the reference name in any error message.
