### PR TITLE
Fixed NM calculation for deletions partially off end of ref.

### DIFF
--- a/bam_md.c
+++ b/bam_md.c
@@ -77,8 +77,8 @@ void bam_fillmd1_core(bam1_t *b, char *ref, int flag, int max_nm)
                 kputc(ref[x+j], str);
             }
             u = 0;
+            x += j; nm += j;
             if (j < l) break;
-            x += l; nm += l;
         } else if (op == BAM_CINS || op == BAM_CSOFT_CLIP) {
             y += l;
             if (op == BAM_CINS) nm += l;


### PR DESCRIPTION
Consider the following example:

             1         2         3
        123456789012345678901234567890
    Ref AAAAAAAAAAAAAAAAAAAACGCTGTCTTG
    Seq      AAAAA----------CGCTG
    Seq                     CGCTG----------AAAAA
    Seq                          CGCTG----------AAAAA

All are 5M10D5M cigar, with the M actually matching. The first has NM:i:10.  The second overhangs the end of the reference. The MD:Z: tag is truncated to just ^TCTTG0. The code that detected this did a break before accumulating the nm variable so it miscalculated NM:i: value.

The reason I haven't automatically merged this in, given the simplicity of it, is I am unsure of what we should actually be doing. In particular the 3rd sequence gives MD of ^0; that is to say it has a deletion of no bases. Correct maybe?