### PR TITLE
Adds support for outputting stats over the full input size distribution.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ AOBJS=		bam_index.o bam_plcmd.o sam_view.o \
 			bam_rmdup.o bam_rmdupse.o bam_mate.o bam_stat.o bam_color.o \
 			bamtk.o kaln.o bam2bcf.o bam2bcf_indel.o errmod.o sample.o \
 			cut_target.o phase.o bam2depth.o padding.o bedcov.o bamshuf.o \
-			faidx.o stats.o bam_flags.o bam_plbuf.o \
+			faidx.o stats.o stats_isize.o bam_flags.o bam_plbuf.o \
 			bam_tview.o bam_tview_curses.o bam_tview_html.o bam_lpileup.o
 INCLUDES=	-I. -I$(HTSDIR)
 LIBCURSES=	-lcurses # -lXCurses
@@ -146,7 +146,8 @@ sam.o: sam.c $(htslib_faidx_h) $(sam_h)
 sam_header.o: sam_header.c sam_header.h $(HTSDIR)/htslib/khash.h
 sam_view.o: sam_view.c $(htslib_sam_h) $(htslib_faidx_h) $(HTSDIR)/htslib/kstring.h $(HTSDIR)/htslib/khash.h
 sample.o: sample.c $(sample_h) $(HTSDIR)/htslib/khash.h
-stats.o: stats.c $(sam_h) sam_header.h samtools.h $(HTSDIR)/htslib/khash.h $(HTSDIR)/htslib/khash_str2int.h $(htslib_faidx_h)
+stats_isize.o: stats_isize.c stats_isize.h $(HTSDIR)/htslib/khash.h
+stats.o: stats.c $(sam_h) sam_header.h samtools.h stats_isize.h $(HTSDIR)/htslib/khash.h $(HTSDIR)/htslib/khash_str2int.h $(htslib_faidx_h)
 
 
 # test programs

