### PR TITLE
change mygetline return type size_t to ssize_t

### DIFF
--- a/stats.c
+++ b/stats.c
@@ -1131,7 +1131,7 @@ void output_stats(stats_t *stats, int sparse)
     }
 }
 
-size_t mygetline(char **line, size_t *n, FILE *fp)
+ssize_t mygetline(char **line, size_t *n, FILE *fp)
 {
     if (line == NULL || n == NULL || fp == NULL)
     {


### PR DESCRIPTION
`mygetline` return type is `size_t` but sentinel value is -1

[`mygetline`](https://github.com/samtools/samtools/blob/43ca26c42891523363b5aa9839fa711cb7bf21bd/stats.c#L1134) return value is compared against `-1` in [`init_regions`](https://github.com/samtools/samtools/blob/43ca26c42891523363b5aa9839fa711cb7bf21bd/stats.c#L1178) but because of the change in signedness the return value of mygetline can never be < 0, though the comparison technically works. I think the intent is mygetline should return `ssize_t`, which will address the compiler warning.