### PR TITLE
Added 'insert size' to the head of the IS section

### DIFF
--- a/misc/plot-bamstats
+++ b/misc/plot-bamstats
@@ -113,7 +113,7 @@ sub parse_params
             },
             {
                 id=>'IS',
-                header=>"# Insert sizes. Use `grep ^IS | cut -f 2-` to extract this part. The columns are: pairs total, inward oriented pairs, outward oriented pairs, other pairs\n",
+                header=>"# Insert sizes. Use `grep ^IS | cut -f 2-` to extract this part. The columns are: insert size, pairs total, inward oriented pairs, outward oriented pairs, other pairs\n",
             },
             {
                 id=>'RL',

--- a/stats.c
+++ b/stats.c
@@ -1052,7 +1052,7 @@ void output_stats(stats_t *stats, int sparse)
         if ( ! sum ) continue;
         printf("GCC\t%d\t%.2f\t%.2f\t%.2f\t%.2f\n", ibase+1,100.*ptr[0]/sum,100.*ptr[1]/sum,100.*ptr[2]/sum,100.*ptr[3]/sum);
     }
-    printf("# Insert sizes. Use `grep ^IS | cut -f 2-` to extract this part. The columns are: pairs total, inward oriented pairs, outward oriented pairs, other pairs\n");
+    printf("# Insert sizes. Use `grep ^IS | cut -f 2-` to extract this part. The columns are: insert size, pairs total, inward oriented pairs, outward oriented pairs, other pairs\n");
     for (isize=0; isize<ibulk; isize++) {
         long in = (long)(stats->isize->inward(stats->isize->data, isize));
         long out = (long)(stats->isize->outward(stats->isize->data, isize));

--- a/test/stat/1.stats.expected
+++ b/test/stat/1.stats.expected
@@ -190,7 +190,7 @@ GCC	32	0.00	50.00	50.00	0.00
 GCC	33	50.00	0.00	0.00	50.00
 GCC	34	50.00	0.00	50.00	0.00
 GCC	35	0.00	0.00	50.00	50.00
-# Insert sizes. Use `grep ^IS | cut -f 2-` to extract this part. The columns are: pairs total, inward oriented pairs, outward oriented pairs, other pairs
+# Insert sizes. Use `grep ^IS | cut -f 2-` to extract this part. The columns are: insert size, pairs total, inward oriented pairs, outward oriented pairs, other pairs
 IS	0	0	0	0	0
 IS	1	0	0	0	0
 IS	2	0	0	0	0

--- a/test/stat/2.stats.expected
+++ b/test/stat/2.stats.expected
@@ -190,7 +190,7 @@ GCC	32	0.00	50.00	50.00	0.00
 GCC	33	50.00	0.00	0.00	50.00
 GCC	34	50.00	0.00	50.00	0.00
 GCC	35	0.00	0.00	50.00	50.00
-# Insert sizes. Use `grep ^IS | cut -f 2-` to extract this part. The columns are: pairs total, inward oriented pairs, outward oriented pairs, other pairs
+# Insert sizes. Use `grep ^IS | cut -f 2-` to extract this part. The columns are: insert size, pairs total, inward oriented pairs, outward oriented pairs, other pairs
 IS	0	0	0	0	0
 IS	1	0	0	0	0
 IS	2	0	0	0	0

--- a/test/stat/3.stats.expected
+++ b/test/stat/3.stats.expected
@@ -153,7 +153,7 @@ GCF	1.26	1
 # GC Content of last fragments. Use `grep ^GCL | cut -f 2-` to extract this part.
 GCL	1.26	1
 # ACGT content per cycle. Use `grep ^GCC | cut -f 2-` to extract this part. The columns are: cycle, and A,C,G,T counts [%]
-# Insert sizes. Use `grep ^IS | cut -f 2-` to extract this part. The columns are: pairs total, inward oriented pairs, outward oriented pairs, other pairs
+# Insert sizes. Use `grep ^IS | cut -f 2-` to extract this part. The columns are: insert size, pairs total, inward oriented pairs, outward oriented pairs, other pairs
 IS	0	0	0	0	0
 IS	1	0	0	0	0
 IS	2	0	0	0	0

--- a/test/stat/4.stats.expected
+++ b/test/stat/4.stats.expected
@@ -190,7 +190,7 @@ GCC	32	0.00	50.00	50.00	0.00
 GCC	33	50.00	0.00	0.00	50.00
 GCC	34	50.00	0.00	50.00	0.00
 GCC	35	0.00	50.00	0.00	50.00
-# Insert sizes. Use `grep ^IS | cut -f 2-` to extract this part. The columns are: pairs total, inward oriented pairs, outward oriented pairs, other pairs
+# Insert sizes. Use `grep ^IS | cut -f 2-` to extract this part. The columns are: insert size, pairs total, inward oriented pairs, outward oriented pairs, other pairs
 IS	0	0	0	0	0
 IS	1	0	0	0	0
 IS	2	0	0	0	0

--- a/test/stat/5.stats.expected
+++ b/test/stat/5.stats.expected
@@ -190,7 +190,7 @@ GCC	32	0.00	100.00	0.00	0.00
 GCC	33	0.00	0.00	50.00	50.00
 GCC	34	100.00	0.00	0.00	0.00
 GCC	35	0.00	0.00	50.00	50.00
-# Insert sizes. Use `grep ^IS | cut -f 2-` to extract this part. The columns are: pairs total, inward oriented pairs, outward oriented pairs, other pairs
+# Insert sizes. Use `grep ^IS | cut -f 2-` to extract this part. The columns are: insert size, pairs total, inward oriented pairs, outward oriented pairs, other pairs
 IS	0	0	0	0	0
 IS	1	0	0	0	0
 IS	2	0	0	0	0

--- a/test/stat/6.stats.expected
+++ b/test/stat/6.stats.expected
@@ -190,7 +190,7 @@ GCC	32	0.00	100.00	0.00	0.00
 GCC	33	0.00	0.00	50.00	50.00
 GCC	34	100.00	0.00	0.00	0.00
 GCC	35	0.00	0.00	50.00	50.00
-# Insert sizes. Use `grep ^IS | cut -f 2-` to extract this part. The columns are: pairs total, inward oriented pairs, outward oriented pairs, other pairs
+# Insert sizes. Use `grep ^IS | cut -f 2-` to extract this part. The columns are: insert size, pairs total, inward oriented pairs, outward oriented pairs, other pairs
 IS	0	0	0	0	0
 IS	1	0	0	0	0
 IS	2	0	0	0	0


### PR DESCRIPTION
The output of the `samtools stats` command contains a header with a description of how to extract the following data section for further analysis. It also states what the columns will correspond to. In the header of the IS section, the insert size is not mentioned. Using the supplied command it will be the first column of the extracted data.

This diff adda this additonal info to the header and modifies the test files as well.