### PR TITLE
Feature/merge no randomness

### DIFF
--- a/test/merge/test_trans_tbl_init.c
+++ b/test/merge/test_trans_tbl_init.c
@@ -295,10 +295,6 @@ int main(int argc, char**argv)
 		}
 	}
 
-	// Set the seed to a fixed value so that calls to lrand48 within functions return predictable values
-	const long GIMMICK_SEED = 0x1234abcd330e;
-	srand48(GIMMICK_SEED);
-
 	bam_hdr_t* out;
 	bam_hdr_t* translate;
 	
@@ -314,7 +310,7 @@ int main(int argc, char**argv)
 		dump_header(out);
 	}
 	if (verbose) printf("RUN test 1\n");
-	trans_tbl_init(out, translate, &tbl_1, false, false);
+	trans_tbl_init(out, translate, &tbl_1, false, false, 1);
 	if (verbose) printf("END RUN test 1\n");
 	if (verbose > 1) {
 		printf("translate\n");
@@ -341,7 +337,7 @@ int main(int argc, char**argv)
 		dump_header(out);
 	}
 	if (verbose) printf("RUN test 2\n");
-	trans_tbl_init(out, translate, &tbl_2, false, false);
+	trans_tbl_init(out, translate, &tbl_2, false, false, 2);
 	if (verbose) printf("END RUN test 2\n");
 	if (verbose > 1) {
 		printf("translate\n");
@@ -368,7 +364,7 @@ int main(int argc, char**argv)
 		dump_header(out);
 	}
 	if (verbose) printf("RUN test 3\n");
-	trans_tbl_init(out, translate, &tbl_3, false, false);
+	trans_tbl_init(out, translate, &tbl_3, false, false, 3);
 	if (verbose) printf("END RUN test 3\n");
 	if (verbose > 1) {
 		printf("translate\n");
@@ -395,7 +391,7 @@ int main(int argc, char**argv)
 		dump_header(out);
 	}
 	if (verbose) printf("RUN test 4\n");
-	trans_tbl_init(out, translate, &tbl_4, false, false);
+	trans_tbl_init(out, translate, &tbl_4, false, false, 4);
 	if (verbose) printf("END RUN test 4\n");
 	if (verbose > 1) {
 		printf("translate\n");
@@ -423,7 +419,7 @@ int main(int argc, char**argv)
 		dump_header(out);
 	}
 	if (verbose) printf("RUN test 5\n");
-	trans_tbl_init(out, translate, &tbl_5, false, false);
+	trans_tbl_init(out, translate, &tbl_5, false, false, 5);
 	if (verbose) printf("END RUN test 5\n");
 	if (verbose > 1) {
 		printf("translate\n");


### PR DESCRIPTION
Depends on pull request #220. 

Removes all randomness from `samtools merge`

The random number generation in `samtools merge` is unnecessary.
Random numbers in the IDs have been replaced by the index of the
input file from which each record comes.

This is (a) very very slightly faster and (b) does not require
one to supply a random seed just to get identical merge output
from two otherwise identical runs.

The drawback is when merging files which have themselves already
been merged, one can expect more collisions, and IDs that will
take the form of original-1-2-3-1-2, which may be more verbose
than desired. On the plus side, these are potentially usefully
informative as to where the record came from.
