### PR TITLE
Makes samtools view subsampling option more random.

### DIFF
--- a/sam_view.c
+++ b/sam_view.c
@@ -64,7 +64,7 @@ static int process_aln(const bam_hdr_t *h, bam1_t *b, samview_settings_t* settin
 	if (settings->bed && b->core.tid >= 0 && !bed_overlap(settings->bed, h->target_name[b->core.tid], b->core.pos, bam_endpos(b)))
 		return 1;
 	if (settings->subsam_frac > 0.) {
-		uint32_t k = __ac_X31_hash_string(bam_get_qname(b)) + settings->subsam_seed;
+		uint32_t k = __ac_Wang_hash(__ac_X31_hash_string(bam_get_qname(b)) ^ settings->subsam_seed);
 		if ((double)(k&0xffffff) / 0x1000000 >= settings->subsam_frac) return 1;
 	}
 	if (settings->rg || settings->rghash) {


### PR DESCRIPTION
Applies the patch given in issue #160 to mix the results of the string hash
a bit more.  Not sure if this is completely random, but it's a lot better
than just using the string hash on its own.
