### PR TITLE
Output fmt option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,17 +198,17 @@ check test: samtools $(BGZIP) $(BUILT_TEST_PROGRAMS)
 	test/split/test_parse_args
 
 
-test/merge/test_bam_translate: test/merge/test_bam_translate.o test/test.o $(HTSLIB)
-	$(CC) -pthread $(LDFLAGS) -o $@ test/merge/test_bam_translate.o test/test.o $(HTSLIB) -lz $(LIBS)
+test/merge/test_bam_translate: test/merge/test_bam_translate.o test/test.o sam_opts.o $(HTSLIB)
+	$(CC) -pthread $(LDFLAGS) -o $@ test/merge/test_bam_translate.o test/test.o sam_opts.o $(HTSLIB) -lz $(LIBS)
 
-test/merge/test_pretty_header: test/merge/test_pretty_header.o $(HTSLIB)
-	$(CC) -pthread $(LDFLAGS) -o $@ test/merge/test_pretty_header.o $(HTSLIB) -lz $(LIBS)
+test/merge/test_pretty_header: test/merge/test_pretty_header.o sam_opts.o $(HTSLIB)
+	$(CC) -pthread $(LDFLAGS) -o $@ test/merge/test_pretty_header.o sam_opts.o $(HTSLIB) -lz $(LIBS)
 
-test/merge/test_rtrans_build: test/merge/test_rtrans_build.o $(HTSLIB)
-	$(CC) -pthread $(LDFLAGS) -o $@ test/merge/test_rtrans_build.o $(HTSLIB) -lz $(LIBS)
+test/merge/test_rtrans_build: test/merge/test_rtrans_build.o sam_opts.o $(HTSLIB)
+	$(CC) -pthread $(LDFLAGS) -o $@ test/merge/test_rtrans_build.o sam_opts.o $(HTSLIB) -lz $(LIBS)
 
-test/merge/test_trans_tbl_init: test/merge/test_trans_tbl_init.o $(HTSLIB)
-	$(CC) -pthread $(LDFLAGS) -o $@ test/merge/test_trans_tbl_init.o $(HTSLIB) -lz $(LIBS)
+test/merge/test_trans_tbl_init: test/merge/test_trans_tbl_init.o sam_opts.o $(HTSLIB)
+	$(CC) -pthread $(LDFLAGS) -o $@ test/merge/test_trans_tbl_init.o sam_opts.o $(HTSLIB) -lz $(LIBS)
 
 test/split/test_count_rg: test/split/test_count_rg.o test/test.o sam_opts.o $(HTSLIB)
 	$(CC) -pthread $(LDFLAGS) -o $@ test/split/test_count_rg.o test/test.o sam_opts.o $(HTSLIB) -lz $(LIBS)
@@ -219,7 +219,7 @@ test/split/test_expand_format_string: test/split/test_expand_format_string.o tes
 test/split/test_filter_header_rg: test/split/test_filter_header_rg.o test/test.o sam_opts.o $(HTSLIB)
 	$(CC) -pthread $(LDFLAGS) -o $@ test/split/test_filter_header_rg.o test/test.o sam_opts.o $(HTSLIB) -lz $(LIBS)
 
-test/split/test_parse_args: test/split/test_parse_args.o test/test.o sam_opts.o sam_opts.o $(HTSLIB)
+test/split/test_parse_args: test/split/test_parse_args.o test/test.o sam_opts.o $(HTSLIB)
 	$(CC) -pthread $(LDFLAGS) -o $@ test/split/test_parse_args.o test/test.o sam_opts.o $(HTSLIB) -lz $(LIBS)
 
 test/vcf-miniview: test/vcf-miniview.o $(HTSLIB)

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ AOBJS=      bam_index.o bam_plcmd.o sam_view.o \
             bamtk.o bam2bcf.o bam2bcf_indel.o errmod.o sample.o \
             cut_target.o phase.o bam2depth.o padding.o bedcov.o bamshuf.o \
             faidx.o dict.o stats.o stats_isize.o bam_flags.o bam_split.o \
-            bam_tview.o bam_tview_curses.o bam_tview_html.o bam_lpileup.o
+            bam_tview.o bam_tview_curses.o bam_tview_html.o bam_lpileup.o \
+            sam_opts.o
 
 EXTRA_CPPFLAGS = $(DFLAGS) -I. -I$(HTSDIR)
 LIBCURSES=  -lcurses # -lXCurses
@@ -132,6 +133,7 @@ bam_lpileup_h = bam_lpileup.h $(htslib_sam_h)
 bam_plbuf_h = bam_plbuf.h $(htslib_sam_h)
 bam_tview_h = bam_tview.h $(htslib_hts_h) $(htslib_sam_h) $(htslib_faidx_h) $(bam2bcf_h) $(HTSDIR)/htslib/khash.h $(bam_lpileup_h)
 sam_h = sam.h $(htslib_sam_h) $(bam_h)
+sam_opts_h = sam_opts.h $(htslib_hts_h)
 sample_h = sample.h $(HTSDIR)/htslib/kstring.h
 
 bam.o: bam.c $(bam_h) sam_header.h
@@ -170,6 +172,7 @@ padding.o: padding.c sam_header.h $(sam_h) $(bam_h) $(htslib_faidx_h)
 phase.o: phase.c $(htslib_sam_h) errmod.h $(HTSDIR)/htslib/kseq.h $(HTSDIR)/htslib/khash.h $(HTSDIR)/htslib/ksort.h
 sam.o: sam.c $(htslib_faidx_h) $(sam_h)
 sam_header.o: sam_header.c sam_header.h $(HTSDIR)/htslib/khash.h
+sam_opts.o: sam_opts.c $(sam_opts_h)
 sam_view.o: sam_view.c $(htslib_sam_h) $(htslib_faidx_h) $(HTSDIR)/htslib/kstring.h $(HTSDIR)/htslib/khash.h samtools.h
 sample.o: sample.c $(sample_h) $(HTSDIR)/htslib/khash.h
 stats_isize.o: stats_isize.c stats_isize.h $(HTSDIR)/htslib/khash.h
@@ -207,17 +210,17 @@ test/merge/test_rtrans_build: test/merge/test_rtrans_build.o $(HTSLIB)
 test/merge/test_trans_tbl_init: test/merge/test_trans_tbl_init.o $(HTSLIB)
 	$(CC) -pthread $(LDFLAGS) -o $@ test/merge/test_trans_tbl_init.o $(HTSLIB) -lz $(LIBS)
 
-test/split/test_count_rg: test/split/test_count_rg.o test/test.o $(HTSLIB)
-	$(CC) -pthread $(LDFLAGS) -o $@ test/split/test_count_rg.o test/test.o $(HTSLIB) -lz $(LIBS)
+test/split/test_count_rg: test/split/test_count_rg.o test/test.o sam_opts.o $(HTSLIB)
+	$(CC) -pthread $(LDFLAGS) -o $@ test/split/test_count_rg.o test/test.o sam_opts.o $(HTSLIB) -lz $(LIBS)
 
-test/split/test_expand_format_string: test/split/test_expand_format_string.o test/test.o $(HTSLIB)
-	$(CC) -pthread $(LDFLAGS) -o $@ test/split/test_expand_format_string.o test/test.o $(HTSLIB) -lz $(LIBS)
+test/split/test_expand_format_string: test/split/test_expand_format_string.o test/test.o sam_opts.o $(HTSLIB)
+	$(CC) -pthread $(LDFLAGS) -o $@ test/split/test_expand_format_string.o test/test.o sam_opts.o $(HTSLIB) -lz $(LIBS)
 
-test/split/test_filter_header_rg: test/split/test_filter_header_rg.o test/test.o $(HTSLIB)
-	$(CC) -pthread $(LDFLAGS) -o $@ test/split/test_filter_header_rg.o test/test.o $(HTSLIB) -lz $(LIBS)
+test/split/test_filter_header_rg: test/split/test_filter_header_rg.o test/test.o sam_opts.o $(HTSLIB)
+	$(CC) -pthread $(LDFLAGS) -o $@ test/split/test_filter_header_rg.o test/test.o sam_opts.o $(HTSLIB) -lz $(LIBS)
 
-test/split/test_parse_args: test/split/test_parse_args.o test/test.o $(HTSLIB)
-	$(CC) -pthread $(LDFLAGS) -o $@ test/split/test_parse_args.o test/test.o $(HTSLIB) -lz $(LIBS)
+test/split/test_parse_args: test/split/test_parse_args.o test/test.o sam_opts.o sam_opts.o $(HTSLIB)
+	$(CC) -pthread $(LDFLAGS) -o $@ test/split/test_parse_args.o test/test.o sam_opts.o $(HTSLIB) -lz $(LIBS)
 
 test/vcf-miniview: test/vcf-miniview.o $(HTSLIB)
 	$(CC) -pthread $(LDFLAGS) -o $@ test/vcf-miniview.o $(HTSLIB) -lz $(LIBS)

--- a/bam2depth.c
+++ b/bam2depth.c
@@ -36,6 +36,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <unistd.h>
 #include "htslib/sam.h"
 #include "samtools.h"
