### PR TITLE
Remove unusued 'total' functions.

### DIFF
--- a/stats_isize.c
+++ b/stats_isize.c
@@ -53,7 +53,6 @@ static uint64_t sparse_other_f(isize_data_t data, int at) {
         return 0;
     }
 }
-static uint64_t sparse_total_f(isize_data_t data, int a) { return sparse_in_f(data, a) + sparse_out_f(data, a) + sparse_other_f(data, a); }
 
 static void sparse_set_f(isize_data_t data, int at, isize_insert_t field, uint64_t value) {
     isize_sparse_data_t *a = data.sparse;
@@ -113,7 +112,6 @@ static int sparse_nitems(isize_data_t data) {
 static uint64_t dense_in_f(isize_data_t data, int at) { return data.dense->isize_inward[at]; }
 static uint64_t dense_out_f(isize_data_t data, int at) { return data.dense->isize_outward[at]; }
 static uint64_t dense_other_f(isize_data_t data, int at) { return data.dense->isize_other[at]; }
-static uint64_t dense_total_f(isize_data_t data, int a) { return dense_in_f(data, a) + dense_out_f(data, a) + dense_other_f(data, a); }
 
 static void dense_set_in_f(isize_data_t data, int at, uint64_t value) { data.dense->isize_inward[at] = value; }
 static void dense_set_out_f(isize_data_t data, int at, uint64_t value) { data.dense->isize_outward[at] = value; }

--- a/stats_isize.h
+++ b/stats_isize.h
@@ -40,7 +40,6 @@ typedef struct
     uint64_t (*inward)(isize_data_t, int);
     uint64_t (*outward)(isize_data_t, int);
     uint64_t (*other)(isize_data_t, int);
-    uint64_t (*total)(isize_data_t, int);
 
     // Set the number of inserts of a given size
     void (*set_inward)(isize_data_t, int, uint64_t);


### PR DESCRIPTION
Should fix the 'unused function' warnings.
