### PR TITLE
Samtools sort - single block problem

### DIFF
--- a/bam_sort.c
+++ b/bam_sort.c
@@ -985,9 +985,10 @@ int bam_sort_core_ext(int is_by_qname, const char *fn, const char *prefix, const
 		fprintf(stderr, "[bam_sort_core] truncated file. Continue anyway.\n");
 	// write the final output
 	if (n_files == 0) { // a single block
-		char mode[8];
-		strcpy(mode, "w");
-		if (level >= 0) sprintf(mode + 1, "%d", level < 9? level : 9);
+		char mode[4];
+    sprintf(mode, "%s%c",
+            hts_file_type(fn) == FT_GZ ? "wb" : "w",
+            level >= 0 ? (level < 9 ? '0' + level : '9') : '\0');
 		ks_mergesort(sort, k, buf, 0);
 		write_buffer(fnout, mode, k, buf, header, n_threads);
 	} else { // then merge


### PR DESCRIPTION
When a small SAM/BAM file is specified, samtools sort command outputs SAM format always.
