### PR TITLE
Fixed GCC section of stats so that read cycle column begins with 1 instead of 0.

### DIFF
--- a/stats.c
+++ b/stats.c
@@ -994,7 +994,7 @@ void output_stats(stats_t *stats)
         uint64_t *ptr = &(stats->acgt_cycles[ibase*4]);
         uint64_t  sum = ptr[0]+ptr[1]+ptr[2]+ptr[3];
         if ( ! sum ) continue;
-        printf("GCC\t%d\t%.2f\t%.2f\t%.2f\t%.2f\n", ibase,100.*ptr[0]/sum,100.*ptr[1]/sum,100.*ptr[2]/sum,100.*ptr[3]/sum);
+        printf("GCC\t%d\t%.2f\t%.2f\t%.2f\t%.2f\n", ibase+1,100.*ptr[0]/sum,100.*ptr[1]/sum,100.*ptr[2]/sum,100.*ptr[3]/sum);
     }
     printf("# Insert sizes. Use `grep ^IS | cut -f 2-` to extract this part. The columns are: pairs total, inward oriented pairs, outward oriented pairs, other pairs\n");
     for (isize=0; isize<ibulk; isize++)


### PR DESCRIPTION
Currently the read cycle column in the FFQ, LFQ, MPC, and IC sections all start with 1, but the GCC section begins with 0.  In an example file, the FFQ section cycle ranges from 1-100 while GCC section cycle ranges from 0-99. 

I've modified the section of stats.c that prints the GCC section so that it does as the other sections do, which is to print ibase+1 instead of just ibase. 
