### PR TITLE
Modifies test.pl so that it exits with non-zero status if any tests fail

### DIFF
--- a/test/test.pl
+++ b/test/test.pl
@@ -20,7 +20,7 @@ printf "    passed  .. %d\n", $$opts{nok};
 printf "    failed  .. %d\n", $$opts{nfailed};
 print "\n";
 
-exit;
+exit $$opts{nfailed};
 
 #--------------------
 


### PR DESCRIPTION
I noticed when I put in the last pull request for the usage tests (which are failing for 4 subcommands) that the travis build did not fail as expected.  This brings samtools' test.pl in line with bcftools such that it exits with a status equal to the number of tests that failed (seems reasonable up to a point -- possibly might be better to just use 0/1 but we should probably be consistent across samtools/bcftools). 
