### PR TITLE
Samtools sort multi-threaded does not error properly when disk writes fail.

### DIFF
--- a/bam_sort.c
+++ b/bam_sort.c
@@ -904,12 +904,12 @@ static int write_buffer(const char *fn, const char *mode, size_t l, bam1_p *buf,
 	samFile* fp;
 	fp = sam_open(fn, mode);
 	if (fp == NULL) return -1;
-	sam_hdr_write(fp, h);
+	if (sam_hdr_write(fp, h) < 0) return -1;
 	if (n_threads > 1) hts_set_threads(fp, n_threads);
 	for (i = 0; i < l; ++i) {
 		if(sam_write1(fp, h, buf[i]) < 0) return -1;
 	}
-	sam_close(fp);
+	if (sam_close(fp) < 0) return -1;
 	return 0;
 }
 


### PR DESCRIPTION
We found that when a disk was full, samtools sort using multi-cores
would not error out as expected, but instead continue, leading to
temp files of size 0.  This commit checks return code of writes
in this portion of the code and will error if writes are not
successful.