### PR TITLE
Check that both key and value exist in sam_header2key_val

### DIFF
--- a/sam_header.c
+++ b/sam_header.c
@@ -687,7 +687,7 @@ void *sam_header2key_val(void *iter, const char type[2], const char key_tag[2], 
         HeaderTag *key, *value;
         key   = header_line_has_tag(hline,key_tag);
         value = header_line_has_tag(hline,value_tag);
-        if ( !key && !value ) 
+        if ( !key || !value ) 
         {
             l = l->next;
             continue;


### PR DESCRIPTION
If either the key or the value don't exist then move on. The previous behavior resulted in segmentation faults when either of the two didn't exist in the header.
