### PR TITLE
Convert from const char* to const char[]

### DIFF
--- a/bam.c
+++ b/bam.c
@@ -8,7 +8,7 @@
 #include "sam_header.h"
 
 int bam_is_be = 0, bam_verbose = 2, bam_no_B = 0;
-static const char *bam_flag2char_table = "pPuUrR12sfd\0\0\0\0\0";
+static const char bam_flag2char_table[] = "pPuUrR12sfd\0\0\0\0\0";
 
 /**************************
  * CIGAR related routines *

--- a/bam.h
+++ b/bam.h
@@ -299,7 +299,7 @@ extern int bam_no_B;
 extern const unsigned char bam_nt16_table[256];
 
 /*! @abstract Table for converting a 4-bit encoded nucleotide to a letter. */
-extern const char *bam_nt16_rev_table;
+extern const char bam_nt16_rev_table[];
 
 extern const char bam_nt16_nt4_table[];
 

--- a/bam_import.c
+++ b/bam_import.c
@@ -59,7 +59,7 @@ static const unsigned short bam_char2flag_table[256] = {
 	0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0
 };
 
-const char *bam_nt16_rev_table = "=ACMGRSVTWYHKDBN";
+const char bam_nt16_rev_table[] = "=ACMGRSVTWYHKDBN";
 
 struct __tamFile_t {
 	gzFile fp;


### PR DESCRIPTION
Convert from const char\* to const char[] for consistency and so I don't have to go const char\* const.
