### PR TITLE
Fixes an issue with -i0 involving truncation of insert sizes.

### DIFF
--- a/stats_isize.c
+++ b/stats_isize.c
@@ -108,7 +108,7 @@ static void sparse_isize_free(isize_data_t data) {
 
 static int sparse_nitems(isize_data_t data) {
     isize_sparse_data_t *a = data.sparse;
-    return a->max;
+    return a->max + 1;
 }
 
 static uint64_t dense_in_f(isize_data_t data, int at) { return data.dense->isize_inward[at]; }

--- a/test/stat/5.stats.expected
+++ b/test/stat/5.stats.expected
@@ -11,7 +11,7 @@ SN	reads unmapped:	0
 SN	reads properly paired:	2	# proper-pair bit set
 SN	reads paired:	2	# paired-end technology bit set
 SN	reads duplicated:	0	# PCR or optical duplicate bit set
-SN	reads MQ0:	0	$ mapped and MQ=0
+SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
 SN	total length:	70	# ignores clipping

--- a/test/stat/6.stats.expected
+++ b/test/stat/6.stats.expected
@@ -11,7 +11,7 @@ SN	reads unmapped:	0
 SN	reads properly paired:	2	# proper-pair bit set
 SN	reads paired:	2	# paired-end technology bit set
 SN	reads duplicated:	0	# PCR or optical duplicate bit set
-SN	reads MQ0:	0	$ mapped and MQ=0
+SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
 SN	total length:	70	# ignores clipping
@@ -188,6 +188,107 @@ GCC	33	0.00	0.00	50.00	50.00
 GCC	34	100.00	0.00	0.00	0.00
 GCC	35	0.00	0.00	50.00	50.00
 # Insert sizes. Use `grep ^IS | cut -f 2-` to extract this part. The columns are: pairs total, inward oriented pairs, outward oriented pairs, other pairs
+IS	0	0	0	0	0
+IS	1	0	0	0	0
+IS	2	0	0	0	0
+IS	3	0	0	0	0
+IS	4	0	0	0	0
+IS	5	0	0	0	0
+IS	6	0	0	0	0
+IS	7	0	0	0	0
+IS	8	0	0	0	0
+IS	9	0	0	0	0
+IS	10	0	0	0	0
+IS	11	0	0	0	0
+IS	12	0	0	0	0
+IS	13	0	0	0	0
+IS	14	0	0	0	0
+IS	15	0	0	0	0
+IS	16	0	0	0	0
+IS	17	0	0	0	0
+IS	18	0	0	0	0
+IS	19	0	0	0	0
+IS	20	0	0	0	0
+IS	21	0	0	0	0
+IS	22	0	0	0	0
+IS	23	0	0	0	0
+IS	24	0	0	0	0
+IS	25	0	0	0	0
+IS	26	0	0	0	0
+IS	27	0	0	0	0
+IS	28	0	0	0	0
+IS	29	0	0	0	0
+IS	30	0	0	0	0
+IS	31	0	0	0	0
+IS	32	0	0	0	0
+IS	33	0	0	0	0
+IS	34	0	0	0	0
+IS	35	0	0	0	0
+IS	36	0	0	0	0
+IS	37	0	0	0	0
+IS	38	0	0	0	0
+IS	39	0	0	0	0
+IS	40	0	0	0	0
+IS	41	0	0	0	0
+IS	42	0	0	0	0
+IS	43	0	0	0	0
+IS	44	0	0	0	0
+IS	45	0	0	0	0
+IS	46	0	0	0	0
+IS	47	0	0	0	0
+IS	48	0	0	0	0
+IS	49	0	0	0	0
+IS	50	0	0	0	0
+IS	51	0	0	0	0
+IS	52	0	0	0	0
+IS	53	0	0	0	0
+IS	54	0	0	0	0
+IS	55	0	0	0	0
+IS	56	0	0	0	0
+IS	57	0	0	0	0
+IS	58	0	0	0	0
+IS	59	0	0	0	0
+IS	60	0	0	0	0
+IS	61	0	0	0	0
+IS	62	0	0	0	0
+IS	63	0	0	0	0
+IS	64	0	0	0	0
+IS	65	0	0	0	0
+IS	66	0	0	0	0
+IS	67	0	0	0	0
+IS	68	0	0	0	0
+IS	69	0	0	0	0
+IS	70	0	0	0	0
+IS	71	0	0	0	0
+IS	72	0	0	0	0
+IS	73	0	0	0	0
+IS	74	0	0	0	0
+IS	75	0	0	0	0
+IS	76	0	0	0	0
+IS	77	0	0	0	0
+IS	78	0	0	0	0
+IS	79	0	0	0	0
+IS	80	0	0	0	0
+IS	81	0	0	0	0
+IS	82	0	0	0	0
+IS	83	0	0	0	0
+IS	84	0	0	0	0
+IS	85	0	0	0	0
+IS	86	0	0	0	0
+IS	87	0	0	0	0
+IS	88	0	0	0	0
+IS	89	0	0	0	0
+IS	90	0	0	0	0
+IS	91	0	0	0	0
+IS	92	0	0	0	0
+IS	93	0	0	0	0
+IS	94	0	0	0	0
+IS	95	0	0	0	0
+IS	96	0	0	0	0
+IS	97	0	0	0	0
+IS	98	0	0	0	0
+IS	99	0	0	0	0
+IS	100	1	1	0	0
 # Read lengths. Use `grep ^RL | cut -f 2-` to extract this part. The columns are: read length, count
 RL	35	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions

--- a/test/test.pl
+++ b/test/test.pl
@@ -2024,6 +2024,6 @@ sub test_stats
     test_cmd($opts,out=>'stat/2.stats.expected',cmd=>"$$opts{bin}/samtools stats -r $$opts{path}/stat/test.fa $$opts{path}/stat/2_equal_cigar_full_seq.sam | tail -n+3",expect_fail=>1);
     test_cmd($opts,out=>'stat/3.stats.expected',cmd=>"$$opts{bin}/samtools stats -r $$opts{path}/stat/test.fa $$opts{path}/stat/3_map_cigar_equal_seq.sam | tail -n+3",expect_fail=>1);
     test_cmd($opts,out=>'stat/4.stats.expected',cmd=>"$$opts{bin}/samtools stats -r $$opts{path}/stat/test.fa $$opts{path}/stat/4_X_cigar_full_seq.sam | tail -n+3",expect_fail=>1);
-    test_cmd($opts,out=>'stat/5.stats.expected',cmd=>"$$opts{bin}/samtools stats -r $$opts{path}/stat/test.fa $$opts{path}/stat/5_insert_cigar.sam | tail -n+3",expect_fail=>1);
-    test_cmd($opts,out=>'stat/6.stats.expected',cmd=>"$$opts{bin}/samtools stats -r $$opts{path}/stat/test.fa -i 0 $$opts{path}/stat/5_insert_cigar.sam | tail -n+3",expect_fail=>1);
+    test_cmd($opts,out=>'stat/5.stats.expected',cmd=>"$$opts{bin}/samtools stats -r $$opts{path}/stat/test.fa $$opts{path}/stat/5_insert_cigar.sam | tail -n+3",expect_fail=>0);
+    test_cmd($opts,out=>'stat/6.stats.expected',cmd=>"$$opts{bin}/samtools stats -r $$opts{path}/stat/test.fa -i 0 $$opts{path}/stat/5_insert_cigar.sam | tail -n+3",expect_fail=>0);
 }


### PR DESCRIPTION
Setting '-i 0' previously caused any inserts of the maximum size to
be omitted. This is due to a bug at line 111 of stats_isize.c where
the maximum insert size is returned as the 'number of items', whereas
it should be the maximum plus one.

This should then cause test 6.stats to succeed. However, it still fails
due to a $/# typo in the expected results. This commit also therefore
fixes the expected results. The same issue caused 5.stats to fail, so
we fix that and remove the expect_failure there for good measure.

Note that 5.stats.expected and 6.stats.expected should now be identical.
