### PR TITLE
Fix segmentation fault from calling samtools depad on non-existant BAM

### DIFF
--- a/padding.c
+++ b/padding.c
@@ -456,9 +456,9 @@ int main_pad2unpad(int argc, char *argv[])
 depad_end:
 	// close files, free and return
 	if (fai) fai_destroy(fai);
-	if (h != in->header) bam_header_destroy(h);
-	samclose(in);
-	samclose(out);
+	if (h && h != in->header) bam_header_destroy(h);
+	if (in) samclose(in);
+	if (out) samclose(out);
 	free(fn_list); free(fn_out);
 	return ret;
 }


### PR DESCRIPTION
See also related issue #145, which has now been fixed but was causing an earlier segmentation fault. Before fix:

```
$ ./samtools depad does_not_exist.bam
[E::hts_open] fail to open file 'does_not_exist.bam'
[depad] failed to open does_not_exist.bam for reading.
Segmentation fault: 11
```

After this fix:

```
$ ./samtools depad does_not_exist.bam
[E::hts_open] fail to open file 'does_not_exist.bam'
[depad] failed to open does_not_exist.bam for reading.
```
