### PR TITLE
Cram3 updates

### DIFF
--- a/bam2depth.c
+++ b/bam2depth.c
@@ -126,6 +126,16 @@ int main_depth(int argc, char *argv[])
             status = EXIT_FAILURE;
             goto depth_end;
         }
+        if (hts_set_opt(data[i]->fp, CRAM_OPT_REQUIRED_FIELDS,
+                        SAM_FLAG | SAM_RNAME | SAM_POS | SAM_MAPQ | SAM_CIGAR |
+                        SAM_SEQ)) {
+            fprintf(stderr, "Failed to set CRAM_OPT_REQUIRED_FIELDS value\n");
+            return 1;
+        }
+        if (hts_set_opt(data[i]->fp, CRAM_OPT_DECODE_MD, 0)) {
+            fprintf(stderr, "Failed to set CRAM_OPT_DECODE_MD value\n");
+            return 1;
+        }
         data[i]->min_mapQ = mapQ;                    // set the mapQ filter
         data[i]->min_len  = min_len;                 // set the qlen filter
         data[i]->hdr = sam_hdr_read(data[i]->fp);    // read the BAM header

--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -264,6 +264,10 @@ static int mpileup(mplp_conf_t *conf, int n, char **fn)
             fprintf(stderr, "[%s] failed to open %s: %s\n", __func__, fn[i], strerror(errno));
             exit(1);
         }
+        if (hts_set_opt(data[i]->fp, CRAM_OPT_DECODE_MD, 0)) {
+            fprintf(stderr, "Failed to set CRAM_OPT_DECODE_MD value\n");
+            return 1;
+        }
         hts_set_fai_filename(data[i]->fp, conf->fai_fname);
         data[i]->conf = conf;
         h_tmp = sam_hdr_read(data[i]->fp);

--- a/bam_stat.c
+++ b/bam_stat.c
@@ -119,6 +119,6 @@ int bam_flagstat(int argc, char *argv[])
     printf("%lld + %lld with mate mapped to a different chr (mapQ>=5)\n", s->n_diffhigh[0], s->n_diffhigh[1]);
     free(s);
     bam_hdr_destroy(header);
-    hts_close(fp);
+    sam_close(fp);
     return 0;
 }

--- a/bam_stat.c
+++ b/bam_stat.c
@@ -23,7 +23,13 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.  */
 
 #include <unistd.h>
-#include "bam.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "htslib/sam.h"
+//#include "bam.h"
 #include "samtools.h"
 
 typedef struct {
@@ -59,7 +65,7 @@ typedef struct {
         if ((c)->flag & BAM_FDUP) ++(s)->n_dup[w];                      \
     } while (0)
 
-bam_flagstat_t *bam_flagstat_core(bamFile fp)
+bam_flagstat_t *bam_flagstat_core(samFile *fp, bam_hdr_t *h)
 {
     bam_flagstat_t *s;
     bam1_t *b;
@@ -68,7 +74,7 @@ bam_flagstat_t *bam_flagstat_core(bamFile fp)
     s = (bam_flagstat_t*)calloc(1, sizeof(bam_flagstat_t));
     b = bam_init1();
     c = &b->core;
-    while ((ret = bam_read1(fp, b)) >= 0)
+    while ((ret = sam_read1(fp, h, b)) >= 0)
         flagstat_loop(s, c);
     bam_destroy1(b);
     if (ret != -1)
@@ -77,20 +83,27 @@ bam_flagstat_t *bam_flagstat_core(bamFile fp)
 }
 int bam_flagstat(int argc, char *argv[])
 {
-    bamFile fp;
-    bam_header_t *header;
+    samFile *fp;
+    bam_hdr_t *header;
     bam_flagstat_t *s;
     if (argc == optind) {
         fprintf(stderr, "Usage: samtools flagstat <in.bam>\n");
         return 1;
     }
-    fp = strcmp(argv[optind], "-")? bam_open(argv[optind], "r") : bam_dopen(STDIN_FILENO, "r");
+    fp = sam_open(argv[optind], "r");
     if (fp == NULL) {
         print_error_errno("Cannot open input file \"%s\"", argv[optind]);
         return 1;
     }
-    header = bam_header_read(fp);
-    s = bam_flagstat_core(fp);
+
+    if (hts_set_opt(fp, CRAM_OPT_REQUIRED_FIELDS,
+		    SAM_FLAG | SAM_MAPQ | SAM_RNEXT)) {
+	fprintf(stderr, "Failed to set CRAM_OPT_REQUIRED_FIELDS value\n");
+	return 1;
+    }
+
+    header = sam_hdr_read(fp);
+    s = bam_flagstat_core(fp, header);
     printf("%lld + %lld in total (QC-passed reads + QC-failed reads)\n", s->n_reads[0], s->n_reads[1]);
     printf("%lld + %lld secondary\n", s->n_secondary[0], s->n_secondary[1]);
     printf("%lld + %lld supplimentary\n", s->n_supp[0], s->n_supp[1]);
@@ -105,7 +118,7 @@ int bam_flagstat(int argc, char *argv[])
     printf("%lld + %lld with mate mapped to a different chr\n", s->n_diffchr[0], s->n_diffchr[1]);
     printf("%lld + %lld with mate mapped to a different chr (mapQ>=5)\n", s->n_diffhigh[0], s->n_diffhigh[1]);
     free(s);
-    bam_header_destroy(header);
-    bam_close(fp);
+    bam_hdr_destroy(header);
+    hts_close(fp);
     return 0;
 }

--- a/bam_stat.c
+++ b/bam_stat.c
@@ -97,9 +97,14 @@ int bam_flagstat(int argc, char *argv[])
     }
 
     if (hts_set_opt(fp, CRAM_OPT_REQUIRED_FIELDS,
-		    SAM_FLAG | SAM_MAPQ | SAM_RNEXT)) {
-	fprintf(stderr, "Failed to set CRAM_OPT_REQUIRED_FIELDS value\n");
-	return 1;
+                    SAM_FLAG | SAM_MAPQ | SAM_RNEXT)) {
+        fprintf(stderr, "Failed to set CRAM_OPT_REQUIRED_FIELDS value\n");
+        return 1;
+    }
+
+    if (hts_set_opt(fp, CRAM_OPT_DECODE_MD, 0)) {
+        fprintf(stderr, "Failed to set CRAM_OPT_DECODE_MD value\n");
+        return 1;
     }
 
     header = sam_hdr_read(fp);

--- a/sam_view.c
+++ b/sam_view.c
@@ -572,6 +572,15 @@ int main_bam2fq(int argc, char *argv[])
         print_error_errno("Cannot read file \"%s\"", argv[optind]);
         return 1;
     }
+    if (hts_set_opt(fp, CRAM_OPT_REQUIRED_FIELDS,
+                    SAM_QNAME | SAM_FLAG | SAM_SEQ | SAM_QUAL)) {
+        fprintf(stderr, "Failed to set CRAM_OPT_REQUIRED_FIELDS value\n");
+        return 1;
+    }
+    if (hts_set_opt(fp, CRAM_OPT_DECODE_MD, 0)) {
+        fprintf(stderr, "Failed to set CRAM_OPT_DECODE_MD value\n");
+        return 1;
+    }
     fpse = NULL;
     if (fnse) {
         fpse = fopen(fnse,"w");


### PR DESCRIPTION
1. Samtools flagstat now uses the sam_open API instead of bam_open, meaning it can run on SAM, BAM and CRAM instead of BAM only.

2. Several tools have been updated to call hts_set_opt to control which SAM columns are needed by the application and whether or not the MD/NM tags should be auto-computed.