### PR TITLE
Deprecate `-S`, `-D`, `-V` in favour of `-t DP,DV,SP`

### DIFF
--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -622,9 +622,7 @@ static void print_usage(FILE *fp, const mplp_conf_t *mplp)
 "  -s, --output-MQ         output mapping quality\n"
 "\n"
 "Output options for genotype likelihoods (when -g/-v is used):\n"
-"  -D/-V                   output per-sample DP/DV in BCF\n"
 "  -g/-v, --BCF/--VCF      generate genotype likelihoods (BCF/VCF output format)\n"
-"  -S                      output per-sample strand bias P-value in BCF\n"
 "  -t, --format-tags LIST  optional per-sample tags to output: DP,DV,DP4,SP []\n"
 "  -u, --uncompressed      generate uncompressed BCF/VCF output\n"
 "\n"
@@ -738,9 +736,9 @@ int bam_mpileup(int argc, char *argv[])
 		case 'u': mplp.flag |= MPLP_NO_COMP | MPLP_BCF; break;
 		case 'a': mplp.flag |= MPLP_NO_ORPHAN | MPLP_REALN; break;
 		case 'B': mplp.flag &= ~MPLP_REALN; break;
-		case 'D': mplp.fmt_flag |= B2B_FMT_DP; break;
-		case 'S': mplp.fmt_flag |= B2B_FMT_SP; break;
-		case 'V': mplp.fmt_flag |= B2B_FMT_DV; break;
+		case 'D': mplp.fmt_flag |= B2B_FMT_DP; fprintf(stderr, "[warning] samtools mpileup option `-D` is functional, but deprecated. Please switch to `-t DP` in future.\n"); break;
+		case 'S': mplp.fmt_flag |= B2B_FMT_SP; fprintf(stderr, "[warning] samtools mpileup option `-S` is functional, but deprecated. Please switch to `-t SP` in future.\n"); break;
+		case 'V': mplp.fmt_flag |= B2B_FMT_DV; fprintf(stderr, "[warning] samtools mpileup option `-V` is functional, but deprecated. Please switch to `-t DV` in future.\n"); break;
 		case 'I': mplp.flag |= MPLP_NO_INDEL; break;
 		case 'E': mplp.flag |= MPLP_REDO_BAQ; break;
 		case '6': mplp.flag |= MPLP_ILLUMINA13; break;

--- a/samtools.1
+++ b/samtools.1
@@ -289,18 +289,39 @@ Only generate pileup in region
 
 .TP
 .B -D
-Output per-sample read depth
+Output per-sample read depth [DEPRECATED - use
+.B -t DP
+instead]
 .TP
 .B -g
 Compute genotype likelihoods and output them in the binary call format (BCF).
 .TP
 .B -S
-Output per-sample Phred-scaled strand bias P-value
+Output per-sample Phred-scaled strand bias P-value [DEPRECATED - use
+.B -t SP
+instead]
+.TP
+.BI -t \ LIST
+Comma-separated list of per-sample tags to output:
+.B DP
+(Number of high-quality bases), 
+.B DV
+(Number of high-quality non-reference bases), 
+.B DP4
+(Number of high-quality ref-forward, ref-reverse, alt-forward and alt-reverse bases), 
+.B SP
+(Phred-scaled strand bias P-value)
+[null]
 .TP
 .B -u
 Similar to
 .B -g
 except that the output is uncompressed BCF, which is preferred for piping.
+.TP
+.B -V
+Output per-sample number of non-reference reads [DEPRECATED - use
+.B -t DV
+instead]
 
 .TP
 .B Options for Genotype Likelihood Computation (for -g or -u):


### PR DESCRIPTION
- Deprecate `-S`, `-D`, `-V` by hiding in short help.
- Options still exist, but warning to stderr is printed when used.
- Updated man for (just) these options.
