### PR TITLE
Fix fixmates for supplementary reads

### DIFF
--- a/bam_mate.c
+++ b/bam_mate.c
@@ -198,6 +198,11 @@ static void bam_mating_core(samFile* in, samFile* out, int remove_reads, int pro
             if ( !remove_reads ) sam_write1(out, header, cur);
             continue; // skip secondary alignments
         }
+        if (cur->core.flag & BAM_FSUPPLEMENTARY)
+        {
+            sam_write1(out, header, cur);
+            continue; // skip supplementary alignments
+        }
         if (cur->core.tid < 0 || cur->core.pos < 0) // If unmapped set the flag
         {
             cur->core.flag |= BAM_FUNMAP;

--- a/bam_stat.c
+++ b/bam_stat.c
@@ -31,12 +31,17 @@ typedef struct {
     long long n_sgltn[2], n_read1[2], n_read2[2];
     long long n_dup[2];
     long long n_diffchr[2], n_diffhigh[2];
+    long long n_secondary[2], n_supp[2];
 } bam_flagstat_t;
 
 #define flagstat_loop(s, c) do {                                        \
         int w = ((c)->flag & BAM_FQCFAIL)? 1 : 0;                       \
         ++(s)->n_reads[w];                                              \
-        if ((c)->flag & BAM_FPAIRED) {                                  \
+        if ((c)->flag & BAM_FSECONDARY ) {                              \
+            ++(s)->n_secondary[w];                                      \
+        } else if ((c)->flag & BAM_FSUPPLEMENTARY ) {                   \
+            ++(s)->n_supp[w];                                           \
+        } else if ((c)->flag & BAM_FPAIRED) {                           \
             ++(s)->n_pair_all[w];                                       \
             if (((c)->flag & BAM_FPROPER_PAIR) && !((c)->flag & BAM_FUNMAP) ) ++(s)->n_pair_good[w];    \
             if ((c)->flag & BAM_FREAD1) ++(s)->n_read1[w];              \
@@ -84,6 +89,8 @@ int bam_flagstat(int argc, char *argv[])
     header = bam_header_read(fp);
     s = bam_flagstat_core(fp);
     printf("%lld + %lld in total (QC-passed reads + QC-failed reads)\n", s->n_reads[0], s->n_reads[1]);
+    printf("%lld + %lld secondary\n", s->n_secondary[0], s->n_secondary[1]); 
+    printf("%lld + %lld supplimentary\n", s->n_supp[0], s->n_supp[1]); 
     printf("%lld + %lld duplicates\n", s->n_dup[0], s->n_dup[1]);
     printf("%lld + %lld mapped (%.2f%%:%.2f%%)\n", s->n_mapped[0], s->n_mapped[1], (float)s->n_mapped[0] / s->n_reads[0] * 100.0, (float)s->n_mapped[1] / s->n_reads[1] * 100.0);
     printf("%lld + %lld paired in sequencing\n", s->n_pair_all[0], s->n_pair_all[1]);


### PR DESCRIPTION
Currently samtools fixmate will incorrectly perceive supplementary reads as primaries and consequently mess up the pairing information for the primaries.  This commit fixes this by passing supplementary reads through unmodified.
This also updates flagstat to separate out the statistics for supplementary and secondary reads.
