### PR TITLE
Removal of calmd memory leak.

### DIFF
--- a/bam_md.c
+++ b/bam_md.c
@@ -110,13 +110,8 @@ void bam_fillmd1_core(bam1_t *b, char *ref, int flag, int max_nm)
         }
     }
     // update NM
-    if (flag & UPDATE_NM) {
+    if ((flag & UPDATE_NM) && !(c->flag & BAM_FUNMAP)) {
         uint8_t *old_nm = bam_aux_get(b, "NM");
-        if (c->flag & BAM_FUNMAP) {
-            free(str->s);
-            free(str);
-            return;
-        }
         if (old_nm) old_nm_i = bam_aux2i(old_nm);
         if (!old_nm) bam_aux_append(b, "NM", 'i', 4, (uint8_t*)&nm);
         else if (nm != old_nm_i) {
@@ -126,13 +121,8 @@ void bam_fillmd1_core(bam1_t *b, char *ref, int flag, int max_nm)
         }
     }
     // update MD
-    if (flag & UPDATE_MD) {
+    if ((flag & UPDATE_MD) && !(c->flag & BAM_FUNMAP)) {
         uint8_t *old_md = bam_aux_get(b, "MD");
-        if (c->flag & BAM_FUNMAP) {
-            free(str->s);
-            free(str);
-            return;
-        }
         if (!old_md) bam_aux_append(b, "MD", 'Z', str->l + 1, (uint8_t*)str->s);
         else {
             int is_diff = 0;
@@ -149,6 +139,7 @@ void bam_fillmd1_core(bam1_t *b, char *ref, int flag, int max_nm)
             }
         }
     }
+
     // drop all tags but RG
     if (flag&DROP_TAG) {
         uint8_t *q = bam_aux_get(b, "RG");
@@ -160,6 +151,7 @@ void bam_fillmd1_core(bam1_t *b, char *ref, int flag, int max_nm)
         for (i = 0; i < b->core.l_qseq; ++i)
             if (qual[i] >= 3) qual[i] = qual[i]/10*10 + 7;
     }
+
     free(str->s); free(str);
 }
 


### PR DESCRIPTION
Free the kstr allocated in bam_fillmd1_core (called by calmd). This was causing a potentially large memory leak to occur.

Fixes #143