--- a/stats_isize.c
+++ b/stats_isize.c
@@ -1,0 +1,200 @@
+/*
+  Author: Nicholas Clarke (nc6@sanger.ac.uk)
+
+  Generalises insert size calculation for samtools stats.
+*/
+#include <stdio.h>
+#include "stats_isize.h"
+#include <htslib/khash.h>
+
+typedef enum {IN,OUT,OTHER} isize_insert_t;
+
+static int max(int a, int b) {
+    if (a < b) {
+        return b;
+    } else {
+        return a;
+    }
+}
+
+static isize_sparse_record_t * sparse_get_f(isize_data_t data, int at) {
+    isize_sparse_data_t *a = data.sparse;
+    khash_t(m32) *h = a->array;
+
+    khint_t k = kh_get(m32, h, at);
+    if (k != kh_end(h)) {
+        return kh_value(h, k);
+    } else {
+        return NULL;
+    }
+}
+
+static uint64_t sparse_in_f(isize_data_t data, int at) {
+    isize_sparse_record_t* a = sparse_get_f(data, at);
+    if (a != NULL) {
+        return a->isize_inward;
+    } else {
+        return 0;
+    }
+}
+static uint64_t sparse_out_f(isize_data_t data, int at) {
+    isize_sparse_record_t* a = sparse_get_f(data, at);
+    if (a != NULL) {
+        return a->isize_outward;
+    } else {
+        return 0;
+    }
+}
+static uint64_t sparse_other_f(isize_data_t data, int at) {
+    isize_sparse_record_t* a = sparse_get_f(data, at);
+    if (a != NULL) {
+        return a->isize_other;
+    } else {
+        return 0;
+    }
+}
+static uint64_t sparse_total_f(isize_data_t data, int a) { return sparse_in_f(data, a) + sparse_out_f(data, a) + sparse_other_f(data, a); }
+
+static void sparse_set_f(isize_data_t data, int at, isize_insert_t field, uint64_t value) {
+    isize_sparse_data_t *a = data.sparse;
+    khash_t(m32) *h = a->array;
+
+    khint_t k = kh_get(m32, h, at);
+    isize_sparse_record_t *rec;
+    if (k != kh_end(h)) {
+        rec = kh_value(h, k);
+    } else if (value != 0) {
+        rec = malloc(sizeof(isize_sparse_record_t));
+        if (rec != NULL) {
+            rec->isize_inward = 0;
+            rec->isize_outward = 0;
+            rec->isize_other = 0;     
+            int stupid = 0;
+            khint_t it = kh_put(m32, h, at, & stupid);
+            kh_value(h, it) = rec;
+            a->max = max(at, a->max);
+        } else {
+            fprintf(stderr, "%s\n", "Failed to allocate memory for isize_sparse_record_t");
+            exit(11);
+        }
+    } else {
+        return;
+    }
+
+    if (field == IN) {
+        rec->isize_inward = value;
+    } else if (field == OUT) {
+        rec->isize_outward = value;
+    } else {
+        rec->isize_other = value;
+    }
+
+}
+
+static void sparse_set_in_f(isize_data_t data, int at, uint64_t value) { sparse_set_f(data, at, IN, value); }
+static void sparse_set_out_f(isize_data_t data, int at, uint64_t value) { sparse_set_f(data, at, OUT, value); }
+static void sparse_set_other_f(isize_data_t data, int at, uint64_t value) { sparse_set_f(data, at, OTHER, value); }
+
+static void sparse_inc_in_f(isize_data_t data, int at) { sparse_set_in_f(data, at, sparse_in_f(data, at) + 1); }
+static void sparse_inc_out_f(isize_data_t data, int at) { sparse_set_out_f(data, at, sparse_out_f(data, at) + 1); }
+static void sparse_inc_other_f(isize_data_t data, int at) { sparse_set_other_f(data, at, sparse_other_f(data, at) + 1); }
+
+static void sparse_isize_free(isize_data_t data) {
+    isize_sparse_data_t *a = data.sparse;
+    kh_destroy(m32, a->array);
+    free(a);
+}
+
+static int sparse_nitems(isize_data_t data) {
+    isize_sparse_data_t *a = data.sparse;
+    return a->max;
+}
+
+static uint64_t dense_in_f(isize_data_t data, int at) { return data.dense->isize_inward[at]; }
+static uint64_t dense_out_f(isize_data_t data, int at) { return data.dense->isize_outward[at]; }
+static uint64_t dense_other_f(isize_data_t data, int at) { return data.dense->isize_other[at]; }
+static uint64_t dense_total_f(isize_data_t data, int a) { return dense_in_f(data, a) + dense_out_f(data, a) + dense_other_f(data, a); }
+
+static void dense_set_in_f(isize_data_t data, int at, uint64_t value) { data.dense->isize_inward[at] = value; }
+static void dense_set_out_f(isize_data_t data, int at, uint64_t value) { data.dense->isize_outward[at] = value; }
+static void dense_set_other_f(isize_data_t data, int at, uint64_t value) { data.dense->isize_other[at] = value; }
+
+static void dense_inc_in_f(isize_data_t data, int at) { data.dense->isize_inward[at] += 1; }
+static void dense_inc_out_f(isize_data_t data, int at) { data.dense->isize_outward[at] += 1; }
+static void dense_inc_other_f(isize_data_t data, int at) { data.dense->isize_other[at] += 1; }
+
+static void dense_isize_free(isize_data_t data) {
+    isize_dense_data_t *a = data.dense;
+    free(a->isize_inward);
+    free(a->isize_outward);
+    free(a->isize_other);
+    free(a);
+}
+
+static int dense_nitems(isize_data_t data) {
+    isize_dense_data_t *a = data.dense;
+    return a->total;
+}
+
+// Construct a relevant isize_t given the bound.
+isize_t *init_isize_t(int bound) {
+    if (bound <= 0) {
+        // Use sparse data structure.
+        isize_sparse_data_t *data = (isize_sparse_data_t *) malloc(sizeof(isize_sparse_data_t));
+
+        // Initialise
+        data->max = 0;
+        data->array = kh_init(m32);
+
+        isize_t *isize = (isize_t *)malloc(sizeof(isize_t));
+
+        isize->data.sparse = data;
+        isize->nitems = & sparse_nitems;
+
+        isize->inward = & sparse_in_f;
+        isize->outward = & sparse_out_f;
+        isize->other = & sparse_other_f;
+
+        isize->set_inward = & sparse_set_in_f;
+        isize->set_outward = & sparse_set_out_f;
+        isize->set_other = & sparse_set_other_f;
+
+        isize->inc_inward = & sparse_inc_in_f;
+        isize->inc_outward = & sparse_inc_out_f;
+        isize->inc_other = & sparse_inc_other_f;
+
+        isize->isize_free = & sparse_isize_free;
+
+        return isize;
+    } else {
+        uint64_t* in = calloc(bound,sizeof(uint64_t));
+        uint64_t* out = calloc(bound,sizeof(uint64_t));
+        uint64_t* other = calloc(bound,sizeof(uint64_t));
+        isize_dense_data_t *rec = (isize_dense_data_t *)malloc(sizeof(isize_dense_data_t));
+        rec->isize_inward = in;
+        rec->isize_outward = out;
+        rec->isize_other = other;
+        rec->total=bound;
+
+        isize_t *isize = (isize_t *)malloc(sizeof(isize_t));
+
+        isize->data.dense = rec;
+        isize->nitems = & dense_nitems;
+
+        isize->inward = & dense_in_f;
+        isize->outward = & dense_out_f;
+        isize->other = & dense_other_f;
+
+        isize->set_inward = & dense_set_in_f;
+        isize->set_outward = & dense_set_out_f;
+        isize->set_other = & dense_set_other_f;
+
+        isize->inc_inward = & dense_inc_in_f;
+        isize->inc_outward = & dense_inc_out_f;
+        isize->inc_other = & dense_inc_other_f;
+
+        isize->isize_free = & dense_isize_free;
+
+        return isize;
+    }
+}

