### PR TITLE
Convert phase to htslib API

### DIFF
--- a/bam.h
+++ b/bam.h
@@ -575,9 +575,9 @@ static inline int bam_reg2bin(uint32_t beg, uint32_t end)
   @param  src   source alignment struct
   @return       pointer to the destination alignment struct
  */
-static inline bam1_t *bam_dup1(const bam1_t *src)
-{
-	return bam_copy1(bam_init1(), src);
-}
+//static inline bam1_t *bam_dup1(const bam1_t *src)
+//{
+//	return bam_copy1(bam_init1(), src);
+//}
 
 #endif


### PR DESCRIPTION
Convert samtools phase command to use new htslib API.
Remove bam1_dup from bam.h to make room for htslib bam1_dup. (this depends on PR htslib#80)
Signed-off-by: Martin O. Pollard mp15@sanger.ac.uk
