### PR TITLE
Removed LDFLAGS.  Variable is usually defined outside of Makefile when the system needs it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 CC       = gcc
 CPPFLAGS = $(DFLAGS) $(INCLUDES)
 CFLAGS   = -g -Wall -O2
-LDFLAGS  =
+#LDFLAGS  =
 DFLAGS=		-D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -D_CURSES_LIB=1
 LOBJS=		bam_aux.o bam.o bam_import.o sam.o \
 			sam_header.o


### PR DESCRIPTION
Having LDFLAGS defined in the Makefile means that some users will have to modify Makefile directly. 

Usually, it is preferable for a user to say:

LDFLAGS=-L/path/lib make 

instead