--- a/stats_isize.h
+++ b/stats_isize.h
@@ -1,0 +1,60 @@
+#include <htslib/khash.h>
+#include <stdint.h>
+
+typedef struct
+{
+    int total;
+    uint64_t *isize_inward, *isize_outward, *isize_other;
+}
+isize_dense_data_t;
+
+typedef struct 
+{ 
+    uint64_t isize_inward, isize_outward, isize_other; 
+}
+isize_sparse_record_t;
+
+KHASH_MAP_INIT_INT(m32, isize_sparse_record_t *)
+
+typedef struct
+{
+    int max;
+    khash_t(m32) *array;
+}
+isize_sparse_data_t;
+
+typedef union {
+    isize_sparse_data_t *sparse;
+    isize_dense_data_t *dense;
+} isize_data_t;
+
+// Insert size structure
+typedef struct
+{
+    isize_data_t data;
+    
+    // Maximum
+    int (*nitems)(isize_data_t);
+
+    // Fetch the number of inserts of a given size
+    uint64_t (*inward)(isize_data_t, int);
+    uint64_t (*outward)(isize_data_t, int);
+    uint64_t (*other)(isize_data_t, int);
+    uint64_t (*total)(isize_data_t, int);
+
+    // Set the number of inserts of a given size
+    void (*set_inward)(isize_data_t, int, uint64_t);
+    void (*set_outward)(isize_data_t, int, uint64_t);
+    void (*set_other)(isize_data_t, int, uint64_t);
+
+    // Increment the number of inserts of a given size
+    void (*inc_inward)(isize_data_t, int);
+    void (*inc_outward)(isize_data_t, int);
+    void (*inc_other)(isize_data_t, int);
+
+    // Free this structure
+    void (*isize_free)(isize_data_t);
+}
+isize_t;
+
+isize_t *init_isize_t(int bound);


### PR DESCRIPTION
Current behaviour is to specify a parameter (-i) which governs the maximum
input size which will be considered. Any input size above this will be output
as the maximum input size. This can lead to peaks in the tail of the IS
distribution appearing incorrectly, as well as potentially breaking the calculation
of average input size.

This commit changes the current behaviour in the following ways:
- Previously, setting "-i 0" would either result in a crash or non-useful behaviour.
  Instead, setting "-i 0" now removes the maximum input size. Rather than using the existing
  array-backed storage, we switch to a hashmap which only stores non-0 entries (e.g. sizes x
  for which there is at least one insert of size x).
- Introduce a new option "--sparse|-x" which sets the IS output into 'sparse' mode - IS
  lines in this mode are only output where the total number of inserts is greater than 0.

This has been tested (on a random humgen test file) to produce identical to samtools/develop
when run with default settings (replicating default behaviour) and to agree on a bunch of randomly
selected insert sizes when using the new behaviour.
