### PR TITLE
Makes samtools view -r and -R read group filtering options both use settings.rghash

### DIFF
--- a/sam_view.c
+++ b/sam_view.c
@@ -239,10 +239,16 @@ int main_samview(int argc, char *argv[])
 		case 'l': settings.library = strdup(optarg); break;
 		case 'L': settings.bed = bed_read(optarg); break;
 		case 'r':
-			if (0 != add_read_group_single(&settings, optarg)) goto view_end;
+			if (0 != add_read_group_single(&settings, optarg)) {
+				ret = 1;
+				goto view_end;
+			}
 			break;
 		case 'R':
-			if (0 != add_read_groups_file(&settings, optarg)) goto view_end;
+			if (0 != add_read_groups_file(&settings, optarg)) {
+				ret = 1;
+				goto view_end;
+			}
 			break;
 				/* REMOVED as htslib doesn't support this
 		//case 'x': out_format = "x"; break;
@@ -377,8 +383,8 @@ view_end:
 	if (settings.remove_aux_len) {
 		free(settings.remove_aux);
 	}
-	sam_close(in);
-	if (!is_count)
+	if (NULL != in) sam_close(in);
+	if (!is_count && NULL != out)
 		sam_close(out);
 	return ret;
 }


### PR DESCRIPTION
Changes the option handling so -r and -R both use settings.rghash instead
or the -r option being stored in a string that then has to be checked
separately.  The code to add the hash entires is also moved into the
option handling loop, so it is possible to have more that one -r or -R
on the command line.  The set of read groups output will be the union of
all the groups requested.  As -r uses the hash, drop_rg now gets called
so unwanted groups are removed from the header.  This fixes issue #152.

Alter process_aln so that read group filtering will only make it return if
the alignment has been filtered out (previously it would return from the
read group filter at this point in either case).  This means other filters
still have a chance to run after the read group one, and fixes issue #153.