+#include "sam_opts.h"
 
 typedef struct {     // auxiliary data structure
     samFile *fp;     // the file handle
@@ -68,6 +69,25 @@ static int read_bam(void *data, bam1_t *b) // read level filters better go here 
 
 int read_file_list(const char *file_list,int *n,char **argv[]);
 
+static int usage() {
+    fprintf(stderr, "\n");
+    fprintf(stderr, "Usage: samtools depth [options] in1.bam [in2.bam [...]]\n");
+    fprintf(stderr, "Options:\n");
+    fprintf(stderr, "   -a                  output all positions (including zero depth)\n");
+    fprintf(stderr, "   -a -a (or -aa)      output absolutely all positions, including unused ref. sequences\n");
+    fprintf(stderr, "   -b <bed>            list of positions or regions\n");
+    fprintf(stderr, "   -f <list>           list of input BAM filenames, one per line [null]\n");
+    fprintf(stderr, "   -l <int>            read length threshold (ignore reads shorter than <int>)\n");
+    fprintf(stderr, "   -q <int>            base quality threshold\n");
+    fprintf(stderr, "   -Q <int>            mapping quality threshold\n");
+    fprintf(stderr, "   -r <chr:from-to>    region\n");
+    fprintf(stderr, "\n");
+
+    sam_global_opt_help(stderr, "-.---");
+
+    return 1;
+}
+
 int main_depth(int argc, char *argv[])
 {
     int i, n, tid, beg, end, pos, *n_plp, baseQ = 0, mapQ = 0, min_len = 0;
@@ -79,10 +99,14 @@ int main_depth(int argc, char *argv[])
     bam_hdr_t *h = NULL; // BAM header of the 1st input
     aux_t **data;
     bam_mplp_t mplp;
-    int last_pos = -1, last_tid = -1;
+    int last_pos = -1, last_tid = -1, ret;
+
+    sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
+    static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
+    assign_short_opts(lopts, "-.---");
 
     // parse the command line
-    while ((n = getopt(argc, argv, "r:b:q:Q:l:f:a")) >= 0) {
+    while ((n = getopt_long(argc, argv, "r:b:q:Q:l:f:a", lopts, NULL)) >= 0) {
         switch (n) {
             case 'l': min_len = atoi(optarg); break; // minimum query length
             case 'r': reg = strdup(optarg); break;   // parsing a region requires a BAM header
@@ -94,23 +118,12 @@ int main_depth(int argc, char *argv[])
             case 'Q': mapQ = atoi(optarg); break;    // mapping quality threshold
             case 'f': file_list = optarg; break;
             case 'a': all++; break;
+            default: if (parse_sam_global_opt(n, optarg, lopts, &ga) == 0) break;
+            case '?': return usage();
         }
     }
-    if (optind == argc && !file_list) {
-        fprintf(stderr, "\n");
-        fprintf(stderr, "Usage: samtools depth [options] in1.bam [in2.bam [...]]\n");
-        fprintf(stderr, "Options:\n");
-        fprintf(stderr, "   -a                  output all positions (including zero depth)\n");
-        fprintf(stderr, "   -a -a (or -aa)      output absolutely all positions, including unused ref. sequences\n");
-        fprintf(stderr, "   -b <bed>            list of positions or regions\n");
-        fprintf(stderr, "   -f <list>           list of input BAM filenames, one per line [null]\n");
-        fprintf(stderr, "   -l <int>            read length threshold (ignore reads shorter than <int>)\n");
-        fprintf(stderr, "   -q <int>            base quality threshold\n");
-        fprintf(stderr, "   -Q <int>            mapping quality threshold\n");
-        fprintf(stderr, "   -r <chr:from-to>    region\n");
-        fprintf(stderr, "\n");
-        return 1;
-    }
+    if (optind == argc && !file_list)
+        return usage();
 
     // initialize the auxiliary data structures
     if (file_list)
@@ -126,7 +139,7 @@ int main_depth(int argc, char *argv[])
     beg = 0; end = 1<<30;  // set the default region
     for (i = 0; i < n; ++i) {
         data[i] = calloc(1, sizeof(aux_t));
-        data[i]->fp = sam_open(argv[optind+i], "r"); // open BAM
+        data[i]->fp = sam_open_format(argv[optind+i], "r", &ga.in); // open BAM
         if (data[i]->fp == NULL) {
             print_error_errno("Could not open \"%s\"", argv[optind+i]);
             status = EXIT_FAILURE;
@@ -172,7 +185,7 @@ int main_depth(int argc, char *argv[])
     mplp = bam_mplp_init(n, read_bam, (void**)data); // initialization
     n_plp = calloc(n, sizeof(int)); // n_plp[i] is the number of covering reads from the i-th BAM
     plp = calloc(n, sizeof(bam_pileup1_t*)); // plp[i] points to the array of covering reads (internal in mplp)
-    while (bam_mplp_auto(mplp, &tid, &pos, n_plp, plp) > 0) { // come to the next covered position
+    while ((ret=bam_mplp_auto(mplp, &tid, &pos, n_plp, plp)) > 0) { // come to the next covered position
         if (pos < beg || pos >= end) continue; // out of range; skip
         if (tid >= h->n_targets) continue;     // diff number of @SQ lines per file?
         if (bed && bed_overlap(bed, h->target_name[tid], pos, pos + 1) == 0) continue; // not in BED; skip
@@ -219,6 +232,7 @@ int main_depth(int argc, char *argv[])
         }
         putchar('\n');
     }
+    if (ret < 0) status = EXIT_FAILURE;
     free(n_plp); free(plp);
     bam_mplp_destroy(mplp);
 

--- a/bam2depth.c
+++ b/bam2depth.c
@@ -102,8 +102,10 @@ int main_depth(int argc, char *argv[])
     int last_pos = -1, last_tid = -1, ret;
 
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
-    static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
-    assign_short_opts(lopts, "-.--.");
+    static const struct option lopts[] = {
+        SAM_OPT_GLOBAL_OPTIONS('-', 0, '-', '-', 0),
+        { NULL, 0, NULL, 0 }
+    };
 
     // parse the command line
     while ((n = getopt_long(argc, argv, "r:b:q:Q:l:f:a", lopts, NULL)) >= 0) {

--- a/bam2depth.c
+++ b/bam2depth.c
@@ -83,7 +83,7 @@ static int usage() {
     fprintf(stderr, "   -r <chr:from-to>    region\n");
     fprintf(stderr, "\n");
 
-    sam_global_opt_help(stderr, "-.---");
+    sam_global_opt_help(stderr, "-.--.");
 
     return 1;
 }
@@ -103,7 +103,7 @@ int main_depth(int argc, char *argv[])
 
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
     static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
-    assign_short_opts(lopts, "-.---");
+    assign_short_opts(lopts, "-.--.");
 
     // parse the command line
     while ((n = getopt_long(argc, argv, "r:b:q:Q:l:f:a", lopts, NULL)) >= 0) {

--- a/bam2depth.c
+++ b/bam2depth.c
@@ -269,6 +269,7 @@ depth_end:
         for (i=0; i<n; i++) free(fn[i]);
         free(fn);
     }
+    sam_global_args_free(&ga);
     return status;
 }
 

--- a/bam2depth.c
+++ b/bam2depth.c
@@ -138,6 +138,7 @@ int main_depth(int argc, char *argv[])
     data = calloc(n, sizeof(aux_t*)); // data[i] for the i-th input
     beg = 0; end = 1<<30;  // set the default region
     for (i = 0; i < n; ++i) {
+        int rf;
         data[i] = calloc(1, sizeof(aux_t));
         data[i]->fp = sam_open_format(argv[optind+i], "r", &ga.in); // open BAM
         if (data[i]->fp == NULL) {
@@ -145,9 +146,9 @@ int main_depth(int argc, char *argv[])
             status = EXIT_FAILURE;
             goto depth_end;
         }
-        if (hts_set_opt(data[i]->fp, CRAM_OPT_REQUIRED_FIELDS,
-                        SAM_FLAG | SAM_RNAME | SAM_POS | SAM_MAPQ | SAM_CIGAR |
-                        SAM_SEQ)) {
+        rf = SAM_FLAG | SAM_RNAME | SAM_POS | SAM_MAPQ | SAM_CIGAR | SAM_SEQ;
+        if (baseQ) rf |= SAM_QUAL;
+        if (hts_set_opt(data[i]->fp, CRAM_OPT_REQUIRED_FIELDS, rf)) {
             fprintf(stderr, "Failed to set CRAM_OPT_REQUIRED_FIELDS value\n");
             return 1;
         }

--- a/bam_mate.c
+++ b/bam_mate.c
@@ -311,8 +311,10 @@ int bam_mating(int argc, char *argv[])
     samFile *in, *out;
     int c, remove_reads = 0, proper_pair_check = 1, add_ct = 0;
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
-    static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
-    assign_short_opts(lopts, "-.O..");
+    static const struct option lopts[] = {
+        SAM_OPT_GLOBAL_OPTIONS('-', 0, 'O', 0, 0),
+        { NULL, 0, NULL, 0 }
+    };
 
     // parse args
     if (argc == 1) { usage(stdout); return 0; }

--- a/bam_mate.c
+++ b/bam_mate.c
@@ -29,6 +29,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include "sam_opts.h"
 #include "htslib/kstring.h"
 #include "htslib/sam.h"
 
@@ -294,10 +295,12 @@ void usage(FILE* where)
 {
     fprintf(where,"Usage: samtools fixmate <in.nameSrt.bam> <out.nameSrt.bam>\n\n");
     fprintf(where,"Options:\n");
-    fprintf(stderr,"  -r         Remove unmapped reads and secondary alignments\n");
-    fprintf(stderr,"  -p         Disable FR proper pair check\n");
-    fprintf(stderr,"  -c         Add template cigar ct tag\n");
-    fprintf(stderr,"  -O FORMAT  Write output as FORMAT ('sam'/'bam'/'cram')\n");
+    fprintf(stderr,"  -r           Remove unmapped reads and secondary alignments\n");
+    fprintf(stderr,"  -p           Disable FR proper pair check\n");
+    fprintf(stderr,"  -c           Add template cigar ct tag\n");
+
+    sam_global_opt_help(stderr, "-.O.-");
+
     fprintf(stderr,"As elsewhere in samtools, use '-' as the filename for stdin/stdout. The input\n");
     fprintf(stderr,"file must be grouped by read name (e.g. sorted by name). Coordinated sorted\n");
     fprintf(stderr,"input is not accepted.\n");
@@ -307,46 +310,41 @@ int bam_mating(int argc, char *argv[])
 {
     samFile *in, *out;
     int c, remove_reads = 0, proper_pair_check = 1, add_ct = 0;
-    char* fmtout = NULL;
-    char modeout[12];
+    sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
+    static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
+    assign_short_opts(lopts, "-.O.-");
+
     // parse args
     if (argc == 1) { usage(stdout); return 0; }
-    while ((c = getopt(argc, argv, "rpcO:")) >= 0) {
+    while ((c = getopt_long(argc, argv, "rpcO:", lopts, NULL)) >= 0) {
         switch (c) {
             case 'r': remove_reads = 1; break;
             case 'p': proper_pair_check = 0; break;
             case 'c': add_ct = 1; break;
-            case 'O': fmtout = optarg; break;
-            default: usage(stderr); return 1;
+            //case 'O': fmtout = optarg; break;
+            default: if (parse_sam_global_opt(c, optarg, lopts, &ga) == 0) break;
+            case '?': usage(stderr); return 1;
         }
     }
     if (optind+1 >= argc) { usage(stderr); return 1; }
-    strcpy(modeout, "w");
-    if (sam_open_mode(&modeout[1], argv[optind+1], fmtout) < 0) {
-        if (fmtout) {
-            fprintf(stderr, "[bam_mating] cannot parse output format \"%s\"\n", fmtout);
-            return 1;
-        }
-
-        // Couldn't determine format from the filename; an unrecognised
-        // extension or perhaps "-".  Emit BAM as samtools 0.1.x did.
-        strcat(modeout, "b");
-    }
 
     // init
-    if ((in = sam_open(argv[optind], "r")) == NULL) {
+    if ((in = sam_open_opts(argv[optind], "rb", &ga.in)) == NULL) {
         fprintf(stderr, "[bam_mating] cannot open input file\n");
         return 1;
     }
-    if ((out = sam_open(argv[optind+1], modeout)) == NULL) {
+    if ((out = sam_open_opts(argv[optind+1], "wb", &ga.out)) == NULL) {
         fprintf(stderr, "[bam_mating] cannot open output file\n");
         return 1;
     }
 
     // run
     bam_mating_core(in, out, remove_reads, proper_pair_check, add_ct);
+
     // cleanup
     sam_close(in); sam_close(out);
+    sam_global_args_free(&ga);
+
     return 0;
 }
 

--- a/bam_mate.c
+++ b/bam_mate.c
@@ -299,7 +299,7 @@ void usage(FILE* where)
     fprintf(stderr,"  -p           Disable FR proper pair check\n");
     fprintf(stderr,"  -c           Add template cigar ct tag\n");
 
-    sam_global_opt_help(stderr, "-.O.-");
+    sam_global_opt_help(stderr, "-.O..");
 
     fprintf(stderr,"As elsewhere in samtools, use '-' as the filename for stdin/stdout. The input\n");
     fprintf(stderr,"file must be grouped by read name (e.g. sorted by name). Coordinated sorted\n");
@@ -312,7 +312,7 @@ int bam_mating(int argc, char *argv[])
     int c, remove_reads = 0, proper_pair_check = 1, add_ct = 0;
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
     static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
-    assign_short_opts(lopts, "-.O.-");
+    assign_short_opts(lopts, "-.O..");
 
     // parse args
     if (argc == 1) { usage(stdout); return 0; }

--- a/bam_mate.c
+++ b/bam_mate.c
@@ -329,11 +329,11 @@ int bam_mating(int argc, char *argv[])
     if (optind+1 >= argc) { usage(stderr); return 1; }
 
     // init
-    if ((in = sam_open_opts(argv[optind], "rb", &ga.in)) == NULL) {
+    if ((in = sam_open_format(argv[optind], "rb", &ga.in)) == NULL) {
         fprintf(stderr, "[bam_mating] cannot open input file\n");
         return 1;
     }
-    if ((out = sam_open_opts(argv[optind+1], "wb", &ga.out)) == NULL) {
+    if ((out = sam_open_format(argv[optind+1], "wb", &ga.out)) == NULL) {
         fprintf(stderr, "[bam_mating] cannot open output file\n");
         return 1;
     }

--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -37,6 +37,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <htslib/khash_str2int.h>
 #include "sam_header.h"
 #include "samtools.h"
+#include "sam_opts.h"
 
 static inline int printw(int c, FILE *fp)
 {
@@ -122,6 +123,7 @@ typedef struct {
     void *bed, *rghash;
     int argc;
     char **argv;
+    sam_global_args ga;
 } mplp_conf_t;
 
 typedef struct {
@@ -260,7 +262,7 @@ static int mpileup(mplp_conf_t *conf, int n, char **fn)
     for (i = 0; i < n; ++i) {
         bam_hdr_t *h_tmp;
         data[i] = calloc(1, sizeof(mplp_aux_t));
-        data[i]->fp = sam_open(fn[i], "rb");
+        data[i]->fp = sam_open_format(fn[i], "rb", &conf->ga.in);
         if ( !data[i]->fp )
         {
             fprintf(stderr, "[%s] failed to open %s: %s\n", __func__, fn[i], strerror(errno));
@@ -754,7 +756,9 @@ int bam_mpileup(int argc, char *argv[])
     mplp.argc = argc; mplp.argv = argv;
     mplp.rflag_filter = BAM_FUNMAP | BAM_FSECONDARY | BAM_FQCFAIL | BAM_FDUP;
     mplp.output_fname = NULL;
-    static const struct option lopts[] =
+    sam_global_args_init(&mplp.ga);
+
+    static struct option lopts[] =
     {
         {"rf", required_argument, NULL, 1},   // require flag
         {"ff", required_argument, NULL, 2},   // filter flag
@@ -803,8 +807,10 @@ int bam_mpileup(int argc, char *argv[])
         {"per-sample-mF", no_argument, NULL, 'p'},
         {"per-sample-mf", no_argument, NULL, 'p'},
         {"platforms", required_argument, NULL, 'P'},
+        SAM_GLOBAL_LOPTS,
         {NULL, 0, NULL, 0}
     };
+    assign_short_opts(lopts, "-.--.");
     while ((c = getopt_long(argc, argv, "Agf:r:l:q:Q:uRC:BDSd:L:b:P:po:e:h:Im:F:EG:6OsVvxt:",lopts,NULL)) >= 0) {
         switch (c) {
         case 'x': mplp.flag &= ~MPLP_SMART_OVERLAPS; break;
@@ -877,7 +883,8 @@ int bam_mpileup(int argc, char *argv[])
             }
             break;
         case 't': mplp.fmt_flag |= parse_format_flag(optarg); break;
-        default:
+        default: if (parse_sam_global_opt(c, optarg, lopts, &mplp.ga) == 0) break;
+        case '?':
             fprintf(stderr,"Invalid option: '%c'\n", c);
             return 1;
         }

--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -760,6 +760,7 @@ int bam_mpileup(int argc, char *argv[])
 
     static struct option lopts[] =
     {
+        SAM_GLOBAL_LOPTS,
         {"rf", required_argument, NULL, 1},   // require flag
         {"ff", required_argument, NULL, 2},   // filter flag
         {"incl-flags", required_argument, NULL, 1},
@@ -807,7 +808,6 @@ int bam_mpileup(int argc, char *argv[])
         {"per-sample-mF", no_argument, NULL, 'p'},
         {"per-sample-mf", no_argument, NULL, 'p'},
         {"platforms", required_argument, NULL, 'P'},
-        SAM_GLOBAL_LOPTS,
         {NULL, 0, NULL, 0}
     };
     assign_short_opts(lopts, "-.--.");

--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -758,9 +758,9 @@ int bam_mpileup(int argc, char *argv[])
     mplp.output_fname = NULL;
     sam_global_args_init(&mplp.ga);
 
-    static struct option lopts[] =
+    static const struct option lopts[] =
     {
-        SAM_GLOBAL_LOPTS,
+        SAM_OPT_GLOBAL_OPTIONS('-', 0, '-', '-', 0),
         {"rf", required_argument, NULL, 1},   // require flag
         {"ff", required_argument, NULL, 2},   // filter flag
         {"incl-flags", required_argument, NULL, 1},
@@ -810,7 +810,6 @@ int bam_mpileup(int argc, char *argv[])
         {"platforms", required_argument, NULL, 'P'},
         {NULL, 0, NULL, 0}
     };
-    assign_short_opts(lopts, "-.--.");
     while ((c = getopt_long(argc, argv, "Agf:r:l:q:Q:uRC:BDSd:L:b:P:po:e:h:Im:F:EG:6OsVvxt:",lopts,NULL)) >= 0) {
         switch (c) {
         case 'x': mplp.flag &= ~MPLP_SMART_OVERLAPS; break;

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -32,6 +32,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <regex.h>
 #include <time.h>
 #include <unistd.h>
+#include <getopt.h>
 #include "htslib/ksort.h"
 #include "htslib/khash.h"
 #include "htslib/klist.h"
@@ -582,7 +583,10 @@ int* rtrans_build(int n, int n_targets, trans_tbl_t* translation_tbl)
   @discussion Padding information may NOT correctly maintained. This
   function is NOT thread safe.
  */
-int bam_merge_core2(int by_qname, const char *out, const char *mode, const char *headers, int n, char * const *fn, int flag, const char *reg, int n_threads)
+int bam_merge_core2(int by_qname, const char *out, const char *mode,
+                    const char *headers, int n, char * const *fn, int flag,
+                    const char *reg, int n_threads,
+                    hts_opt *in_opts, hts_opt *out_opts)
 {
     samFile *fpout, **fp;
     heap1_t *heap;
@@ -639,6 +643,7 @@ int bam_merge_core2(int by_qname, const char *out, const char *mode, const char 
             // FIXME: possible memory leak
             return -1;
         }
+        hts_opt_apply(fp[i], in_opts);
         hin = sam_hdr_read(fp[i]);
         if (hout)
             trans_tbl_init(hout, hin, translation_tbl+i, flag & MERGE_COMBINE_RG, flag & MERGE_COMBINE_PG);
@@ -741,6 +746,7 @@ int bam_merge_core2(int by_qname, const char *out, const char *mode, const char 
         fprintf(stderr, "[%s] fail to create the output file.\n", __func__);
         return -1;
     }
+    hts_opt_apply(fpout, out_opts);
     sam_hdr_write(fpout, hout);
     if (!(flag & MERGE_UNCOMP)) hts_set_threads(fpout, n_threads);
 
@@ -783,31 +789,28 @@ int bam_merge_core2(int by_qname, const char *out, const char *mode, const char 
     return 0;
 }
 
-int bam_merge_core(int by_qname, const char *out, const char *headers, int n, char * const *fn, int flag, const char *reg)
-{
-    char mode[12];
-    strcpy(mode, "wb");
-    if (flag & MERGE_UNCOMP) strcat(mode, "0");
-    else if (flag & MERGE_LEVEL1) strcat(mode, "1");
-    return bam_merge_core2(by_qname, out, mode, headers, n, fn, flag, reg, 0);
-}
-
 static void merge_usage(FILE *to)
 {
     fprintf(to, "Usage:   samtools merge [-nurlf] [-h inh.sam] [-b <bamlist.fofn>] <out.bam> <in1.bam> <in2.bam> [<in3.bam> ... <inN.bam>]\n\n");
-    fprintf(to, "Options: -n       sort by read names\n");
-    fprintf(to, "         -r       attach RG tag (inferred from file names)\n");
-    fprintf(to, "         -u       uncompressed BAM output\n");
-    fprintf(to, "         -f       overwrite the output BAM if exist\n");
-    fprintf(to, "         -1       compress level 1\n");
-    fprintf(to, "         -l INT   compression level, from 0 to 9 [-1]\n");
-    fprintf(to, "         -@ INT   number of BAM compression threads [0]\n");
-    fprintf(to, "         -R STR   merge file in the specified region STR [all]\n");
-    fprintf(to, "         -h FILE  copy the header in FILE to <out.bam> [in1.bam]\n");
-    fprintf(to, "         -c       combine RG tags with colliding IDs rather than amending them\n");
-    fprintf(to, "         -p       combine PG tags with colliding IDs rather than amending them\n");
-    fprintf(to, "         -s VALUE override random seed\n");
-    fprintf(to, "         -b FILE  list of input BAM filenames, one per line [null]\n\n");
+    fprintf(to, "Options:\n");
+    fprintf(to, "  -n             sort by read names\n");
+    fprintf(to, "  -r             attach RG tag (inferred from file names)\n");
+    fprintf(to, "  -u             uncompressed BAM output\n");
+    fprintf(to, "  -f             overwrite the output BAM if exist\n");
+    fprintf(to, "  -1             compress level 1\n");
+    fprintf(to, "  -l INT         compression level, from 0 to 9 [-1]\n");
+    fprintf(to, "  -@ INT         number of BAM compression threads [0]\n");
+    fprintf(to, "  -R STR         merge file in the specified region STR [all]\n");
+    fprintf(to, "  -h FILE        copy the header in FILE to <out.bam> [in1.bam]\n");
+    fprintf(to, "  -c             combine RG tags with colliding IDs rather than amending them\n");
+    fprintf(to, "  -p             combine PG tags with colliding IDs rather than amending them\n");
+    fprintf(to, "  -s VALUE       override random seed\n");
+    fprintf(to, "  -b FILE        list of input BAM filenames, one per line [null]\n\n");
+    fprintf(to, "  -O FORMAT, --output-fmt FORMAT\n");
+    fprintf(to, "                 write output as FORMAT ('sam'/'bam'/'cram'\n");
+    fprintf(to, "  --input-fmt-option  OPTION=VALUE\n");
+    fprintf(to, "  --output-fmt-option OPTION=VALUE\n");
+    fprintf(to, "                 control the input or output format via OPTION or OPTION=VALUE\n");
 }
 
 int bam_merge(int argc, char *argv[])
@@ -817,13 +820,41 @@ int bam_merge(int argc, char *argv[])
     long random_seed = (long)time(NULL);
     char** fn = NULL;
     int fn_size = 0;
+    hts_opt *in_opts = NULL, *out_opts = NULL;
+    //char *fmtout="bam";
+    char *fmtout=NULL;
 
     if (argc == 1) {
         merge_usage(stdout);
         return 0;
     }
 
-    while ((c = getopt(argc, argv, "h:nru1R:f@:l:cps:b:")) >= 0) {
+    enum {
+        INPUT_FMT_OPTION = CHAR_MAX+1,
+        OUTPUT_FMT_OPTION,
+    };
+
+    static const struct option lopts[] =
+    {
+        {"input-fmt-option",  required_argument, NULL, INPUT_FMT_OPTION}, 
+        {"output-fmt-option", required_argument, NULL, OUTPUT_FMT_OPTION}, 
+        {"output-fmt",        required_argument, NULL, 'O'}, 
+        {"", no_argument,       NULL, 'n'}, 
+        {"", no_argument,       NULL, 'r'}, 
+        {"", no_argument,       NULL, 'u'}, 
+        {"", no_argument,       NULL, 'f'}, 
+        {"", no_argument,       NULL, '1'}, 
+        {"", required_argument, NULL, '@'}, 
+        {"", required_argument, NULL, 'R'}, 
+        {"", required_argument, NULL, 'h'}, 
+        {"", no_argument,       NULL, 'c'}, 
+        {"", no_argument,       NULL, 'p'}, 
+        {"", required_argument, NULL, 's'}, 
+        {"", required_argument, NULL, 'b'}, 
+        {NULL, 0, NULL, 0}
+    };
+
+    while ((c = getopt_long(argc, argv, "h:nru1R:f@:l:cps:b:O:", lopts, NULL)) >= 0) {
         switch (c) {
         case 'r': flag |= MERGE_RG; break;
         case 'f': flag |= MERGE_FORCE; break;
@@ -854,6 +885,20 @@ int bam_merge(int argc, char *argv[])
             }
             break;
         }
+        case INPUT_FMT_OPTION:
+            if (hts_opt_add(&in_opts, optarg))
+                merge_usage(stderr), ret=1;
+            break;
+
+        case OUTPUT_FMT_OPTION:
+            if (hts_opt_add(&out_opts, optarg))
+                merge_usage(stderr), ret=1;
+            break;
+
+        case 'O': fmtout = optarg; break;
+
+        default:
+            return 1;
         }
     }
     if ( argc - optind < 1 ) {
@@ -884,9 +929,19 @@ int bam_merge(int argc, char *argv[])
         merge_usage(stderr);
         return 1;
     }
-    strcpy(mode, "wb");
+    if (strcmp(argv[optind], "-") == 0 && !fmtout)
+        fmtout = "bam";
+    strcpy(mode, "w");
+    if (sam_open_mode(&mode[1], argv[optind], fmtout) < 0) {
+        if (fmtout) fprintf(stderr, "[bam_sort] can't parse output format \"%s\"\n", fmtout);
+        else fprintf(stderr, "[bam_sort] can't determine output format\n");
+        return 1;
+    }
     if (level >= 0) sprintf(strchr(mode, '\0'), "%d", level < 9? level : 9);
-    if (bam_merge_core2(is_by_qname, argv[optind], mode, fn_headers, fn_size+nargcfiles, fn, flag, reg, n_threads) < 0) ret = 1;
+    if (bam_merge_core2(is_by_qname, argv[optind], mode, fn_headers, 
+                        fn_size+nargcfiles, fn, flag, reg, n_threads,
+                        in_opts, out_opts) < 0)
+    ret = 1;
 end:
     if (fn_size > 0) {
         int i;
@@ -958,12 +1013,13 @@ typedef struct {
     int index;
 } worker_t;
 
-static void write_buffer(const char *fn, const char *mode, size_t l, bam1_p *buf, const bam_hdr_t *h, int n_threads)
+static void write_buffer(const char *fn, const char *mode, size_t l, bam1_p *buf, const bam_hdr_t *h, int n_threads, hts_opt *opts)
 {
     size_t i;
     samFile* fp;
     fp = sam_open(fn, mode);
     if (fp == NULL) return;
+    hts_opt_apply(fp, opts);
     sam_hdr_write(fp, h);
     if (n_threads > 1) hts_set_threads(fp, n_threads);
     for (i = 0; i < l; ++i)
@@ -978,7 +1034,17 @@ static void *worker(void *data)
     ks_mergesort(sort, w->buf_len, w->buf, 0);
     name = (char*)calloc(strlen(w->prefix) + 20, 1);
     sprintf(name, "%s.%.4d.bam", w->prefix, w->index);
-    write_buffer(name, "wb1", w->buf_len, w->buf, w->h, 0);
+    write_buffer(name, "wb1", w->buf_len, w->buf, w->h, 0, NULL);
+
+// Consider using CRAM temporary files if the final output is CRAM.
+// Typically it is comparable speed while being smaller.
+//    hts_opt opt[2] = {
+//        {"version=3.0", CRAM_OPT_VERSION, {"3.0"}, NULL},
+//        {"no_ref",      CRAM_OPT_NO_REF,  {1},     NULL}
+//    };
+//    opt[0].next = &opt[1];
+//    write_buffer(name, "wc1", w->buf_len, w->buf, w->h, 0, opt);
+
     free(name);
     return 0;
 }
@@ -1026,10 +1092,13 @@ static int sort_blocks(int n_files, size_t k, bam1_p *buf, const char *prefix, c
   @return 0 for successful sorting, negative on errors
 
   @discussion It may create multiple temporary subalignment files
-  and then merge them by calling bam_merge_core(). This function is
+  and then merge them by calling bam_merge_core2(). This function is
   NOT thread safe.
  */
-int bam_sort_core_ext(int is_by_qname, const char *fn, const char *prefix, const char *fnout, const char *modeout, size_t _max_mem, int n_threads)
+int bam_sort_core_ext(int is_by_qname, const char *fn, const char *prefix,
+                      const char *fnout, const char *modeout,
+                      size_t _max_mem, int n_threads,
+                      hts_opt *in_opts, hts_opt *out_opts)
 {
     int ret, i, n_files = 0;
     size_t mem, max_k, k, max_mem;
@@ -1047,6 +1116,7 @@ int bam_sort_core_ext(int is_by_qname, const char *fn, const char *prefix, const
         fprintf(stderr, "[bam_sort_core] fail to open file %s\n", fn);
         return -1;
     }
+    hts_opt_apply(fp, in_opts);
     header = sam_hdr_read(fp);
     if (is_by_qname) change_SO(header, "queryname");
     else change_SO(header, "coordinate");
@@ -1078,7 +1148,7 @@ int bam_sort_core_ext(int is_by_qname, const char *fn, const char *prefix, const
     // write the final output
     if (n_files == 0) { // a single block
         ks_mergesort(sort, k, buf, 0);
-        write_buffer(fnout, modeout, k, buf, header, n_threads);
+        write_buffer(fnout, modeout, k, buf, header, n_threads, out_opts);
     } else { // then merge
         char **fns;
         n_files = sort_blocks(n_files, k, buf, prefix, header, n_threads);
@@ -1088,7 +1158,9 @@ int bam_sort_core_ext(int is_by_qname, const char *fn, const char *prefix, const
             fns[i] = (char*)calloc(strlen(prefix) + 20, 1);
             sprintf(fns[i], "%s.%.4d.bam", prefix, i);
         }
-        if (bam_merge_core2(is_by_qname, fnout, modeout, NULL, n_files, fns, MERGE_COMBINE_RG|MERGE_COMBINE_PG, NULL, n_threads) < 0) {
+        if (bam_merge_core2(is_by_qname, fnout, modeout, NULL, n_files, fns,
+                            MERGE_COMBINE_RG|MERGE_COMBINE_PG, NULL, n_threads,
+                            in_opts, out_opts) < 0) {
             // Propagate bam_merge_core2() failure; it has already emitted a
             // message explaining the failure, so no further message is needed.
             return -1;
@@ -1107,16 +1179,6 @@ int bam_sort_core_ext(int is_by_qname, const char *fn, const char *prefix, const
     return 0;
 }
 
-int bam_sort_core(int is_by_qname, const char *fn, const char *prefix, size_t max_mem)
-{
-    int ret;
-    char *fnout = calloc(strlen(prefix) + 4 + 1, 1);
-    sprintf(fnout, "%s.bam", prefix);
-    ret = bam_sort_core_ext(is_by_qname, fn, prefix, fnout, "wb", max_mem, 0);
-    free(fnout);
-    return ret;
-}
-
 static int sort_usage(FILE *fp, int status)
 {
     fprintf(fp,
@@ -1129,6 +1191,11 @@ static int sort_usage(FILE *fp, int status)
 "  -O FORMAT  Write output as FORMAT ('sam'/'bam'/'cram')   (either -O or\n"
 "  -T PREFIX  Write temporary files to PREFIX.nnnn.bam       -T is required)\n"
 "  -@ INT     Set number of sorting and compression threads [1]\n"
+"  -O FORMAT, --output-fmt FORMAT\n"
+"             Write output as FORMAT ('sam'/'bam'/'cram'\n"
+"  --input-fmt-option  OPTION=VALUE\n"
+"  --output-fmt-option OPTION=VALUE\n"
+"             Control the input or output format via OPTION or OPTION=VALUE\n"
 "\n"
 "Legacy usage: samtools sort [options...] <in.bam> <out.prefix>\n"
 "Options:\n"
@@ -1144,17 +1211,38 @@ int bam_sort(int argc, char *argv[])
     int c, i, modern, nargs, is_by_qname = 0, is_stdout = 0, ret = EXIT_SUCCESS, n_threads = 0, level = -1, full_path = 0;
     char *fnout = "-", *fmtout = NULL, modeout[12], *tmpprefix = NULL;
     kstring_t fnout_buffer = { 0, 0, NULL };
+    hts_opt *in_opts = NULL, *out_opts = NULL;
 
     modern = 0;
     for (i = 1; i < argc; ++i)
         if (argv[i][0] == '-' && strpbrk(argv[i], "OT")) { modern = 1; break; }
 
-    while ((c = getopt(argc, argv, modern? "l:m:no:O:T:@:" : "fnom:@:l:")) >= 0) {
-        switch (c) {
-        case 'f': full_path = 1; break;
-        case 'o': if (modern) fnout = optarg; else is_stdout = 1; break;
-        case 'n': is_by_qname = 1; break;
-        case 'm': {
+    if (modern) {
+        enum {
+            INPUT_FMT_OPTION = CHAR_MAX+1,
+            OUTPUT_FMT_OPTION,
+        };
+
+        static const struct option lopts[] =
+            {
+                {"input-fmt-option",  required_argument, NULL, INPUT_FMT_OPTION}, 
+                {"output-fmt-option", required_argument, NULL, OUTPUT_FMT_OPTION}, 
+                {"", required_argument, NULL, 'l'}, 
+                {"", required_argument, NULL, 'm'}, 
+                {"", no_argument,       NULL, 'n'}, 
+                {"", required_argument, NULL, 'o'}, 
+                {"output-fmt", required_argument, NULL, 'O'}, 
+                {"", required_argument, NULL, 'T'}, 
+                {"", required_argument, NULL, '@'}, 
+                {NULL, 0, NULL, 0}
+            };
+
+        while ((c = getopt_long(argc, argv, "l:m:no:O:T:@:", lopts, NULL)) >= 0) {
+            switch (c) {
+            case 'f': full_path = 1; break;
+            case 'o': if (modern) fnout = optarg; else is_stdout = 1; break;
+            case 'n': is_by_qname = 1; break;
+            case 'm': {
                 char *q;
                 max_mem = strtol(optarg, &q, 0);
                 if (*q == 'k' || *q == 'K') max_mem <<= 10;
@@ -1162,11 +1250,43 @@ int bam_sort(int argc, char *argv[])
                 else if (*q == 'g' || *q == 'G') max_mem <<= 30;
                 break;
             }
-        case 'O': fmtout = optarg; break;
-        case 'T': tmpprefix = optarg; break;
-        case '@': n_threads = atoi(optarg); break;
-        case 'l': level = atoi(optarg); break;
-        default: return sort_usage(stderr, EXIT_FAILURE);
+            case 'O': fmtout = optarg; break;
+            case 'T': tmpprefix = optarg; break;
+            case '@': n_threads = atoi(optarg); break;
+            case 'l': level = atoi(optarg); break;
+
+            case INPUT_FMT_OPTION:
+                if (hts_opt_add(&in_opts, optarg))
+                    return sort_usage(stderr, EXIT_FAILURE);
+                break;
+
+            case OUTPUT_FMT_OPTION:
+                if (hts_opt_add(&out_opts, optarg))
+                    return sort_usage(stderr, EXIT_FAILURE);
+                break;
+
+
+            default: return sort_usage(stderr, EXIT_FAILURE);
+            }
+        }
+    } else {
+        while ((c = getopt(argc, argv, "fnom:@:l:")) >= 0) {
+            switch (c) {
+            case 'f': full_path = 1; break;
+            case 'o': if (modern) fnout = optarg; else is_stdout = 1; break;
+            case 'n': is_by_qname = 1; break;
+            case 'm': {
+                char *q;
+                max_mem = strtol(optarg, &q, 0);
+                if (*q == 'k' || *q == 'K') max_mem <<= 10;
+                else if (*q == 'm' || *q == 'M') max_mem <<= 20;
+                else if (*q == 'g' || *q == 'G') max_mem <<= 30;
+                break;
+            }
+            case '@': n_threads = atoi(optarg); break;
+            case 'l': level = atoi(optarg); break;
+            default: return sort_usage(stderr, EXIT_FAILURE);
+            }
         }
     }
 
@@ -1202,9 +1322,15 @@ int bam_sort(int argc, char *argv[])
         goto sort_end;
     }
 
-    if (bam_sort_core_ext(is_by_qname, (nargs > 0)? argv[optind] : "-", tmpprefix, fnout, modeout, max_mem, n_threads) < 0) ret = EXIT_FAILURE;
+    if (bam_sort_core_ext(is_by_qname, (nargs > 0)? argv[optind] : "-",
+                          tmpprefix, fnout, modeout, max_mem, n_threads,
+                          in_opts, out_opts) < 0)
+        ret = EXIT_FAILURE;
 
 sort_end:
     free(fnout_buffer.s);
+    hts_opt_free(in_opts);
+    hts_opt_free(out_opts);
+
     return ret;
 }

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -817,8 +817,10 @@ int bam_merge(int argc, char *argv[])
     int fn_size = 0;
 
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
-    static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
-    assign_short_opts(lopts, "-.O..");
+    static const struct option lopts[] = {
+        SAM_OPT_GLOBAL_OPTIONS('-', 0, 'O', 0, 0),
+        { NULL, 0, NULL, 0 }
+    };
 
     if (argc == 1) {
         merge_usage(stdout);
@@ -1166,8 +1168,10 @@ int bam_sort(int argc, char *argv[])
         if (argv[i][0] == '-' && strpbrk(argv[i], "OT")) { modern = 1; break; }
 
     if (modern) {
-        static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
-        assign_short_opts(lopts, "-.O..");
+        static const struct option lopts[] = {
+            SAM_OPT_GLOBAL_OPTIONS('-', 0, 'O', 0, 0),
+            { NULL, 0, NULL, 0 }
+        };
 
         while ((c = getopt_long(argc, argv, "l:m:no:O:T:@:", lopts, NULL)) >= 0) {
             switch (c) {

--- a/bam_split.c
+++ b/bam_split.c
@@ -96,8 +96,10 @@ static parsed_opts_t* parse_args(int argc, char** argv)
     const char* optstring = "vf:u:";
     char* delim;
 
-    static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
-    assign_short_opts(lopts, "-....");
+    static const struct option lopts[] = {
+        SAM_OPT_GLOBAL_OPTIONS('-', 0, 0, 0, 0),
+        { NULL, 0, NULL, 0 }
+    };
 
     parsed_opts_t* retval = calloc(sizeof(parsed_opts_t), 1);
     if (! retval ) { perror("cannot allocate option parsing memory"); return NULL; }

--- a/bam_split.c
+++ b/bam_split.c
@@ -509,7 +509,7 @@ static int cleanup_state(state_t* status)
 {
     int ret = 0;
 
-    if (!status) return;
+    if (!status) return 0;
     if (status->unaccounted_header) bam_hdr_destroy(status->unaccounted_header);
     if (status->unaccounted_file) ret |= sam_close(status->unaccounted_file);
     sam_close(status->merged_input_file);

--- a/bam_tview.c
+++ b/bam_tview.c
@@ -29,6 +29,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <htslib/faidx.h>
 #include <htslib/sam.h>
 #include <htslib/bgzf.h>
+#include "sam_opts.h"
 
 khash_t(kh_rg)* get_rg_sample(const char* header, const char* sample)
 {
@@ -53,7 +54,8 @@ khash_t(kh_rg)* get_rg_sample(const char* header, const char* sample)
     return rg_hash;
 }
 
-int base_tv_init(tview_t* tv, const char *fn, const char *fn_fa, const char *samples)
+int base_tv_init(tview_t* tv, const char *fn, const char *fn_fa,
+                 const char *samples, htsFormat *fmt)
 {
     assert(tv!=NULL);
     assert(fn!=NULL);
@@ -61,7 +63,7 @@ int base_tv_init(tview_t* tv, const char *fn, const char *fn_fa, const char *sam
     tv->color_for = TV_COLOR_MAPQ;
     tv->is_dot = 1;
 
-    tv->fp = sam_open(fn, "r");
+    tv->fp = sam_open_format(fn, "r", fmt);
     if(tv->fp == NULL)
     {
         fprintf(stderr,"sam_open %s. %s\n", fn,fn_fa);
@@ -340,9 +342,12 @@ static void error(const char *format, ...)
 }
 
 enum dipsay_mode {display_ncurses,display_html,display_text};
-extern tview_t* curses_tv_init(const char *fn, const char *fn_fa, const char *samples);
-extern tview_t* html_tv_init(const char *fn, const char *fn_fa, const char *samples);
-extern tview_t* text_tv_init(const char *fn, const char *fn_fa, const char *samples);
+extern tview_t* curses_tv_init(const char *fn, const char *fn_fa,
+                               const char *samples, const htsFormat *fmt);
+extern tview_t* html_tv_init(const char *fn, const char *fn_fa,
+                             const char *samples, const htsFormat *fmt);
+extern tview_t* text_tv_init(const char *fn, const char *fn_fa,
+                             const char *samples, const htsFormat *fmt);
 
 int bam_tview_main(int argc, char *argv[])
 {
@@ -350,7 +355,12 @@ int bam_tview_main(int argc, char *argv[])
     tview_t* tv=NULL;
     char *samples=NULL, *position=NULL;
     int c;
-    while ((c = getopt(argc, argv, "s:p:d:")) >= 0) {
+
+    sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
+    static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
+    assign_short_opts(lopts, "-.---");
+
+    while ((c = getopt_long(argc, argv, "s:p:d:", lopts, NULL)) >= 0) {
         switch (c) {
             case 's': samples=optarg; break;
             case 'p': position=optarg; break;
@@ -365,28 +375,32 @@ int bam_tview_main(int argc, char *argv[])
                 }
                 break;
             }
-            default: error(NULL);
+            default: if (parse_sam_global_opt(c, optarg, lopts, &ga) == 0) break;
+            case '?': error(NULL);
         }
     }
     if (argc==optind) error(NULL);
 
     switch(view_mode)
     {
-        case display_ncurses:
-            {
-            tv = curses_tv_init(argv[optind], (optind+1>=argc)? 0 : argv[optind+1], samples);
+        case display_ncurses: {
+            tv = curses_tv_init(argv[optind],
+                                (optind+1>=argc)? 0 : argv[optind+1],
+                                samples, &ga.in);
             break;
-            }
-        case display_text:
-            {
-            tv = text_tv_init(argv[optind], (optind+1>=argc)? 0 : argv[optind+1], samples);
+        }
+        case display_text: {
+            tv = text_tv_init(argv[optind],
+                              (optind+1>=argc)? 0 : argv[optind+1],
+                              samples, &ga.in);
             break;
-            }
-        case display_html:
-            {
-            tv = html_tv_init(argv[optind], (optind+1>=argc)? 0 : argv[optind+1], samples);
+        }
+        case display_html: {
+            tv = html_tv_init(argv[optind],
+                              (optind+1>=argc)? 0 : argv[optind+1],
+                              samples, &ga.in);
             break;
-            }
+        }
     }
     if (tv==NULL)
     {

--- a/bam_tview.c
+++ b/bam_tview.c
@@ -357,8 +357,10 @@ int bam_tview_main(int argc, char *argv[])
     int c;
 
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
-    static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
-    assign_short_opts(lopts, "-.--.");
+    static const struct option lopts[] = {
+        SAM_OPT_GLOBAL_OPTIONS('-', 0, '-', '-', 0),
+        { NULL, 0, NULL, 0 }
+    };
 
     while ((c = getopt_long(argc, argv, "s:p:d:", lopts, NULL)) >= 0) {
         switch (c) {

--- a/bam_tview.c
+++ b/bam_tview.c
@@ -358,7 +358,7 @@ int bam_tview_main(int argc, char *argv[])
 
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
     static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
-    assign_short_opts(lopts, "-.---");
+    assign_short_opts(lopts, "-.--.");
 
     while ((c = getopt_long(argc, argv, "s:p:d:", lopts, NULL)) >= 0) {
         switch (c) {

--- a/bam_tview.h
+++ b/bam_tview.h
@@ -89,7 +89,8 @@ char bam_aux_getCQi(bam1_t *b, int i);
 #define TV_BASE_COLOR_SPACE 1
 
 int tv_pl_func(uint32_t tid, uint32_t pos, int n, const bam_pileup1_t *pl, void *data);
-int base_tv_init(tview_t*,const char *fn, const char *fn_fa, const char *samples);
+int base_tv_init(tview_t*,const char *fn, const char *fn_fa,
+                 const char *samples, htsFormat *fmt);
 void base_tv_destroy(tview_t*);
 int base_draw_aln(tview_t *tv, int tid, int pos);
 

--- a/bam_tview_curses.c
+++ b/bam_tview_curses.c
@@ -275,7 +275,8 @@ end_loop:
 
 
 
-tview_t* curses_tv_init(const char *fn, const char *fn_fa, const char *samples)
+tview_t* curses_tv_init(const char *fn, const char *fn_fa, const char *samples,
+                        htsFormat *fmt)
     {
     curses_tview_t *tv = (curses_tview_t*)calloc(1, sizeof(curses_tview_t));
     tview_t* base=(tview_t*)tv;
@@ -285,7 +286,7 @@ tview_t* curses_tv_init(const char *fn, const char *fn_fa, const char *samples)
         return 0;
         }
 
-    base_tv_init(base,fn,fn_fa,samples);
+    base_tv_init(base,fn,fn_fa,samples,fmt);
     /* initialize callbacks */
 #define SET_CALLBACK(fun) base->my_##fun=curses_##fun;
     SET_CALLBACK(destroy);
@@ -328,11 +329,13 @@ tview_t* curses_tv_init(const char *fn, const char *fn_fa, const char *samples)
 #include <stdio.h>
 #warning "No curses library is available; tview with curses is disabled."
 
-extern tview_t* text_tv_init(const char *fn, const char *fn_fa, const char *samples);
+extern tview_t* text_tv_init(const char *fn, const char *fn_fa, const char *samples,
+                             htsFormat *fmt);
 
-tview_t* curses_tv_init(const char *fn, const char *fn_fa, const char *samples)
+tview_t* curses_tv_init(const char *fn, const char *fn_fa, const char *samples,
+                        htsFormat *fmt)
     {
-    return text_tv_init(fn,fn_fa,samples);
+    return text_tv_init(fn,fn_fa,samples,fmt);
     }
 #endif // #ifdef _HAVE_CURSES
 

--- a/bam_tview_html.c
+++ b/bam_tview_html.c
@@ -312,7 +312,8 @@ static void init_pair(html_tview_t *tv,int id_ge_1, const char* pen, const char*
     }
 */
 
-tview_t* html_tv_init(const char *fn, const char *fn_fa, const char *samples)
+tview_t* html_tv_init(const char *fn, const char *fn_fa, const char *samples,
+                      htsFormat *fmt)
     {
     char* colstr=getenv("COLUMNS");
     html_tview_t *tv = (html_tview_t*)calloc(1, sizeof(html_tview_t));
@@ -326,7 +327,7 @@ tview_t* html_tv_init(const char *fn, const char *fn_fa, const char *samples)
     tv->screen=NULL;
     tv->out=stdout;
     tv->attributes=0;
-    base_tv_init(base,fn,fn_fa,samples);
+    base_tv_init(base,fn,fn_fa,samples,fmt);
     /* initialize callbacks */
 #define SET_CALLBACK(fun) base->my_##fun=html_##fun;
     SET_CALLBACK(destroy);
@@ -364,9 +365,10 @@ tview_t* html_tv_init(const char *fn, const char *fn_fa, const char *samples)
     }
 
 
-tview_t* text_tv_init(const char *fn, const char *fn_fa, const char *samples)
+tview_t* text_tv_init(const char *fn, const char *fn_fa, const char *samples,
+                      htsFormat *fmt)
     {
-    tview_t* tv=html_tv_init(fn,fn_fa,samples);
+    tview_t* tv=html_tv_init(fn,fn_fa,samples,fmt);
     tv->my_drawaln=text_drawaln;
     return tv;
     }

--- a/bamshuf.c
+++ b/bamshuf.c
@@ -99,8 +99,8 @@ static int bamshuf(const char *fn, int n_files, const char *pre, int clevel,
 
     for (i = 0; i < n_files; ++i) {
         fnt[i] = (char*)calloc(l + 10, 1);
-        sprintf(fnt[i], "%s.%.4d.%s", pre, i, hts_format_file_extension(&ga->out));
-        fpt[i] = sam_open_format(fnt[i], "wb1", &ga->out);
+        sprintf(fnt[i], "%s.%.4d.bam", pre, i);
+        fpt[i] = sam_open(fnt[i], "wb1");
         if (fpt[i] == NULL) {
             print_error_errno("Cannot open intermediate file \"%s\"", fnt[i]);
             return 1;
@@ -123,7 +123,7 @@ static int bamshuf(const char *fn, int n_files, const char *pre, int clevel,
     sprintf(modew, "wb%d", (clevel >= 0 && clevel <= 9)? clevel : DEF_CLEVEL);
     if (!is_stdout) { // output to a file
         char *fnw = (char*)calloc(l + 5, 1);
-        sprintf(fnw, "%s.bam", pre);
+        sprintf(fnw, "%s.%s", pre,  hts_format_file_extension(&ga->out));
         fpw = sam_open_format(fnw, modew, &ga->out);
         free(fnw);
     } else fpw = sam_open_format("-", modew, &ga->out); // output to stdout

--- a/bamshuf.c
+++ b/bamshuf.c
@@ -123,7 +123,10 @@ static int bamshuf(const char *fn, int n_files, const char *pre, int clevel,
     sprintf(modew, "wb%d", (clevel >= 0 && clevel <= 9)? clevel : DEF_CLEVEL);
     if (!is_stdout) { // output to a file
         char *fnw = (char*)calloc(l + 5, 1);
-        sprintf(fnw, "%s.%s", pre,  hts_format_file_extension(&ga->out));
+        if (ga->out.format == unknown_format)
+            sprintf(fnw, "%s.bam", pre); // "wb" above makes BAM the default
+        else
+            sprintf(fnw, "%s.%s", pre,  hts_format_file_extension(&ga->out));
         fpw = sam_open_format(fnw, modew, &ga->out);
         free(fnw);
     } else fpw = sam_open_format("-", modew, &ga->out); // output to stdout
@@ -173,7 +176,7 @@ static int usage(FILE *fp, int n_files) {
             "      -n INT   number of temporary files [%d]\n", // n_files
             DEF_CLEVEL, n_files);
 
-    sam_global_opt_help(fp, "-...-");
+    sam_global_opt_help(fp, "-....");
 
     return 1;
 }
@@ -183,7 +186,7 @@ int main_bamshuf(int argc, char *argv[])
     int c, n_files = 64, clevel = DEF_CLEVEL, is_stdout = 0, is_un = 0;
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
     static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
-    assign_short_opts(lopts, "-...-");
+    assign_short_opts(lopts, "-....");
 
     while ((c = getopt_long(argc, argv, "n:l:uO", lopts, NULL)) >= 0) {
         switch (c) {

--- a/bamshuf.c
+++ b/bamshuf.c
@@ -185,8 +185,10 @@ int main_bamshuf(int argc, char *argv[])
 {
     int c, n_files = 64, clevel = DEF_CLEVEL, is_stdout = 0, is_un = 0;
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
-    static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
-    assign_short_opts(lopts, "-....");
+    static const struct option lopts[] = {
+        SAM_OPT_GLOBAL_OPTIONS('-', 0, 0, 0, 0),
+        { NULL, 0, NULL, 0 }
+    };
 
     while ((c = getopt_long(argc, argv, "n:l:uO", lopts, NULL)) >= 0) {
         switch (c) {

--- a/bedcov.c
+++ b/bedcov.c
@@ -71,8 +71,10 @@ int main_bedcov(int argc, char *argv[])
     int usage = 0;
 
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
-    static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
-    assign_short_opts(lopts, "-.--.");
+    static const struct option lopts[] = {
+        SAM_OPT_GLOBAL_OPTIONS('-', 0, '-', '-', 0),
+        { NULL, 0, NULL, 0 }
+    };
 
     while ((c = getopt_long(argc, argv, "Q:", lopts, NULL)) >= 0) {
         switch (c) {

--- a/bedcov.c
+++ b/bedcov.c
@@ -83,7 +83,7 @@ int main_bedcov(int argc, char *argv[])
         if (usage) break;
     }
     if (optind + 2 > argc) {
-        fprintf(stderr, "Usage: samtools [options] bedcov <in.bed> <in1.bam> [...]\n\n");
+        fprintf(stderr, "Usage: samtools bedcov [options] <in.bed> <in1.bam> [...]\n\n");
         fprintf(stderr, "  -Q INT       Only count bases of at least INT quality [0]\n");
         sam_global_opt_help(stderr, "-.---");
         return 1;

--- a/bedcov.c
+++ b/bedcov.c
@@ -31,6 +31,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <unistd.h>
 #include "htslib/kstring.h"
 #include "htslib/sam.h"
+#include "sam_opts.h"
 
 #include "htslib/kseq.h"
 KSTREAM_INIT(gzFile, gzread, 16384)
@@ -67,14 +68,24 @@ int main_bedcov(int argc, char *argv[])
     int *n_plp, dret, i, n, c, min_mapQ = 0;
     int64_t *cnt;
     const bam_pileup1_t **plp;
+    int usage = 0;
 
-    while ((c = getopt(argc, argv, "Q:")) >= 0) {
+    sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
+    static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
+    assign_short_opts(lopts, "-.---");
+
+    while ((c = getopt_long(argc, argv, "Q:", lopts, NULL)) >= 0) {
         switch (c) {
         case 'Q': min_mapQ = atoi(optarg); break;
+        default: if (parse_sam_global_opt(c, optarg, lopts, &ga) == 0) break;
+        case '?': usage = 1; break;
         }
+        if (usage) break;
     }
     if (optind + 2 > argc) {
-        fprintf(stderr, "Usage: samtools bedcov <in.bed> <in1.bam> [...]\n");
+        fprintf(stderr, "Usage: samtools [options] bedcov <in.bed> <in1.bam> [...]\n\n");
+        fprintf(stderr, "  -Q INT       Only count bases of at least INT quality [0]\n");
+        sam_global_opt_help(stderr, "-.---");
         return 1;
     }
     memset(&str, 0, sizeof(kstring_t));
@@ -84,8 +95,9 @@ int main_bedcov(int argc, char *argv[])
     for (i = 0; i < n; ++i) {
         aux[i] = calloc(1, sizeof(aux_t));
         aux[i]->min_mapQ = min_mapQ;
-        aux[i]->fp = sam_open(argv[i+optind+1], "r");
-        idx[i] = sam_index_load(aux[i]->fp, argv[i+optind+1]);
+        aux[i]->fp = sam_open_format(argv[i+optind+1], "r", &ga.in);
+        if (aux[i]->fp)
+            idx[i] = sam_index_load(aux[i]->fp, argv[i+optind+1]);
         if (aux[i]->fp == 0 || idx[i] == 0) {
             fprintf(stderr, "ERROR: fail to open index BAM file '%s'\n", argv[i+optind+1]);
             return 2;
@@ -152,5 +164,6 @@ bed_error:
     }
     free(aux); free(idx);
     free(str.s);
+    sam_global_args_free(&ga);
     return 0;
 }

--- a/bedcov.c
+++ b/bedcov.c
@@ -72,7 +72,7 @@ int main_bedcov(int argc, char *argv[])
 
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
     static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
-    assign_short_opts(lopts, "-.---");
+    assign_short_opts(lopts, "-.--.");
 
     while ((c = getopt_long(argc, argv, "Q:", lopts, NULL)) >= 0) {
         switch (c) {
@@ -85,7 +85,7 @@ int main_bedcov(int argc, char *argv[])
     if (optind + 2 > argc) {
         fprintf(stderr, "Usage: samtools bedcov [options] <in.bed> <in1.bam> [...]\n\n");
         fprintf(stderr, "  -Q INT       Only count bases of at least INT quality [0]\n");
-        sam_global_opt_help(stderr, "-.---");
+        sam_global_opt_help(stderr, "-.--.");
         return 1;
     }
     memset(&str, 0, sizeof(kstring_t));

--- a/cut_target.c
+++ b/cut_target.c
@@ -173,8 +173,10 @@ int main_cut_target(int argc, char *argv[])
     ct_t g;
 
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
-    static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
-    assign_short_opts(lopts, "-.--.");
+    static const struct option lopts[] = {
+        SAM_OPT_GLOBAL_OPTIONS('-', 0, '-', '-', 0),
+        { NULL, 0, NULL, 0 }
+    };
 
     memset(&g, 0, sizeof(ct_t));
     g.min_baseQ = 13; g.tid = -1;

--- a/phase.c
+++ b/phase.c
@@ -550,8 +550,10 @@ int main_phase(int argc, char *argv[])
     uint16_t *bases;
 
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
-    static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
-    assign_short_opts(lopts, "-....");
+    static const struct option lopts[] = {
+        SAM_OPT_GLOBAL_OPTIONS('-', 0, 0, 0, 0),
+        { NULL, 0, NULL, 0 }
+    };
 
     memset(&g, 0, sizeof(phaseg_t));
     g.flag = FLAG_FIX_CHIMERA;

--- a/sam_opts.c
+++ b/sam_opts.c
@@ -78,16 +78,16 @@ int parse_sam_global_opt(int c, char *optarg, struct option *lopt,
 	}
 
 	if (strcmp(lopt->name, "input-fmt") == 0) {
-	    r = hts_parse_opt_format(&ga->in, optarg);
+	    r = hts_parse_format(&ga->in, optarg);
 	    break;
 	} else if (strcmp(lopt->name, "input-fmt-option") == 0) {
-	    r = hts_opt_add(&ga->in.opts, optarg);
+	    r = hts_opt_add(ga->in.specific, optarg);
 	    break;
 	} else if (strcmp(lopt->name, "output-fmt") == 0) {
-	    r = hts_parse_opt_format(&ga->out, optarg);
+	    r = hts_parse_format(&ga->out, optarg);
 	    break;
 	} else if (strcmp(lopt->name, "output-fmt-option") == 0) {
-	    r = hts_opt_add(&ga->out.opts, optarg);
+	    r = hts_opt_add(ga->out.specific, optarg);
 	    break;
 	} else if (strcmp(lopt->name, "verbose") == 0) {
 	    ga->verbosity++;
@@ -152,9 +152,9 @@ void sam_global_args_init(sam_global_args *ga) {
 }
 
 void sam_global_args_free(sam_global_args *ga) {
-    if (ga->in.opts)
-	hts_opt_free(ga->in.opts);
+    if (ga->in.specific)
+	hts_opt_free(ga->in.specific);
 
-    if (ga->out.opts)
-	hts_opt_free(ga->out.opts);
+    if (ga->out.specific)
+	hts_opt_free(ga->out.specific);
 }

--- a/sam_opts.c
+++ b/sam_opts.c
@@ -1,0 +1,160 @@
+/*  sam_opts.c -- utilities to aid parsing common command line options.
+
+    Copyright (C) 2015 Genome Research Ltd.
+
+    Author: James Bonfield <jkb@sanger.ac.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.  */
+
+#include <stdio.h>
+#include <string.h>
+#include "sam_opts.h"
+
+/*
+ * Assign a short option to each of the long options listed above.
+ *
+ * There should be one character per option. This will be one of:
+ * '.'    No short option has been assigned. Use --long-opt only.
+ * '-'    The long (and short) option has been disabled.
+ * <c>    Otherwise the short option is character <c>.
+ *
+ * Consider using varargs to supply a map, or some better tokenised
+ * string that allows things out of order.  It's all internal to 
+ * samtools though so we can change later without breaking the public
+ * API.
+ */
+void assign_short_opts(struct option lopts[], const char *shortopts) {
+    int i, j;
+    
+    // Assign sub-command specific short option codes
+    for (i=j=0; shortopts && shortopts[i]; i++,j++) {
+	lopts[j] = lopts[i];
+
+	if (shortopts[i] == '-')
+	    j--; // skip this option.
+	else if (shortopts[i] != '.')
+	    lopts[j].val = shortopts[i];
+    }
+    lopts[j] = lopts[i];
+}
+
+/*
+ * Processes a standard "global" samtools long option.
+ *
+ * The 'c' value is the return value from a getopt_long() call.  It is checked
+ * against the lopt[] array to find the corresponding value as this may have
+ * been reassigned by the individual subcommand.
+ *
+ * Having found the entry, the corresponding long form is used to apply the
+ * option, storing the setting in sam_global_args *ga.
+ *
+ * Returns 0 on success,
+ *        -1 on failure.
+ */
+int parse_sam_global_opt(int c, char *optarg, struct option *lopt, 
+			 sam_global_args *ga) {
+    int r = 0;
+
+    while (lopt->name) {
+	if (c != lopt->val) {
+	    lopt++;
+	    continue;
+	}
+
+	if (strcmp(lopt->name, "input-fmt") == 0) {
+	    r = hts_parse_opt_format(&ga->in, optarg);
+	    break;
+	} else if (strcmp(lopt->name, "input-fmt-option") == 0) {
+	    r = hts_opt_add(&ga->in.opts, optarg);
+	    break;
+	} else if (strcmp(lopt->name, "output-fmt") == 0) {
+	    r = hts_parse_opt_format(&ga->out, optarg);
+	    break;
+	} else if (strcmp(lopt->name, "output-fmt-option") == 0) {
+	    r = hts_opt_add(&ga->out.opts, optarg);
+	    break;
+	} else if (strcmp(lopt->name, "verbose") == 0) {
+	    ga->verbosity++;
+	    break;
+	}
+    }
+
+    if (!lopt->name) {
+	fprintf(stderr, "Unexpected global option: %s\n", lopt->name);
+	return -1;
+    }
+
+    return r;
+}
+
+/*
+ * Report the usage for global options.
+ *
+ * This accepts the same shortopts string as used by assign_short_opts()
+ * to determine which options need to be printed and how.
+ */
+void sam_global_opt_help(FILE *fp, char *shortopts) {
+    int i = 0;
+
+    struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
+    int nopts = sizeof(lopts)/sizeof(*lopts);
+
+    for (i = 0; shortopts && shortopts[i] && i < nopts; i++) {
+	if (shortopts[i] == '-')
+	    continue;
+
+	if (shortopts[i] == '.')
+	    fprintf(fp, "      --");
+	else
+	    fprintf(fp, "  -%c, --", shortopts[i]);
+
+	if (strcmp(lopts[i].name, "input-fmt") == 0)
+	    fprintf(fp,"input-fmt FORMAT[,OPT[=VAL]]...\n"
+		    "               Specify input format (SAM, BAM, CRAM)\n");
+	else if (strcmp(lopts[i].name, "input-fmt-option") == 0)
+	    fprintf(fp,"input-fmt-option OPT[=VAL]\n"
+		    "               Specify a single input file format option in the form\n"
+		    "               of OPTION or OPTION=VALUE\n");
+	else if (strcmp(lopts[i].name, "output-fmt") == 0)
+	    fprintf(fp,"output-fmt FORMAT[,OPT[=VAL]]...\n"
+		    "               Specify output format (SAM, BAM, CRAM)\n");
+	else if (strcmp(lopts[i].name, "output-fmt-option") == 0)
+	    fprintf(fp,"output-fmt-option OPT[=VAL]\n"
+		    "               Specify a single output file format option in the form\n"
+		    "               of OPTION or OPTION=VALUE\n");
+	else if (strcmp(lopts[i].name, "verbose") == 0)
+	    fprintf(fp,"verbose\n"
+		    "               Increment level of verbosity\n");
+    }
+}
+
+void sam_global_args_init(sam_global_args *ga) {
+    if (!ga)
+	return;
+    
+    memset(ga, 0, sizeof(*ga));
+}
+
+void sam_global_args_free(sam_global_args *ga) {
+    if (ga->in.opts)
+	hts_opt_free(ga->in.opts);
+
+    if (ga->out.opts)
+	hts_opt_free(ga->out.opts);
+}

--- a/sam_opts.c
+++ b/sam_opts.c
@@ -23,6 +23,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "sam_opts.h"
 
@@ -89,9 +90,17 @@ int parse_sam_global_opt(int c, char *optarg, struct option *lopt,
 	} else if (strcmp(lopt->name, "output-fmt-option") == 0) {
 	    r = hts_opt_add((hts_opt **)&ga->out.specific, optarg);
 	    break;
-	} else if (strcmp(lopt->name, "verbose") == 0) {
-	    ga->verbosity++;
+	} else if (strcmp(lopt->name, "reference") == 0) {
+	    char ref[8192];
+	    ref[8191] = 0;
+	    snprintf(ref, 8191, "reference=%s", optarg);
+	    ga->reference = strdup(optarg);
+	    r  = hts_opt_add((hts_opt **)&ga->in.specific, ref);
+	    r |= hts_opt_add((hts_opt **)&ga->out.specific, ref);
 	    break;
+//	} else if (strcmp(lopt->name, "verbose") == 0) {
+//	    ga->verbosity++;
+//	    break;
 	}
     }
 
@@ -138,9 +147,12 @@ void sam_global_opt_help(FILE *fp, char *shortopts) {
 	    fprintf(fp,"output-fmt-option OPT[=VAL]\n"
 		    "               Specify a single output file format option in the form\n"
 		    "               of OPTION or OPTION=VALUE\n");
-	else if (strcmp(lopts[i].name, "verbose") == 0)
-	    fprintf(fp,"verbose\n"
-		    "               Increment level of verbosity\n");
+	else if (strcmp(lopts[i].name, "reference") == 0)
+	    fprintf(fp,"reference FILE\n"
+		    "               Reference sequence FASTA FILE [null]\n");
+//	else if (strcmp(lopts[i].name, "verbose") == 0)
+//	    fprintf(fp,"verbose\n"
+//		    "               Increment level of verbosity\n");
     }
 }
 
@@ -157,4 +169,7 @@ void sam_global_args_free(sam_global_args *ga) {
 
     if (ga->out.specific)
 	hts_opt_free(ga->out.specific);
+
+    if (ga->reference)
+	free(ga->reference);
 }

--- a/sam_opts.c
+++ b/sam_opts.c
@@ -68,7 +68,7 @@ void assign_short_opts(struct option lopts[], const char *shortopts) {
  * Returns 0 on success,
  *        -1 on failure.
  */
-int parse_sam_global_opt(int c, char *optarg, struct option *lopt, 
+int parse_sam_global_opt(int c, const char *optarg, const struct option *lopt,
 			 sam_global_args *ga) {
     int r = 0;
 
@@ -91,12 +91,12 @@ int parse_sam_global_opt(int c, char *optarg, struct option *lopt,
 	    r = hts_opt_add((hts_opt **)&ga->out.specific, optarg);
 	    break;
 	} else if (strcmp(lopt->name, "reference") == 0) {
-	    char ref[8192];
-	    ref[8191] = 0;
-	    snprintf(ref, 8191, "reference=%s", optarg);
+	    char *ref = malloc(10 + strlen(optarg) + 1);
+	    sprintf(ref, "reference=%s", optarg);
 	    ga->reference = strdup(optarg);
 	    r  = hts_opt_add((hts_opt **)&ga->in.specific, ref);
 	    r |= hts_opt_add((hts_opt **)&ga->out.specific, ref);
+	    free(ref);
 	    break;
 //	} else if (strcmp(lopt->name, "verbose") == 0) {
 //	    ga->verbosity++;
@@ -118,7 +118,7 @@ int parse_sam_global_opt(int c, char *optarg, struct option *lopt,
  * This accepts the same shortopts string as used by assign_short_opts()
  * to determine which options need to be printed and how.
  */
-void sam_global_opt_help(FILE *fp, char *shortopts) {
+void sam_global_opt_help(FILE *fp, const char *shortopts) {
     int i = 0;
 
     struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;

--- a/sam_opts.c
+++ b/sam_opts.c
@@ -81,13 +81,13 @@ int parse_sam_global_opt(int c, char *optarg, struct option *lopt,
 	    r = hts_parse_format(&ga->in, optarg);
 	    break;
 	} else if (strcmp(lopt->name, "input-fmt-option") == 0) {
-	    r = hts_opt_add(ga->in.specific, optarg);
+	    r = hts_opt_add((hts_opt **)&ga->in.specific, optarg);
 	    break;
 	} else if (strcmp(lopt->name, "output-fmt") == 0) {
 	    r = hts_parse_format(&ga->out, optarg);
 	    break;
 	} else if (strcmp(lopt->name, "output-fmt-option") == 0) {
-	    r = hts_opt_add(ga->out.specific, optarg);
+	    r = hts_opt_add((hts_opt **)&ga->out.specific, optarg);
 	    break;
 	} else if (strcmp(lopt->name, "verbose") == 0) {
 	    ga->verbosity++;

--- a/sam_opts.c
+++ b/sam_opts.c
@@ -28,34 +28,6 @@ DEALINGS IN THE SOFTWARE.  */
 #include "sam_opts.h"
 
 /*
- * Assign a short option to each of the long options listed above.
- *
- * There should be one character per option. This will be one of:
- * '.'    No short option has been assigned. Use --long-opt only.
- * '-'    The long (and short) option has been disabled.
- * <c>    Otherwise the short option is character <c>.
- *
- * Consider using varargs to supply a map, or some better tokenised
- * string that allows things out of order.  It's all internal to 
- * samtools though so we can change later without breaking the public
- * API.
- */
-void assign_short_opts(struct option lopts[], const char *shortopts) {
-    int i, j;
-    
-    // Assign sub-command specific short option codes
-    for (i=j=0; shortopts && shortopts[i]; i++,j++) {
-	lopts[j] = lopts[i];
-
-	if (shortopts[i] == '-')
-	    j--; // skip this option.
-	else if (shortopts[i] != '.')
-	    lopts[j].val = shortopts[i];
-    }
-    lopts[j] = lopts[i];
-}
-
-/*
  * Processes a standard "global" samtools long option.
  *
  * The 'c' value is the return value from a getopt_long() call.  It is checked
@@ -115,16 +87,22 @@ int parse_sam_global_opt(int c, const char *optarg, const struct option *lopt,
 /*
  * Report the usage for global options.
  *
- * This accepts the same shortopts string as used by assign_short_opts()
+ * This accepts a string with one character per SAM_OPT_GLOBAL_OPTIONS option
  * to determine which options need to be printed and how.
+ * Each character should be one of:
+ * '.'    No short option has been assigned. Use --long-opt only.
+ * '-'    The long (and short) option has been disabled.
+ * <c>    Otherwise the short option is character <c>.
  */
 void sam_global_opt_help(FILE *fp, const char *shortopts) {
     int i = 0;
 
-    struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
-    int nopts = sizeof(lopts)/sizeof(*lopts);
+    static const struct option lopts[] = {
+        SAM_OPT_GLOBAL_OPTIONS(0,0,0,0,0),
+        { NULL, 0, NULL, 0 }
+    };
 
-    for (i = 0; shortopts && shortopts[i] && i < nopts; i++) {
+    for (i = 0; shortopts && shortopts[i] && lopts[i].name; i++) {
 	if (shortopts[i] == '-')
 	    continue;
 

--- a/sam_opts.h
+++ b/sam_opts.h
@@ -25,6 +25,7 @@ DEALINGS IN THE SOFTWARE.  */
 #ifndef BAM_OPTS_H
 #define BAM_OPTS_H
 
+#include <stdio.h>
 #include <limits.h>
 #include <getopt.h>
 #include <htslib/hts.h>

--- a/sam_opts.h
+++ b/sam_opts.h
@@ -33,8 +33,8 @@ DEALINGS IN THE SOFTWARE.  */
 typedef struct sam_global_args {
     htsFormat in;
     htsFormat out;
-    char *reference; // TO DO
-    int verbosity;
+    char *reference;
+    //int verbosity;
 } sam_global_args;
 
 #define SAM_GLOBAL_ARGS_INIT {{0},{0}}
@@ -44,7 +44,8 @@ enum {
     SAM_OPT_INPUT_FMT_OPTION,
     SAM_OPT_OUTPUT_FMT,
     SAM_OPT_OUTPUT_FMT_OPTION,
-    SAM_OPT_VERBOSE
+    SAM_OPT_REFERENCE,
+    //SAM_OPT_VERBOSE
 };
 
 // Use this within an existing struct option lopts[] = {...}, used where
@@ -54,7 +55,8 @@ enum {
     {"input-fmt-option",  required_argument, NULL, SAM_OPT_INPUT_FMT_OPTION}, \
     {"output-fmt",        required_argument, NULL, SAM_OPT_OUTPUT_FMT}, \
     {"output-fmt-option", required_argument, NULL, SAM_OPT_OUTPUT_FMT_OPTION}, \
-    {"verbose",           no_argument,       NULL, SAM_OPT_VERBOSE}
+    {"reference",         required_argument, NULL, SAM_OPT_REFERENCE}
+    //{"verbose",           no_argument,       NULL, SAM_OPT_VERBOSE}
 
 // Use this to completely assign all long options, used where the subcommand
 // doesn't have any long options of its own.

--- a/sam_opts.h
+++ b/sam_opts.h
@@ -50,6 +50,8 @@ enum {
 
 // Use this within an existing struct option lopts[] = {...}, used where
 // the subcommmand is already using some long options.
+//
+// NOTE: MUST use this as the first thing in struct option lopts[] array.
 #define SAM_GLOBAL_LOPTS \
     {"input-fmt",         required_argument, NULL, SAM_OPT_INPUT_FMT}, \
     {"input-fmt-option",  required_argument, NULL, SAM_OPT_INPUT_FMT_OPTION}, \

--- a/sam_opts.h
+++ b/sam_opts.h
@@ -31,13 +31,13 @@ DEALINGS IN THE SOFTWARE.  */
 #include <htslib/hts.h>
 
 typedef struct sam_global_args {
-    htsFileOpts in;
-    htsFileOpts out;
+    htsFormat in;
+    htsFormat out;
     char *reference; // TO DO
     int verbosity;
 } sam_global_args;
 
-#define SAM_GLOBAL_ARGS_INIT {HTS_FILE_OPTS_INIT, HTS_FILE_OPTS_INIT, NULL, 0}
+#define SAM_GLOBAL_ARGS_INIT {{0},{0}}
 
 enum {
     SAM_OPT_INPUT_FMT = CHAR_MAX+1,

--- a/sam_opts.h
+++ b/sam_opts.h
@@ -1,0 +1,104 @@
+/*  sam_opts.h -- utilities to aid parsing common command line options.
+
+    Copyright (C) 2015 Genome Research Ltd.
+
+    Author: James Bonfield <jkb@sanger.ac.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.  */
+
+#ifndef BAM_OPTS_H
+#define BAM_OPTS_H
+
+#include <limits.h>
+#include <getopt.h>
+#include <htslib/hts.h>
+
+typedef struct sam_global_args {
+    htsFileOpts in;
+    htsFileOpts out;
+    char *reference; // TO DO
+    int verbosity;
+} sam_global_args;
+
+#define SAM_GLOBAL_ARGS_INIT {HTS_FILE_OPTS_INIT, HTS_FILE_OPTS_INIT, NULL, 0}
+
+enum {
+    SAM_OPT_INPUT_FMT = CHAR_MAX+1,
+    SAM_OPT_INPUT_FMT_OPTION,
+    SAM_OPT_OUTPUT_FMT,
+    SAM_OPT_OUTPUT_FMT_OPTION,
+    SAM_OPT_VERBOSE
+};
+
+// Use this within an existing struct option lopts[] = {...}, used where
+// the subcommmand is already using some long options.
+#define SAM_GLOBAL_LOPTS \
+    {"input-fmt",         required_argument, NULL, SAM_OPT_INPUT_FMT}, \
+    {"input-fmt-option",  required_argument, NULL, SAM_OPT_INPUT_FMT_OPTION}, \
+    {"output-fmt",        required_argument, NULL, SAM_OPT_OUTPUT_FMT}, \
+    {"output-fmt-option", required_argument, NULL, SAM_OPT_OUTPUT_FMT_OPTION}, \
+    {"verbose",           no_argument,       NULL, SAM_OPT_VERBOSE}
+
+// Use this to completely assign all long options, used where the subcommand
+// doesn't have any long options of its own.
+//
+// Eg: struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
+#define SAM_GLOBAL_LOPTS_INIT {SAM_GLOBAL_LOPTS, {NULL,0,NULL,0}}
+
+
+/*
+ * Assign a short option to each of the long options listed above.
+ *
+ * There should be one character per option. This will be one of:
+ * '.'    No short option has been assigned. Use --long-opt only.
+ * '-'    The long (and short) option has been disabled.
+ * <c>    Otherwise the short option is character <c>.
+ */
+void assign_short_opts(struct option lopts[], const char *shortopts);
+
+
+/*
+ * Processes a standard "global" samtools long option.
+ *
+ * The 'c' value is the return value from a getopt_long() call.  It is checked
+ * against the lopt[] array to find the corresponding value as this may have
+ * been reassigned by the individual subcommand.
+ *
+ * Having found the entry, the corresponding long form is used to apply the
+ * option, storing the setting in sam_global_args *ga.
+ *
+ * Returns 0 on success,
+ *        -1 on failure.
+ */
+int parse_sam_global_opt(int c, char *optarg, struct option *lopt, 
+			 sam_global_args *ga);
+
+/*
+ * Report the usage for global options.
+ *
+ * This accepts the same shortopts string as used by assign_short_opts()
+ * to determine which options need to be printed and how.
+ */
+void sam_global_opt_help(FILE *fp, char *shortopts);
+
+
+void sam_global_args_init(sam_global_args *ga);
+void sam_global_args_free(sam_global_args *ga);
+
+#endif

--- a/sam_opts.h
+++ b/sam_opts.h
@@ -22,8 +22,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.  */
 
-#ifndef BAM_OPTS_H
-#define BAM_OPTS_H
+#ifndef SAM_OPTS_H
+#define SAM_OPTS_H
 
 #include <stdio.h>
 #include <limits.h>
@@ -91,8 +91,8 @@ void assign_short_opts(struct option lopts[], const char *shortopts);
  * Returns 0 on success,
  *        -1 on failure.
  */
-int parse_sam_global_opt(int c, char *optarg, struct option *lopt, 
-			 sam_global_args *ga);
+int parse_sam_global_opt(int c, const char *optarg, const struct option *lopt,
+                         sam_global_args *ga);
 
 /*
  * Report the usage for global options.
@@ -100,7 +100,7 @@ int parse_sam_global_opt(int c, char *optarg, struct option *lopt,
  * This accepts the same shortopts string as used by assign_short_opts()
  * to determine which options need to be printed and how.
  */
-void sam_global_opt_help(FILE *fp, char *shortopts);
+void sam_global_opt_help(FILE *fp, const char *shortopts);
 
 
 void sam_global_args_init(sam_global_args *ga);

--- a/sam_opts.h
+++ b/sam_opts.h
@@ -48,35 +48,21 @@ enum {
     //SAM_OPT_VERBOSE
 };
 
-// Use this within an existing struct option lopts[] = {...}, used where
-// the subcommmand is already using some long options.
-//
-// NOTE: MUST use this as the first thing in struct option lopts[] array.
-#define SAM_GLOBAL_LOPTS \
-    {"input-fmt",         required_argument, NULL, SAM_OPT_INPUT_FMT}, \
-    {"input-fmt-option",  required_argument, NULL, SAM_OPT_INPUT_FMT_OPTION}, \
-    {"output-fmt",        required_argument, NULL, SAM_OPT_OUTPUT_FMT}, \
-    {"output-fmt-option", required_argument, NULL, SAM_OPT_OUTPUT_FMT_OPTION}, \
-    {"reference",         required_argument, NULL, SAM_OPT_REFERENCE}
+#define SAM_OPT_VAL(val, defval) ((val) == '-')? '?' : (val)? (val) : (defval)
+
+// Use this within struct option lopts[] = {...} to add the standard global
+// options.  The arguments determine whether the corresponding option is
+// enabled and, if so, whether it has a short option equivalent:
+// 0      No short option has been assigned. Use --long-opt only.
+// '-'    Both long and short options are disabled.
+// <c>    Otherwise the equivalent short option is character <c>.
+#define SAM_OPT_GLOBAL_OPTIONS(o1, o2, o3, o4, o5) \
+    {"input-fmt",         required_argument, NULL, SAM_OPT_VAL(o1, SAM_OPT_INPUT_FMT)}, \
+    {"input-fmt-option",  required_argument, NULL, SAM_OPT_VAL(o2, SAM_OPT_INPUT_FMT_OPTION)}, \
+    {"output-fmt",        required_argument, NULL, SAM_OPT_VAL(o3, SAM_OPT_OUTPUT_FMT)}, \
+    {"output-fmt-option", required_argument, NULL, SAM_OPT_VAL(o4, SAM_OPT_OUTPUT_FMT_OPTION)}, \
+    {"reference",         required_argument, NULL, SAM_OPT_VAL(o5, SAM_OPT_REFERENCE)}
     //{"verbose",           no_argument,       NULL, SAM_OPT_VERBOSE}
-
-// Use this to completely assign all long options, used where the subcommand
-// doesn't have any long options of its own.
-//
-// Eg: struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
-#define SAM_GLOBAL_LOPTS_INIT {SAM_GLOBAL_LOPTS, {NULL,0,NULL,0}}
-
-
-/*
- * Assign a short option to each of the long options listed above.
- *
- * There should be one character per option. This will be one of:
- * '.'    No short option has been assigned. Use --long-opt only.
- * '-'    The long (and short) option has been disabled.
- * <c>    Otherwise the short option is character <c>.
- */
-void assign_short_opts(struct option lopts[], const char *shortopts);
-
 
 /*
  * Processes a standard "global" samtools long option.
@@ -97,8 +83,12 @@ int parse_sam_global_opt(int c, const char *optarg, const struct option *lopt,
 /*
  * Report the usage for global options.
  *
- * This accepts the same shortopts string as used by assign_short_opts()
+ * This accepts a string with one character per SAM_OPT_GLOBAL_OPTIONS option
  * to determine which options need to be printed and how.
+ * Each character should be one of:
+ * '.'    No short option has been assigned. Use --long-opt only.
+ * '-'    The long (and short) option has been disabled.
+ * <c>    Otherwise the short option is character <c>.
  */
 void sam_global_opt_help(FILE *fp, const char *shortopts);
 

--- a/sam_view.c
+++ b/sam_view.c
@@ -249,9 +249,10 @@ int main_samview(int argc, char *argv[])
         .bed = NULL,
     };
 
-    static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
-
-    assign_short_opts(lopts, "-.O.T");
+    static const struct option lopts[] = {
+        SAM_OPT_GLOBAL_OPTIONS('-', 0, 'O', 0, 'T'),
+        { NULL, 0, NULL, 0 }
+    };
 
     /* parse command-line options */
     strcpy(out_mode, "w");
@@ -609,8 +610,10 @@ int main_bam2fq(int argc, char *argv[])
     int c;
 
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
-    static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
-    assign_short_opts(lopts, "-.--.");
+    static const struct option lopts[] = {
+        SAM_OPT_GLOBAL_OPTIONS('-', 0, '-', '-', 0),
+        { NULL, 0, NULL, 0 }
+    };
 
     while ((c = getopt_long(argc, argv, "nOts:", lopts, NULL)) > 0) {
         switch (c) {

--- a/sam_view.c
+++ b/sam_view.c
@@ -338,7 +338,7 @@ int main_samview(int argc, char *argv[])
     // generate the fn_list if necessary
     if (fn_list == 0 && fn_ref) fn_list = samfaipath(fn_ref);
     // open file handlers
-    if ((in = sam_open_opts(argv[optind], "r", &ga.in)) == 0) {
+    if ((in = sam_open_format(argv[optind], "r", &ga.in)) == 0) {
         print_error_errno("failed to open \"%s\" for reading", argv[optind]);
         ret = 1;
         goto view_end;
@@ -365,7 +365,7 @@ int main_samview(int argc, char *argv[])
         header->l_text = l;
     }
     if (!is_count) {
-        if ((out = sam_open_opts(fn_out? fn_out : "-", out_mode, &ga.out)) == 0) {
+        if ((out = sam_open_format(fn_out? fn_out : "-", out_mode, &ga.out)) == 0) {
             print_error_errno("failed to open \"%s\" for writing", fn_out? fn_out : "standard output");
             ret = 1;
             goto view_end;
@@ -377,7 +377,8 @@ int main_samview(int argc, char *argv[])
                 goto view_end;
             }
         }
-        if (*out_format || is_header || ga.out.format.compression != no_compression)  {
+        if (*out_format || is_header ||
+            (ga.out.format != sam && ga.out.format != unknown_format))  {
             if (sam_hdr_write(out, header) != 0) {
                 fprintf(stderr, "[main_samview] failed to write the SAM header\n");
                 ret = 1;
@@ -385,7 +386,7 @@ int main_samview(int argc, char *argv[])
             }
         }
         if (fn_un_out) {
-                if ((un_out = sam_open_opts(fn_un_out, out_mode, &ga.out)) == 0) {
+                if ((un_out = sam_open_format(fn_un_out, out_mode, &ga.out)) == 0) {
                 print_error_errno("failed to open \"%s\" for writing", fn_un_out);
                 ret = 1;
                 goto view_end;
@@ -639,7 +640,7 @@ int main_bam2fq(int argc, char *argv[])
         return 1;
     }
 
-    fp = sam_open_opts(argv[optind], "r", &ga.in);
+    fp = sam_open_format(argv[optind], "r", &ga.in);
     if (fp == NULL) {
         print_error_errno("Cannot read file \"%s\"", argv[optind]);
         return 1;

--- a/samtools.1
+++ b/samtools.1
@@ -1115,6 +1115,112 @@ the important libraries used by samtools.
 .B --version-only
 Display the full samtools version number in a machine-readable format.
 .PP
+.SH GLOBAL OPTIONS
+.PP
+Several long-options are shared between multiple samtools subcommands:
+\fB--input-fmt\fR, \fB--input-fmt-options\fR, \fB--output-fmt\fR,
+\fB--output-fmt-options\fR, and \fB--reference\fR.
+The input format is typically auto-detected so specifying the format
+is usually unnecessary and the option is included for completeness.
+Note that not all subcommands have all options.  Consult the subcommand
+help for more details.
+.PP
+Format strings recognised are "sam", "bam" and "cram".  They may be
+followed by a comma separated list of options as \fIkey\fR or
+\fIkey\fR=\fIvalue\fR. See below for examples.
+.PP
+The \fBfmt-options\fR arguments accept either a single \fIoption\fR or
+\fIoption\fR=\fIvalue\fR.  Note that some options only work on some
+file formats and only on read or write streams.  If value is
+unspecified for a boolean option, the value is assumed to be 1.  The
+valid options are as follows.
+.RS 0
+.\" General purpose
+.TP 4
+.BI nthreads= INT
+Specifies the number of threads to use during encoding and/or
+decoding.  For BAM this will be encoding only.  In CRAM the threads
+are dynamically shared between encoder and decoder.
+.\" CRAM specific
+.TP
+.BI reference= fasta_file
+Specifies a FASTA reference file for use in CRAM encoding or decoding.
+It usually is not required for decoding except in the situation of the
+MD5 not being obtainable via the REF_PATH or REF_CACHE environment variables.
+.TP
+.BI decode_md= 0|1
+CRAM decode only; defaults to 1 (on).  CRAM does not typically store
+MD and NM tags, preferring to generate them on the fly.  This option
+controls this behaviour.
+.TP
+.BI ignore_md5= 0|1
+CRAM decode only; defaults to 0 (off).  When enabled, md5 checksum
+errors on the reference sequence and block checksum errors within CRAM
+are ignored.  Use of this option is strongly discouraged.
+.TP
+.BI required_fields= bit-field
+CRAM decode only; specifies which SAM columns need to be populated.
+By default all fields are used.  Limiting the decode to specific
+columns can have significant performance gains.  The bit-field is a
+numerical value constructed from the following table.
+.TS
+center;
+rb l .
+0x1	SAM_QNAME
+0x2	SAM_FLAG
+0x4	SAM_RNAME
+0x8	SAM_POS
+0x10	SAM_MAPQ
+0x20	SAM_CIGAR
+0x40	SAM_RNEXT
+0x80	SAM_PNEXT
+0x100	SAM_TLEN
+0x200	SAM_SEQ
+0x400	SAM_QUAL
+0x800	SAM_AUX
+0x1000	SAM_RGAUX
+.TE
+.TP
+.BI multi_seq_per_slice= 0|1
+CRAM encode only; defaults to 0 (off).  By default CRAM generates one
+container per reference sequence, except in the case of many small
+references (such as a fragmented assembly).
+.TP
+.BI version= major.minor
+CRAM encode only.  Specifies the CRAM version number.  Acceptable
+values are "2.1" and "3.0".
+.TP
+.BI seqs_per_slice= INT
+CRAM encode only; defaults to 10000.
+.TP
+.BI slices_per_container= INT
+CRAM encode only; defaults to 1.  The effect of having multiple slices
+per container is to share the compression header block between
+multiple slices.  This is unlikely to have any significant impact
+unless the number of sequences per slice is reduced.  (Together these
+two options control the granularity of random access.)
+.TP
+.BI embed_ref= 0|1
+CRAM encode only; defaults to 0 (off).  If 1, this will store portions
+of the reference sequence in each slice, permitting decode without
+having requiring an external copy of the reference sequence.
+.TP
+.BI no_ref= 0|1
+CRAM encode only; defaults to 0 (off).  If 1, sequences will be stored
+verbatim with no reference encoding.  This can be useful if no
+reference is available for the file.
+.RE
+.PP
+For example:
+.RS 4
+.HP 4
+samtools view --input-fmt-option decode_md=0
+.br
+--output-fmt cram,version=3.0 --output-fmt-option embed_ref
+.br
+--output-fmt-option seqs_per_slice=2000 -o foo.cram foo.bam
+.RE
+.PP
 .SH REFERENCE SEQUENCES
 .PP
 The CRAM format requires use of a reference sequence for both reading

--- a/stats.c
+++ b/stats.c
@@ -55,6 +55,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include "samtools.h"
 #include <htslib/khash.h>
 #include "stats_isize.h"
+#include "sam_opts.h"
 
 #define BWA_MIN_RDLEN 35
 // From the spec
@@ -1321,6 +1322,7 @@ static void error(const char *format, ...)
         printf("    -t, --target-regions <file>         Do stats in these regions only. Tab-delimited file chr,from,to, 1-based, inclusive.\n");
         printf("    -s, --sam                           Input is SAM (usually auto-detected now).\n");
         printf("    -x, --sparse                        Suppress outputting IS rows where there are no insertions.\n");
+        sam_global_opt_help(stdout, "-.---");
         printf("\n");
     }
     else
@@ -1367,6 +1369,8 @@ int main_stats(int argc, char *argv[])
     char in_mode[5];
     int sparse = 0;
 
+    sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
+
     stats_t *stats = calloc(1,sizeof(stats_t));
     stats->ngc    = 200;
     stats->nquals = 256;
@@ -1390,7 +1394,7 @@ int main_stats(int argc, char *argv[])
 
     strcpy(in_mode, "rb");
 
-    static const struct option loptions[] =
+    static struct option loptions[] =
     {
         {"help", no_argument, NULL, 'h'},
         {"remove-dups", no_argument, NULL, 'd'},
@@ -1407,9 +1411,13 @@ int main_stats(int argc, char *argv[])
         {"id", required_argument, NULL, 'I'},
         {"GC-depth", required_argument, NULL, 1},
         {"sparse", no_argument, NULL, 'x'},
+        SAM_GLOBAL_LOPTS,
         {NULL, 0, NULL, 0}
     };
     int opt;
+
+    assign_short_opts(loptions, "-.---");
+
     while ( (opt=getopt_long(argc,argv,"?hdsxr:c:l:i:t:m:q:f:F:I:1:",loptions,NULL))>0 )
     {
         switch (opt)
@@ -1435,7 +1443,9 @@ int main_stats(int argc, char *argv[])
             case 'x': sparse = 1; break;
             case '?':
             case 'h': error(NULL);
-            default: error("Unknown argument: %s\n", optarg);
+            default:
+                if (parse_sam_global_opt(opt, optarg, loptions, &ga) == 0) break;
+                else error("Unknown argument: %s\n", optarg);
         }
     }
     if ( optind<argc )
@@ -1462,7 +1472,7 @@ int main_stats(int argc, char *argv[])
     stats->cov_rbuf.size = stats->nbases*5;
     stats->cov_rbuf.buffer = calloc(sizeof(int32_t),stats->cov_rbuf.size);
     // .. bam
-    if ((sam = sam_open(bam_fname, in_mode)) == 0)
+    if ((sam = sam_open_format(bam_fname, in_mode, &ga.in)) == 0)
         error("Failed to open: %s\n", bam_fname);
     stats->sam = sam;
     stats->sam_header = sam_hdr_read(sam);
@@ -1510,14 +1520,21 @@ int main_stats(int argc, char *argv[])
     else
     {
         // Stream through the entire BAM ignoring off-target regions if -t is given
-        while (sam_read1(sam, stats->sam_header, bam_line) >= 0)
+        int ret;
+        while ((ret = sam_read1(sam, stats->sam_header, bam_line)) >= 0)
             collect_stats(bam_line,stats);
+
+        if (ret < -1) {
+            fprintf(stderr, "Failure while decoding file\n");
+            return 1;
+        }
     }
     round_buffer_flush(stats,-1);
 
     output_stats(stats, sparse);
     bam_destroy1(bam_line);
     bam_hdr_destroy(stats->sam_header);
+    sam_global_args_free(&ga);
 
     cleanup_stats(stats);
 

--- a/stats.c
+++ b/stats.c
@@ -1322,7 +1322,7 @@ static void error(const char *format, ...)
         printf("    -t, --target-regions <file>         Do stats in these regions only. Tab-delimited file chr,from,to, 1-based, inclusive.\n");
         printf("    -s, --sam                           Input is SAM (usually auto-detected now).\n");
         printf("    -x, --sparse                        Suppress outputting IS rows where there are no insertions.\n");
-        sam_global_opt_help(stdout, "-.---");
+        sam_global_opt_help(stdout, "-.--.");
         printf("\n");
     }
     else
@@ -1416,7 +1416,7 @@ int main_stats(int argc, char *argv[])
     };
     int opt;
 
-    assign_short_opts(loptions, "-.---");
+    assign_short_opts(loptions, "-.--.");
 
     while ( (opt=getopt_long(argc,argv,"?hdsxr:c:l:i:t:m:q:f:F:I:1:",loptions,NULL))>0 )
     {

--- a/stats.c
+++ b/stats.c
@@ -1394,9 +1394,9 @@ int main_stats(int argc, char *argv[])
 
     strcpy(in_mode, "rb");
 
-    static struct option loptions[] =
+    static const struct option loptions[] =
     {
-        SAM_GLOBAL_LOPTS,
+        SAM_OPT_GLOBAL_OPTIONS('-', 0, '-', '-', 0),
         {"help", no_argument, NULL, 'h'},
         {"remove-dups", no_argument, NULL, 'd'},
         {"sam", no_argument, NULL, 's'},
@@ -1415,8 +1415,6 @@ int main_stats(int argc, char *argv[])
         {NULL, 0, NULL, 0}
     };
     int opt;
-
-    assign_short_opts(loptions, "-.--.");
 
     while ( (opt=getopt_long(argc,argv,"?hdsxr:c:l:i:t:m:q:f:F:I:1:",loptions,NULL))>0 )
     {

--- a/stats.c
+++ b/stats.c
@@ -1396,6 +1396,7 @@ int main_stats(int argc, char *argv[])
 
     static struct option loptions[] =
     {
+        SAM_GLOBAL_LOPTS,
         {"help", no_argument, NULL, 'h'},
         {"remove-dups", no_argument, NULL, 'd'},
         {"sam", no_argument, NULL, 's'},
@@ -1411,7 +1412,6 @@ int main_stats(int argc, char *argv[])
         {"id", required_argument, NULL, 'I'},
         {"GC-depth", required_argument, NULL, 1},
         {"sparse", no_argument, NULL, 'x'},
-        SAM_GLOBAL_LOPTS,
         {NULL, 0, NULL, 0}
     };
     int opt;

--- a/test/split/test_expand_format_string.c
+++ b/test/split/test_expand_format_string.c
@@ -85,7 +85,7 @@ int main(int argc, char**argv)
 
     // test
     xfreopen(tempfname, "w", stderr); // Redirect stderr to pipe
-    char* output_1 = expand_format_string(format_string_1, basename_1, rg_id_1, rg_idx_1, bam);
+    char* output_1 = expand_format_string(format_string_1, basename_1, rg_id_1, rg_idx_1, NULL);
     fclose(stderr);
 
     if (verbose) printf("END RUN test 1\n");

--- a/test/split/test_expand_format_string.c
+++ b/test/split/test_expand_format_string.c
@@ -85,7 +85,7 @@ int main(int argc, char**argv)
 
     // test
     xfreopen(tempfname, "w", stderr); // Redirect stderr to pipe
-    char* output_1 = expand_format_string(format_string_1, basename_1, rg_id_1, rg_idx_1);
+    char* output_1 = expand_format_string(format_string_1, basename_1, rg_id_1, rg_idx_1, bam);
     fclose(stderr);
 
     if (verbose) printf("END RUN test 1\n");

--- a/test/split/test_parse_args.c
+++ b/test/split/test_parse_args.c
@@ -38,7 +38,7 @@ bool check_test_1(const parsed_opts_t* opts) {
     if ( opts->merged_input_name != NULL
         || opts->unaccounted_header_name != NULL
         || opts->unaccounted_name != NULL
-        || strcmp(opts->output_format_string,"%*_%#.bam")
+        || strcmp(opts->output_format_string,"%*_%#.%f")
         || opts->verbose == true )
         return false;
     return true;
@@ -57,7 +57,7 @@ bool check_test_2(const parsed_opts_t* opts) {
         || strcmp(opts->merged_input_name, "merged.bam")
         || opts->unaccounted_header_name != NULL
         || opts->unaccounted_name != NULL
-        || strcmp(opts->output_format_string,"%*_%#.bam")
+        || strcmp(opts->output_format_string,"%*_%#.%f")
         || opts->verbose == true )
         return false;
     return true;


### PR DESCRIPTION
Still to do, but maybe an issue for another pull request:
- Sanitisation of help formatting. The indentation differs for each and every sub-command.
- Sanitisation of help long/short options.  Even the already existant long opts differ between some sub-commands.
- Use of hts_opt_add and cast of htsFormat->specific.  Should this be migrated entirely into htslib and hide hts_opt structure internal to it?