### PR TITLE
Fix for unreferenced linker lib -ltinfo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ PROG=		samtools
 INCLUDES=	-I.
 SUBDIRS=	. bcftools misc
 LIBPATH=
-LIBCURSES=	-lcurses # -lXCurses
+LIBCURSES=	-lcurses -ltinfo # -lXCurses
 
 
 .SUFFIXES:.c .o


### PR DESCRIPTION
This fixes the linker for NCURSES:
`/data/apps/binutils/2.23.2/bin/ld: bam_tview_curses.o: undefined reference to symbol 'keypad'
/data/apps/binutils/2.23.2/bin/ld: note: 'keypad' is defined in DSO /lib64/libtinfo.so.5 so try adding it to the linker command line
/lib64/libtinfo.so.5: could not read symbols: Invalid operation`

Signed-off-by: Adam Brenner aebrenne@uci.edu
