### PR TITLE
Replace 'samtools depth' cryptic 'minQLen' with real description

### DIFF
--- a/bam2depth.c
+++ b/bam2depth.c
@@ -98,7 +98,7 @@ int main_depth(int argc, char *argv[])
         fprintf(stderr, "Options:\n");
         fprintf(stderr, "   -b <bed>            list of positions or regions\n");
         fprintf(stderr, "   -f <list>           list of input BAM filenames, one per line [null]\n");
-        fprintf(stderr, "   -l <int>            minQLen\n");
+        fprintf(stderr, "   -l <int>            minimum mapped read length (from CIGAR string)\n");
         fprintf(stderr, "   -q <int>            base quality threshold\n");
         fprintf(stderr, "   -Q <int>            mapping quality threshold\n");
         fprintf(stderr, "   -r <chr:from-to>    region\n");


### PR DESCRIPTION
Could anyone understand 'minQLen' in the 'samtools depth' help?

```
$ ./samtools depth

Usage: samtools depth [options] in1.bam [in2.bam [...]]
Options:
   -b <bed>            list of positions or regions
   -f <list>           list of input BAM filenames, one per line [null]
   -l <int>            minQLen
   -q <int>            base quality threshold
   -Q <int>            mapping quality threshold
   -r <chr:from-to>    region
```

Reading the source code, this is mapped to variable `min_len` which (if set) is compared to each mapped read's length calculated from the CIGAR string using `bam_cigar2qlen(b->core.n_cigar, bam_get_cigar(b))`.

I think it makes more sense to label the `-l` option as "minimum mapped read length (from CIGAR string)" as per this one-line change.
