### PR TITLE
Add sam_index_load() and samfetch() to legacy API

### DIFF
--- a/bam.h
+++ b/bam.h
@@ -460,7 +460,7 @@ extern "C" {
 
     /*!
       @abstract Retrieve the alignments that are overlapped with the
-      specified region.
+      specified region.  (For BAM files only; see also samfetch() in sam.h.)
 
       @discussion A user defined function will be called for each
       retrieved alignment ordered by its start position.

--- a/sam.c
+++ b/sam.c
@@ -1,6 +1,6 @@
 /*  sam.c -- format-neutral SAM/BAM API.
 
-    Copyright (C) 2009, 2012-2014 Genome Research Ltd.
+    Copyright (C) 2009, 2012-2015 Genome Research Ltd.
     Portions copyright (C) 2011 Broad Institute.
 
     Author: Heng Li <lh3@sanger.ac.uk>
@@ -74,6 +74,17 @@ void samclose(samfile_t *fp)
         sam_close(fp->file);
         free(fp);
     }
+}
+
+int samfetch(samfile_t *fp, const bam_index_t *idx, int tid, int beg, int end, void *data, bam_fetch_f func)
+{
+    bam1_t *b = bam_init1();
+    hts_itr_t *iter = sam_itr_queryi(idx, tid, beg, end);
+    int ret;
+    while ((ret = sam_itr_next(fp->file, iter, b)) >= 0) func(b, data);
+    hts_itr_destroy(iter);
+    bam_destroy1(b);
+    return (ret == -1)? 0 : ret;
 }
 
 int sampileup(samfile_t *fp, int mask, bam_pileup_f func, void *func_data)

--- a/sam.h
+++ b/sam.h
@@ -1,6 +1,6 @@
 /*  sam.h -- format-neutral SAM/BAM API.
 
-    Copyright (C) 2009, 2013, 2014 Genome Research Ltd.
+    Copyright (C) 2009, 2013-2015 Genome Research Ltd.
 
     Author: Heng Li <lh3@sanger.ac.uk>
 
@@ -101,6 +101,30 @@ extern "C" {
       @return       bytes written
      */
     static inline int samwrite(samfile_t *fp, const bam1_t *b) { return sam_write1(fp->file, fp->header, b); }
+
+    /*!
+      @abstract     Load BAM/CRAM index for use with samfetch()
+      @param  fp    file handler
+      @param  fn    name of the BAM or CRAM file (NOT the index file)
+      @return       pointer to the index structure
+     */
+    static inline bam_index_t *samtools_sam_index_load(samfile_t *fp, const char *fn) { return sam_index_load(fp->file, fn); }
+    #undef sam_index_load
+    #define sam_index_load(fp,fn) (samtools_sam_index_load((fp), (fn)))
+
+    /*!
+      @abstract Retrieve the alignments overlapping the specified region.
+      @discussion A user defined function will be called for each
+      retrieved alignment ordered by its start position.
+      @param  fp    file handler
+      @param  idx   index returned by sam_index_load()
+      @param  tid   chromosome ID as is defined in the header
+      @param  beg   start coordinate, 0-based
+      @param  end   end coordinate, 0-based
+      @param  data  user provided data (will be transferred to func)
+      @param  func  user defined function
+     */
+    int samfetch(samfile_t *fp, const bam_index_t *idx, int tid, int beg, int end, void *data, bam_fetch_f func);
 
     /*!
       @abstract     Get the pileup for a whole alignment file


### PR DESCRIPTION
Add legacy API sam.h functions sam_index_load() and samfetch() providing bam_fetch()-style iteration over either BAM or CRAM files.  (In general we recommend recoding against the htslib API directly, but this addition may help existing libbam-using programs to be CRAM-enabled easily.)