### PR TITLE
Cram reheader 2.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ bam_md.o: bam_md.c $(htslib_faidx_h) $(htslib_sam_h) kprobaln.h
 bam_pileup.o: bam_pileup.c $(sam_h)
 bam_plbuf.o: bam_plbuf.c $(htslib_hts_h) $(htslib_sam_h) $(bam_plbuf_h)
 bam_plcmd.o: bam_plcmd.c $(htslib_sam_h) $(htslib_faidx_h) $(HTSDIR)/htslib/kstring.h $(HTSDIR)/htslib/khash_str2int.h sam_header.h samtools.h $(bam2bcf_h) $(sample_h)
-bam_reheader.o: bam_reheader.c $(htslib_bgzf_h) $(bam_h) version.h
+bam_reheader.o: bam_reheader.c $(htslib_bgzf_h) $(bam_h)
 bam_rmdup.o: bam_rmdup.c $(sam_h) $(HTSDIR)/htslib/khash.h
 bam_rmdupse.o: bam_rmdupse.c $(sam_h) $(HTSDIR)/htslib/khash.h $(HTSDIR)/htslib/klist.h
 bam_sort.o: bam_sort.c $(HTSDIR)/htslib/ksort.h $(HTSDIR)/htslib/khash.h $(HTSDIR)/htslib/klist.h $(HTSDIR)/htslib/kstring.h $(htslib_sam_h)

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ AOBJS=      bam_index.o bam_plcmd.o sam_view.o \
             bamtk.o bam2bcf.o bam2bcf_indel.o errmod.o sample.o \
             cut_target.o phase.o bam2depth.o padding.o bedcov.o bamshuf.o \
             faidx.o dict.o stats.o stats_isize.o bam_flags.o bam_split.o \
-            bam_tview.o bam_tview_curses.o bam_tview_html.o bam_lpileup.o
+            bam_tview.o bam_tview_curses.o bam_tview_html.o bam_lpileup.o \
+            sam_opts.o
 
 EXTRA_CPPFLAGS = $(DFLAGS) -I. -I$(HTSDIR)
 LIBCURSES=  -lcurses # -lXCurses
@@ -132,6 +133,7 @@ bam_lpileup_h = bam_lpileup.h $(htslib_sam_h)
 bam_plbuf_h = bam_plbuf.h $(htslib_sam_h)
 bam_tview_h = bam_tview.h $(htslib_hts_h) $(htslib_sam_h) $(htslib_faidx_h) $(bam2bcf_h) $(HTSDIR)/htslib/khash.h $(bam_lpileup_h)
 sam_h = sam.h $(htslib_sam_h) $(bam_h)
+sam_opts_h = sam_opts.h $(htslib_hts_h)
 sample_h = sample.h $(HTSDIR)/htslib/kstring.h
 
 bam.o: bam.c $(bam_h) sam_header.h
@@ -170,6 +172,7 @@ padding.o: padding.c sam_header.h $(sam_h) $(bam_h) $(htslib_faidx_h)
 phase.o: phase.c $(htslib_sam_h) errmod.h $(HTSDIR)/htslib/kseq.h $(HTSDIR)/htslib/khash.h $(HTSDIR)/htslib/ksort.h
 sam.o: sam.c $(htslib_faidx_h) $(sam_h)
 sam_header.o: sam_header.c sam_header.h $(HTSDIR)/htslib/khash.h
+sam_opts.o: sam_opts.c $(sam_opts_h)
 sam_view.o: sam_view.c $(htslib_sam_h) $(htslib_faidx_h) $(HTSDIR)/htslib/kstring.h $(HTSDIR)/htslib/khash.h samtools.h
 sample.o: sample.c $(sample_h) $(HTSDIR)/htslib/khash.h
 stats_isize.o: stats_isize.c stats_isize.h $(HTSDIR)/htslib/khash.h
@@ -195,29 +198,29 @@ check test: samtools $(BGZIP) $(BUILT_TEST_PROGRAMS)
 	test/split/test_parse_args
 
 
-test/merge/test_bam_translate: test/merge/test_bam_translate.o test/test.o $(HTSLIB)
-	$(CC) -pthread $(LDFLAGS) -o $@ test/merge/test_bam_translate.o test/test.o $(HTSLIB) -lz $(LIBS)
+test/merge/test_bam_translate: test/merge/test_bam_translate.o test/test.o sam_opts.o $(HTSLIB)
+	$(CC) -pthread $(LDFLAGS) -o $@ test/merge/test_bam_translate.o test/test.o sam_opts.o $(HTSLIB) -lz $(LIBS)
 
-test/merge/test_pretty_header: test/merge/test_pretty_header.o $(HTSLIB)
-	$(CC) -pthread $(LDFLAGS) -o $@ test/merge/test_pretty_header.o $(HTSLIB) -lz $(LIBS)
+test/merge/test_pretty_header: test/merge/test_pretty_header.o sam_opts.o $(HTSLIB)
+	$(CC) -pthread $(LDFLAGS) -o $@ test/merge/test_pretty_header.o sam_opts.o $(HTSLIB) -lz $(LIBS)
 
-test/merge/test_rtrans_build: test/merge/test_rtrans_build.o $(HTSLIB)
-	$(CC) -pthread $(LDFLAGS) -o $@ test/merge/test_rtrans_build.o $(HTSLIB) -lz $(LIBS)
+test/merge/test_rtrans_build: test/merge/test_rtrans_build.o sam_opts.o $(HTSLIB)
+	$(CC) -pthread $(LDFLAGS) -o $@ test/merge/test_rtrans_build.o sam_opts.o $(HTSLIB) -lz $(LIBS)
 
-test/merge/test_trans_tbl_init: test/merge/test_trans_tbl_init.o $(HTSLIB)
-	$(CC) -pthread $(LDFLAGS) -o $@ test/merge/test_trans_tbl_init.o $(HTSLIB) -lz $(LIBS)
+test/merge/test_trans_tbl_init: test/merge/test_trans_tbl_init.o sam_opts.o $(HTSLIB)
+	$(CC) -pthread $(LDFLAGS) -o $@ test/merge/test_trans_tbl_init.o sam_opts.o $(HTSLIB) -lz $(LIBS)
 
-test/split/test_count_rg: test/split/test_count_rg.o test/test.o $(HTSLIB)
-	$(CC) -pthread $(LDFLAGS) -o $@ test/split/test_count_rg.o test/test.o $(HTSLIB) -lz $(LIBS)
+test/split/test_count_rg: test/split/test_count_rg.o test/test.o sam_opts.o $(HTSLIB)
+	$(CC) -pthread $(LDFLAGS) -o $@ test/split/test_count_rg.o test/test.o sam_opts.o $(HTSLIB) -lz $(LIBS)
 
-test/split/test_expand_format_string: test/split/test_expand_format_string.o test/test.o $(HTSLIB)
-	$(CC) -pthread $(LDFLAGS) -o $@ test/split/test_expand_format_string.o test/test.o $(HTSLIB) -lz $(LIBS)
+test/split/test_expand_format_string: test/split/test_expand_format_string.o test/test.o sam_opts.o $(HTSLIB)
+	$(CC) -pthread $(LDFLAGS) -o $@ test/split/test_expand_format_string.o test/test.o sam_opts.o $(HTSLIB) -lz $(LIBS)
 
-test/split/test_filter_header_rg: test/split/test_filter_header_rg.o test/test.o $(HTSLIB)
-	$(CC) -pthread $(LDFLAGS) -o $@ test/split/test_filter_header_rg.o test/test.o $(HTSLIB) -lz $(LIBS)
+test/split/test_filter_header_rg: test/split/test_filter_header_rg.o test/test.o sam_opts.o $(HTSLIB)
+	$(CC) -pthread $(LDFLAGS) -o $@ test/split/test_filter_header_rg.o test/test.o sam_opts.o $(HTSLIB) -lz $(LIBS)
 
-test/split/test_parse_args: test/split/test_parse_args.o test/test.o $(HTSLIB)
-	$(CC) -pthread $(LDFLAGS) -o $@ test/split/test_parse_args.o test/test.o $(HTSLIB) -lz $(LIBS)
+test/split/test_parse_args: test/split/test_parse_args.o test/test.o sam_opts.o $(HTSLIB)
+	$(CC) -pthread $(LDFLAGS) -o $@ test/split/test_parse_args.o test/test.o sam_opts.o $(HTSLIB) -lz $(LIBS)
 
 test/vcf-miniview: test/vcf-miniview.o $(HTSLIB)
 	$(CC) -pthread $(LDFLAGS) -o $@ test/vcf-miniview.o $(HTSLIB) -lz $(LIBS)

--- a/bam2depth.c
+++ b/bam2depth.c
@@ -36,6 +36,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <unistd.h>
 #include "htslib/sam.h"
 #include "samtools.h"
+#include "sam_opts.h"
 
 typedef struct {     // auxiliary data structure
     samFile *fp;     // the file handle
@@ -68,6 +69,26 @@ static int read_bam(void *data, bam1_t *b) // read level filters better go here 
 
 int read_file_list(const char *file_list,int *n,char **argv[]);
 
+static int usage() {
+    fprintf(stderr, "\n");
+    fprintf(stderr, "Usage: samtools depth [options] in1.bam [in2.bam [...]]\n");
+    fprintf(stderr, "Options:\n");
+    fprintf(stderr, "   -a                  output all positions (including zero depth)\n");
+    fprintf(stderr, "   -a -a (or -aa)      output absolutely all positions, including unused ref. sequences\n");
+    fprintf(stderr, "   -b <bed>            list of positions or regions\n");
+    fprintf(stderr, "   -f <list>           list of input BAM filenames, one per line [null]\n");
+    fprintf(stderr, "   -l <int>            read length threshold (ignore reads shorter than <int>)\n");
+    fprintf(stderr, "   -m <int>            maximum coverage depth [8000]\n");  // the htslib's default
+    fprintf(stderr, "   -q <int>            base quality threshold\n");
+    fprintf(stderr, "   -Q <int>            mapping quality threshold\n");
+    fprintf(stderr, "   -r <chr:from-to>    region\n");
+    fprintf(stderr, "\n");
+
+    sam_global_opt_help(stderr, "-.--.");
+
+    return 1;
+}
+
 int main_depth(int argc, char *argv[])
 {
     int i, n, tid, beg, end, pos, *n_plp, baseQ = 0, mapQ = 0, min_len = 0;
@@ -79,10 +100,14 @@ int main_depth(int argc, char *argv[])
     bam_hdr_t *h = NULL; // BAM header of the 1st input
     aux_t **data;
     bam_mplp_t mplp;
-    int last_pos = -1, last_tid = -1;
+    int last_pos = -1, last_tid = -1, ret;
+
+    sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
+    static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
+    assign_short_opts(lopts, "-.--.");
 
     // parse the command line
-    while ((n = getopt(argc, argv, "r:b:q:Q:l:f:am:")) >= 0) {
+    while ((n = getopt_long(argc, argv, "r:b:q:Q:l:f:am:", lopts, NULL)) >= 0) {
         switch (n) {
             case 'l': min_len = atoi(optarg); break; // minimum query length
             case 'r': reg = strdup(optarg); break;   // parsing a region requires a BAM header
@@ -95,24 +120,12 @@ int main_depth(int argc, char *argv[])
             case 'f': file_list = optarg; break;
             case 'a': all++; break;
             case 'm': max_depth = atoi(optarg); break; // maximum coverage depth
+            default: if (parse_sam_global_opt(n, optarg, lopts, &ga) == 0) break;
+            case '?': return usage();
         }
     }
-    if (optind == argc && !file_list) {
-        fprintf(stderr, "\n");
-        fprintf(stderr, "Usage: samtools depth [options] in1.bam [in2.bam [...]]\n");
-        fprintf(stderr, "Options:\n");
-        fprintf(stderr, "   -a                  output all positions (including zero depth)\n");
-        fprintf(stderr, "   -a -a (or -aa)      output absolutely all positions, including unused ref. sequences\n");
-        fprintf(stderr, "   -b <bed>            list of positions or regions\n");
-        fprintf(stderr, "   -f <list>           list of input BAM filenames, one per line [null]\n");
-        fprintf(stderr, "   -l <int>            read length threshold (ignore reads shorter than <int>)\n");
-        fprintf(stderr, "   -m <int>            maximum coverage depth [8000]\n");  // the htslib's default
-        fprintf(stderr, "   -q <int>            base quality threshold\n");
-        fprintf(stderr, "   -Q <int>            mapping quality threshold\n");
-        fprintf(stderr, "   -r <chr:from-to>    region\n");
-        fprintf(stderr, "\n");
-        return 1;
-    }
+    if (optind == argc && !file_list)
+        return usage();
 
     // initialize the auxiliary data structures
     if (file_list)
@@ -127,16 +140,17 @@ int main_depth(int argc, char *argv[])
     data = calloc(n, sizeof(aux_t*)); // data[i] for the i-th input
     beg = 0; end = 1<<30;  // set the default region
     for (i = 0; i < n; ++i) {
+        int rf;
         data[i] = calloc(1, sizeof(aux_t));
-        data[i]->fp = sam_open(argv[optind+i], "r"); // open BAM
+        data[i]->fp = sam_open_format(argv[optind+i], "r", &ga.in); // open BAM
         if (data[i]->fp == NULL) {
             print_error_errno("Could not open \"%s\"", argv[optind+i]);
             status = EXIT_FAILURE;
             goto depth_end;
         }
-        if (hts_set_opt(data[i]->fp, CRAM_OPT_REQUIRED_FIELDS,
-                        SAM_FLAG | SAM_RNAME | SAM_POS | SAM_MAPQ | SAM_CIGAR |
-                        SAM_SEQ)) {
+        rf = SAM_FLAG | SAM_RNAME | SAM_POS | SAM_MAPQ | SAM_CIGAR | SAM_SEQ;
+        if (baseQ) rf |= SAM_QUAL;
+        if (hts_set_opt(data[i]->fp, CRAM_OPT_REQUIRED_FIELDS, rf)) {
             fprintf(stderr, "Failed to set CRAM_OPT_REQUIRED_FIELDS value\n");
             return 1;
         }
@@ -176,7 +190,7 @@ int main_depth(int argc, char *argv[])
         bam_mplp_set_maxcnt(mplp,max_depth);  // set maximum coverage depth
     n_plp = calloc(n, sizeof(int)); // n_plp[i] is the number of covering reads from the i-th BAM
     plp = calloc(n, sizeof(bam_pileup1_t*)); // plp[i] points to the array of covering reads (internal in mplp)
-    while (bam_mplp_auto(mplp, &tid, &pos, n_plp, plp) > 0) { // come to the next covered position
+    while ((ret=bam_mplp_auto(mplp, &tid, &pos, n_plp, plp)) > 0) { // come to the next covered position
         if (pos < beg || pos >= end) continue; // out of range; skip
         if (tid >= h->n_targets) continue;     // diff number of @SQ lines per file?
         if (bed && bed_overlap(bed, h->target_name[tid], pos, pos + 1) == 0) continue; // not in BED; skip
@@ -223,6 +237,7 @@ int main_depth(int argc, char *argv[])
         }
         putchar('\n');
     }
+    if (ret < 0) status = EXIT_FAILURE;
     free(n_plp); free(plp);
     bam_mplp_destroy(mplp);
 
@@ -259,6 +274,7 @@ depth_end:
         for (i=0; i<n; i++) free(fn[i]);
         free(fn);
     }
+    sam_global_args_free(&ga);
     return status;
 }
 

--- a/bam_split.c
+++ b/bam_split.c
@@ -32,6 +32,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <regex.h>
 #include <htslib/khash.h>
 #include <htslib/kstring.h>
+#include "sam_opts.h"
 
 
 KHASH_MAP_INIT_STR(c2i, int)
@@ -42,6 +43,7 @@ struct parsed_opts {
     char* unaccounted_name;
     char* output_format_string;
     bool verbose;
+    sam_global_args ga;
 };
 
 typedef struct parsed_opts parsed_opts_t;
@@ -60,7 +62,7 @@ struct state {
 
 typedef struct state state_t;
 
-static void cleanup_state(state_t* status);
+static int cleanup_state(state_t* status);
 static void cleanup_opts(parsed_opts_t* opts);
 
 static void usage(FILE *write_to)
@@ -69,17 +71,21 @@ static void usage(FILE *write_to)
 "Usage: samtools split [-u <unaccounted.bam>[:<unaccounted_header.sam>]]\n"
 "                      [-f <format_string>] [-v] <merged.bam>\n"
 "Options:\n"
-"  -f STRING       output filename format string [\"%%*_%%#.bam\"]\n"
+"  -f STRING       output filename format string [\"%%*_%%#.%%f\"]\n"
 "  -u FILE1        put reads with no RG tag or an unrecognised RG tag in FILE1\n"
 "  -u FILE1:FILE2  ...and override the header with FILE2\n"
-"  -v              verbose output\n"
+"  -v              verbose output\n");
+    sam_global_opt_help(write_to, "-....");
+    fprintf(write_to,
 "\n"
 "Format string expansions:\n"
 "  %%%%     %%\n"
 "  %%*     basename\n"
 "  %%#     @RG index\n"
 "  %%!     @RG ID\n"
+"  %%f     format type\n"
       );
+
 }
 
 // Takes the command line options and turns them into something we can understand
@@ -90,11 +96,16 @@ static parsed_opts_t* parse_args(int argc, char** argv)
     const char* optstring = "vf:u:";
     char* delim;
 
+    static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
+    assign_short_opts(lopts, "-....");
+
     parsed_opts_t* retval = calloc(sizeof(parsed_opts_t), 1);
     if (! retval ) { perror("cannot allocate option parsing memory"); return NULL; }
 
+    sam_global_args_init(&retval->ga);
+
     int opt;
-    while ((opt = getopt(argc, argv, optstring)) != -1) {
+    while ((opt = getopt_long(argc, argv, optstring, lopts, NULL)) != -1) {
         switch (opt) {
         case 'f':
             retval->output_format_string = strdup(optarg);
@@ -112,14 +123,21 @@ static parsed_opts_t* parse_args(int argc, char** argv)
                 if (! retval->unaccounted_header_name ) { perror("cannot allocate string memory"); return NULL; }
             }
             break;
-        default:
+
+        case '?':
             usage(stdout);
             free(retval);
             return NULL;
+
+        default:
+            if (parse_sam_global_opt(opt, optarg, lopts, &retval->ga) != 0) {
+                usage(stdout);
+                return NULL;
+            }
         }
     }
 
-    if (retval->output_format_string == NULL) retval->output_format_string = strdup("%*_%#.bam");
+    if (retval->output_format_string == NULL) retval->output_format_string = strdup("%*_%#.%f");
 
     argc -= optind;
     argv += optind;
@@ -138,7 +156,7 @@ static parsed_opts_t* parse_args(int argc, char** argv)
 }
 
 // Expands a output filename format string
-static char* expand_format_string(const char* format_string, const char* basename, const char* rg_id, const int rg_idx)
+static char* expand_format_string(const char* format_string, const char* basename, const char* rg_id, const int rg_idx, htsFormat *format)
 {
     kstring_t str = { 0, 0, NULL };
     const char* pointer = format_string;
@@ -158,6 +176,13 @@ static char* expand_format_string(const char* format_string, const char* basenam
                 break;
             case '!':
                 kputs(rg_id, &str);
+                break;
+            case 'f':
+                // Only really need to cope with sam, bam, cram
+                if (format->format != unknown_format)
+                    kputs(hts_format_file_extension(format), &str);
+                else
+                    kputs("bam", &str);
                 break;
             case '\0':
                 // Error is: fprintf(stderr, "bad format string, trailing %%\n");
@@ -302,7 +327,7 @@ static state_t* init(parsed_opts_t* opts)
         return NULL;
     }
 
-    retval->merged_input_file = sam_open(opts->merged_input_name, "rb");
+    retval->merged_input_file = sam_open_format(opts->merged_input_name, "rb", &opts->ga.in);
     if (!retval->merged_input_file) {
         fprintf(stderr, "Could not open input file (%s)\n", opts->merged_input_name);
         free(retval);
@@ -312,7 +337,7 @@ static state_t* init(parsed_opts_t* opts)
 
     if (opts->unaccounted_name) {
         if (opts->unaccounted_header_name) {
-            samFile* hdr_load = sam_open(opts->unaccounted_header_name, "r");
+            samFile* hdr_load = sam_open_format(opts->unaccounted_header_name, "r", &opts->ga.in);
             if (!hdr_load) {
                 fprintf(stderr, "Could not open unaccounted header file (%s)\n", opts->unaccounted_header_name);
                 cleanup_state(retval);
@@ -324,7 +349,7 @@ static state_t* init(parsed_opts_t* opts)
             retval->unaccounted_header = bam_hdr_dup(retval->merged_input_header);
         }
 
-        retval->unaccounted_file = sam_open(opts->unaccounted_name, "wb");
+        retval->unaccounted_file = sam_open_format(opts->unaccounted_name, "wb", &opts->ga.out);
         if (retval->unaccounted_file == NULL) {
             fprintf(stderr, "Could not open unaccounted output file: %s\n", opts->unaccounted_name);
             cleanup_state(retval);
@@ -359,14 +384,19 @@ static state_t* init(parsed_opts_t* opts)
     for (i = 0; i < retval->output_count; i++) {
         char* output_filename = NULL;
 
-        if ( ( output_filename = expand_format_string(opts->output_format_string, input_base_name, retval->rg_id[i], i) ) == NULL) {
+        output_filename = expand_format_string(opts->output_format_string,
+                                               input_base_name,
+                                               retval->rg_id[i], i,
+                                               &opts->ga.out);
+    
+        if ( output_filename == NULL ) {
             fprintf(stderr, "Error expanding output filename format string.\r\n");
             cleanup_state(retval);
             free(input_base_name);
             return NULL;
         }
 
-        retval->rg_output_file[i] = sam_open(output_filename, "wb");
+        retval->rg_output_file[i] = sam_open_format(output_filename, "wb", &opts->ga.out);
         if (retval->rg_output_file[i] == NULL) {
             fprintf(stderr, "Could not open output file: %s\r\n", output_filename);
             cleanup_state(retval);
@@ -412,10 +442,15 @@ static bool split(state_t* state)
 
     bam1_t* file_read = bam_init1();
     // Read the first record
-    if (sam_read1(state->merged_input_file, state->merged_input_header, file_read) < 0) {
+    int r;
+    if ((r=sam_read1(state->merged_input_file, state->merged_input_header, file_read)) < 0) {
         // Nothing more to read?  Ignore this file
         bam_destroy1(file_read);
         file_read = NULL;
+        if (r < -1) {
+            fprintf(stderr, "Could not write read sequence\n");
+            return false;
+        }
     }
 
     while (file_read != NULL) {
@@ -433,7 +468,10 @@ static bool split(state_t* state)
         if (iter != kh_end(state->rg_hash)) {
             // if found write to the appropriate untangled bam
             int i = kh_val(state->rg_hash,iter);
-            sam_write1(state->rg_output_file[i], state->rg_output_header[i], file_read);
+            if (sam_write1(state->rg_output_file[i], state->rg_output_header[i], file_read) < 0) {
+                fprintf(stderr, "Could not write sequence\n");
+                return false;
+            }
         } else {
             // otherwise write to the unaccounted bam if there is one or fail
             if (state->unaccounted_file == NULL) {
@@ -445,31 +483,40 @@ static bool split(state_t* state)
                 bam_destroy1(file_read);
                 return false;
             } else {
-                sam_write1(state->unaccounted_file, state->unaccounted_header, file_read);
+                if (sam_write1(state->unaccounted_file, state->unaccounted_header, file_read) < 0) {
+                    fprintf(stderr, "Could not write sequence\n");
+                    return false;
+                }
             }
         }
 
         // Replace written read with the next one to process
-        if (sam_read1(state->merged_input_file, state->merged_input_header, file_read) < 0) {
+        if ((r=sam_read1(state->merged_input_file, state->merged_input_header, file_read)) < 0) {
             // Nothing more to read?  Ignore this file in future
             bam_destroy1(file_read);
             file_read = NULL;
+            if (r < -1) {
+                fprintf(stderr, "Could not write read sequence\n");
+                return false;
+            }
         }
     }
 
     return true;
 }
 
-static void cleanup_state(state_t* status)
+static int cleanup_state(state_t* status)
 {
-    if (!status) return;
+    int ret = 0;
+
+    if (!status) return 0;
     if (status->unaccounted_header) bam_hdr_destroy(status->unaccounted_header);
-    if (status->unaccounted_file) sam_close(status->unaccounted_file);
+    if (status->unaccounted_file) ret |= sam_close(status->unaccounted_file);
     sam_close(status->merged_input_file);
     size_t i;
     for (i = 0; i < status->output_count; i++) {
         bam_hdr_destroy(status->rg_output_header[i]);
-        sam_close(status->rg_output_file[i]);
+        ret |= sam_close(status->rg_output_file[i]);
         free(status->rg_id[i]);
     }
     bam_hdr_destroy(status->merged_input_header);
@@ -478,6 +525,8 @@ static void cleanup_state(state_t* status)
     kh_destroy_c2i(status->rg_hash);
     free(status->rg_id);
     free(status);
+
+    return ret;
 }
 
 static void cleanup_opts(parsed_opts_t* opts)
@@ -487,6 +536,7 @@ static void cleanup_opts(parsed_opts_t* opts)
     free(opts->unaccounted_header_name);
     free(opts->unaccounted_name);
     free(opts->output_format_string);
+    sam_global_args_free(&opts->ga);
     free(opts);
 }
 
@@ -500,7 +550,7 @@ int main_split(int argc, char** argv)
 
     if (split(status)) ret = 0;
 
-    cleanup_state(status);
+    ret |= (cleanup_state(status) != 0);
 cleanup_opts:
     cleanup_opts(opts);
 

--- a/bam_tview.h
+++ b/bam_tview.h
@@ -89,7 +89,8 @@ char bam_aux_getCQi(bam1_t *b, int i);
 #define TV_BASE_COLOR_SPACE 1
 
 int tv_pl_func(uint32_t tid, uint32_t pos, int n, const bam_pileup1_t *pl, void *data);
-int base_tv_init(tview_t*,const char *fn, const char *fn_fa, const char *samples);
+int base_tv_init(tview_t*,const char *fn, const char *fn_fa,
+                 const char *samples, htsFormat *fmt);
 void base_tv_destroy(tview_t*);
 int base_draw_aln(tview_t *tv, int tid, int pos);
 

--- a/bam_tview_curses.c
+++ b/bam_tview_curses.c
@@ -275,7 +275,8 @@ end_loop:
 
 
 
-tview_t* curses_tv_init(const char *fn, const char *fn_fa, const char *samples)
+tview_t* curses_tv_init(const char *fn, const char *fn_fa, const char *samples,
+                        htsFormat *fmt)
     {
     curses_tview_t *tv = (curses_tview_t*)calloc(1, sizeof(curses_tview_t));
     tview_t* base=(tview_t*)tv;
@@ -285,7 +286,7 @@ tview_t* curses_tv_init(const char *fn, const char *fn_fa, const char *samples)
         return 0;
         }
 
-    base_tv_init(base,fn,fn_fa,samples);
+    base_tv_init(base,fn,fn_fa,samples,fmt);
     /* initialize callbacks */
 #define SET_CALLBACK(fun) base->my_##fun=curses_##fun;
     SET_CALLBACK(destroy);
@@ -328,11 +329,13 @@ tview_t* curses_tv_init(const char *fn, const char *fn_fa, const char *samples)
 #include <stdio.h>
 #warning "No curses library is available; tview with curses is disabled."
 
-extern tview_t* text_tv_init(const char *fn, const char *fn_fa, const char *samples);
+extern tview_t* text_tv_init(const char *fn, const char *fn_fa, const char *samples,
+                             htsFormat *fmt);
 
-tview_t* curses_tv_init(const char *fn, const char *fn_fa, const char *samples)
+tview_t* curses_tv_init(const char *fn, const char *fn_fa, const char *samples,
+                        htsFormat *fmt)
     {
-    return text_tv_init(fn,fn_fa,samples);
+    return text_tv_init(fn,fn_fa,samples,fmt);
     }
 #endif // #ifdef _HAVE_CURSES
 

--- a/bam_tview_html.c
+++ b/bam_tview_html.c
@@ -312,7 +312,8 @@ static void init_pair(html_tview_t *tv,int id_ge_1, const char* pen, const char*
     }
 */
 
-tview_t* html_tv_init(const char *fn, const char *fn_fa, const char *samples)
+tview_t* html_tv_init(const char *fn, const char *fn_fa, const char *samples,
+                      htsFormat *fmt)
     {
     char* colstr=getenv("COLUMNS");
     html_tview_t *tv = (html_tview_t*)calloc(1, sizeof(html_tview_t));
@@ -326,7 +327,7 @@ tview_t* html_tv_init(const char *fn, const char *fn_fa, const char *samples)
     tv->screen=NULL;
     tv->out=stdout;
     tv->attributes=0;
-    base_tv_init(base,fn,fn_fa,samples);
+    base_tv_init(base,fn,fn_fa,samples,fmt);
     /* initialize callbacks */
 #define SET_CALLBACK(fun) base->my_##fun=html_##fun;
     SET_CALLBACK(destroy);
@@ -364,9 +365,10 @@ tview_t* html_tv_init(const char *fn, const char *fn_fa, const char *samples)
     }
 
 
-tview_t* text_tv_init(const char *fn, const char *fn_fa, const char *samples)
+tview_t* text_tv_init(const char *fn, const char *fn_fa, const char *samples,
+                      htsFormat *fmt)
     {
-    tview_t* tv=html_tv_init(fn,fn_fa,samples);
+    tview_t* tv=html_tv_init(fn,fn_fa,samples,fmt);
     tv->my_drawaln=text_drawaln;
     return tv;
     }

--- a/bamshuf.c
+++ b/bamshuf.c
@@ -29,9 +29,10 @@ DEALINGS IN THE SOFTWARE.  */
 #include <string.h>
 #include <assert.h>
 #include "htslib/sam.h"
-#include "htslib/bgzf.h"
+#include "htslib/hts.h"
 #include "htslib/ksort.h"
 #include "samtools.h"
+#include "sam_opts.h"
 
 #define DEF_CLEVEL 1
 
@@ -73,9 +74,10 @@ static inline int elem_lt(elem_t x, elem_t y)
 
 KSORT_INIT(bamshuf, elem_t, elem_lt)
 
-static int bamshuf(const char *fn, int n_files, const char *pre, int clevel, int is_stdout)
+static int bamshuf(const char *fn, int n_files, const char *pre, int clevel,
+                   int is_stdout, sam_global_args *ga)
 {
-    BGZF *fp, *fpw, **fpt;
+    samFile *fp, *fpw, **fpt;
     char **fnt, modew[8];
     bam1_t *b;
     int i, l;
@@ -83,101 +85,122 @@ static int bamshuf(const char *fn, int n_files, const char *pre, int clevel, int
     int64_t *cnt;
 
     // split
-    fp = strcmp(fn, "-")? bgzf_open(fn, "r") : bgzf_dopen(fileno(stdin), "r");
+    fp = sam_open_format(fn, "r", &ga->in);
     if (fp == NULL) {
         print_error_errno("Cannot open input file \"%s\"", fn);
         return 1;
     }
 
-    h = bam_hdr_read(fp);
+    h = sam_hdr_read(fp);
     fnt = (char**)calloc(n_files, sizeof(char*));
-    fpt = (BGZF**)calloc(n_files, sizeof(BGZF*));
+    fpt = (samFile**)calloc(n_files, sizeof(samFile*));
     cnt = (int64_t*)calloc(n_files, 8);
     l = strlen(pre);
+
     for (i = 0; i < n_files; ++i) {
         fnt[i] = (char*)calloc(l + 10, 1);
         sprintf(fnt[i], "%s.%.4d.bam", pre, i);
-        fpt[i] = bgzf_open(fnt[i], "w1");
+        fpt[i] = sam_open(fnt[i], "wb1");
         if (fpt[i] == NULL) {
             print_error_errno("Cannot open intermediate file \"%s\"", fnt[i]);
             return 1;
         }
-        bam_hdr_write(fpt[i], h);
+        sam_hdr_write(fpt[i], h);
     }
     b = bam_init1();
-    while (bam_read1(fp, b) >= 0) {
+    while (sam_read1(fp, h, b) >= 0) {
         uint32_t x;
         x = hash_X31_Wang(bam_get_qname(b)) % n_files;
-        bam_write1(fpt[x], b);
+        sam_write1(fpt[x], h, b);
         ++cnt[x];
     }
     bam_destroy1(b);
-    for (i = 0; i < n_files; ++i) bgzf_close(fpt[i]);
+    for (i = 0; i < n_files; ++i) sam_close(fpt[i]);
     free(fpt);
-    bgzf_close(fp);
+    sam_close(fp);
+
     // merge
-    sprintf(modew, "w%d", (clevel >= 0 && clevel <= 9)? clevel : DEF_CLEVEL);
+    sprintf(modew, "wb%d", (clevel >= 0 && clevel <= 9)? clevel : DEF_CLEVEL);
     if (!is_stdout) { // output to a file
         char *fnw = (char*)calloc(l + 5, 1);
-        sprintf(fnw, "%s.bam", pre);
-        fpw = bgzf_open(fnw, modew);
+        if (ga->out.format == unknown_format)
+            sprintf(fnw, "%s.bam", pre); // "wb" above makes BAM the default
+        else
+            sprintf(fnw, "%s.%s", pre,  hts_format_file_extension(&ga->out));
+        fpw = sam_open_format(fnw, modew, &ga->out);
         free(fnw);
-    } else fpw = bgzf_dopen(fileno(stdout), modew); // output to stdout
+    } else fpw = sam_open_format("-", modew, &ga->out); // output to stdout
     if (fpw == NULL) {
         if (is_stdout) print_error_errno("Cannot open standard output");
         else print_error_errno("Cannot open output file \"%s.bam\"", pre);
         return 1;
     }
 
-    bam_hdr_write(fpw, h);
-    bam_hdr_destroy(h);
+    sam_hdr_write(fpw, h);
     for (i = 0; i < n_files; ++i) {
         int64_t j, c = cnt[i];
         elem_t *a;
-        fp = bgzf_open(fnt[i], "r");
-        bam_hdr_destroy(bam_hdr_read(fp));
+        fp = sam_open_format(fnt[i], "r", &ga->in);
+        bam_hdr_destroy(sam_hdr_read(fp));
         a = (elem_t*)calloc(c, sizeof(elem_t));
         for (j = 0; j < c; ++j) {
             a[j].b = bam_init1();
-            assert(bam_read1(fp, a[j].b) >= 0);
+            sam_read1(fp, h, a[j].b);
             a[j].key = hash_X31_Wang(bam_get_qname(a[j].b));
         }
-        bgzf_close(fp);
+        sam_close(fp);
         unlink(fnt[i]);
         free(fnt[i]);
         ks_introsort(bamshuf, c, a);
         for (j = 0; j < c; ++j) {
-            bam_write1(fpw, a[j].b);
+            sam_write1(fpw, h, a[j].b);
             bam_destroy1(a[j].b);
         }
         free(a);
     }
-    bgzf_close(fpw);
+    sam_close(fpw);
+    bam_hdr_destroy(h);
     free(fnt); free(cnt);
+    sam_global_args_free(ga);
+
     return 0;
+}
+
+static int usage(FILE *fp, int n_files) {
+    fprintf(fp,
+            "Usage:   samtools bamshuf [-Ou] [-n nFiles] [-c cLevel] <in.bam> <out.prefix>\n\n"
+            "Options:\n"
+            "      -O       output to stdout\n"
+            "      -u       uncompressed BAM output\n"
+            "      -l INT   compression level [%d]\n" // DEF_CLEVEL
+            "      -n INT   number of temporary files [%d]\n", // n_files
+            DEF_CLEVEL, n_files);
+
+    sam_global_opt_help(fp, "-....");
+
+    return 1;
 }
 
 int main_bamshuf(int argc, char *argv[])
 {
     int c, n_files = 64, clevel = DEF_CLEVEL, is_stdout = 0, is_un = 0;
-    while ((c = getopt(argc, argv, "n:l:uO")) >= 0) {
+    sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
+    static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
+    assign_short_opts(lopts, "-....");
+
+    while ((c = getopt_long(argc, argv, "n:l:uO", lopts, NULL)) >= 0) {
         switch (c) {
         case 'n': n_files = atoi(optarg); break;
         case 'l': clevel = atoi(optarg); break;
         case 'u': is_un = 1; break;
         case 'O': is_stdout = 1; break;
+        default: if (parse_sam_global_opt(c, optarg, lopts, &ga) == 0) break;
+        case '?': return usage(stderr, n_files);
         }
     }
     if (is_un) clevel = 0;
-    if (optind + 2 > argc) {
-        fprintf(stderr,
-"Usage:   samtools bamshuf [-Ou] [-n nFiles] [-c cLevel] <in.bam> <out.prefix>\n\n"
-"Options: -O      output to stdout\n"
-"         -u      uncompressed BAM output\n"
-"         -l INT  compression level [%d]\n" // DEF_CLEVEL
-"         -n INT  number of temporary files [%d]\n", // n_files
-                DEF_CLEVEL, n_files);
-        return 1;
-    }
-    return bamshuf(argv[optind], n_files, argv[optind+1], clevel, is_stdout);
+    if (optind + 2 > argc)
+        return usage(stderr, n_files);
+
+    return bamshuf(argv[optind], n_files, argv[optind+1], clevel, is_stdout, &ga);
 }

--- a/phase.c
+++ b/phase.c
@@ -31,6 +31,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <zlib.h>
 #include "htslib/sam.h"
 #include "errmod.h"
+#include "sam_opts.h"
 
 #include "htslib/kseq.h"
 KSTREAM_INIT(gzFile, gzread, 16384)
@@ -537,7 +538,7 @@ static int gl2cns(float q[16])
 
 int main_phase(int argc, char *argv[])
 {
-    int c, tid, pos, vpos = 0, n, lasttid = -1, max_vpos = 0;
+    int c, tid, pos, vpos = 0, n, lasttid = -1, max_vpos = 0, usage = 0;
     const bam_pileup1_t *plp;
     bam_plp_t iter;
     nseq_t *seqs;
@@ -548,10 +549,14 @@ int main_phase(int argc, char *argv[])
     errmod_t *em;
     uint16_t *bases;
 
+    sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
+    static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
+    assign_short_opts(lopts, "-....");
+
     memset(&g, 0, sizeof(phaseg_t));
     g.flag = FLAG_FIX_CHIMERA;
     g.min_varLOD = 37; g.k = 13; g.min_baseQ = 13; g.max_depth = 256;
-    while ((c = getopt(argc, argv, "Q:eFq:k:b:l:D:A:")) >= 0) {
+    while ((c = getopt_long(argc, argv, "Q:eFq:k:b:l:D:A:", lopts, NULL)) >= 0) {
         switch (c) {
             case 'D': g.max_depth = atoi(optarg); break;
             case 'q': g.min_varLOD = atoi(optarg); break;
@@ -562,9 +567,12 @@ int main_phase(int argc, char *argv[])
             case 'A': g.flag |= FLAG_DROP_AMBI; break;
             case 'b': g.pre = strdup(optarg); break;
             case 'l': fn_list = strdup(optarg); break;
+            default: if (parse_sam_global_opt(c, optarg, lopts, &ga) == 0) break;
+            case '?': usage=1; break;
         }
+        if (usage) break;
     }
-    if (argc == optind) {
+    if (usage || argc == optind) {
         fprintf(stderr, "\n");
         fprintf(stderr, "Usage:   samtools phase [options] <in.bam>\n\n");
         fprintf(stderr, "Options: -k INT    block length [%d]\n", g.k);
@@ -577,9 +585,12 @@ int main_phase(int argc, char *argv[])
         fprintf(stderr, "         -A        drop reads with ambiguous phase\n");
 //      fprintf(stderr, "         -e        do not discover SNPs (effective with -l)\n");
         fprintf(stderr, "\n");
+
+        sam_global_opt_help(stderr, "-....");
+
         return 1;
     }
-    g.fp = sam_open(argv[optind], "r");
+    g.fp = sam_open_format(argv[optind], "r", &ga.in);
     g.fp_hdr = sam_hdr_read(g.fp);
     if (fn_list) { // read the list of sites to phase
         set = loadpos(fn_list, g.fp_hdr);
@@ -587,9 +598,14 @@ int main_phase(int argc, char *argv[])
     } else g.flag &= ~FLAG_LIST_EXCL;
     if (g.pre) { // open BAMs to write
         char *s = (char*)malloc(strlen(g.pre) + 20);
-        strcpy(s, g.pre); strcat(s, ".0.bam"); g.out[0] = sam_open(s, "wb");
-        strcpy(s, g.pre); strcat(s, ".1.bam"); g.out[1] = sam_open(s, "wb");
-        strcpy(s, g.pre); strcat(s, ".chimera.bam"); g.out[2] = sam_open(s, "wb");
+        if (ga.out.format == unknown_format)
+            ga.out.format = bam; // default via "wb".
+        strcpy(s, g.pre); strcat(s, ".0."); strcat(s, hts_format_file_extension(&ga.out));
+        g.out[0] = sam_open_format(s, "wb", &ga.out);
+        strcpy(s, g.pre); strcat(s, ".1."); strcat(s, hts_format_file_extension(&ga.out));
+        g.out[1] = sam_open_format(s, "wb", &ga.out);
+        strcpy(s, g.pre); strcat(s, ".chimera."); strcat(s, hts_format_file_extension(&ga.out));
+        g.out[2] = sam_open_format(s, "wb", &ga.out);
         for (c = 0; c <= 2; ++c) {
             g.out_hdr[c] = bam_hdr_dup(g.fp_hdr);
             sam_hdr_write(g.out[c], g.out_hdr[c]);
@@ -716,5 +732,6 @@ int main_phase(int argc, char *argv[])
         }
         free(g.pre); free(g.b);
     }
+    sam_global_args_free(&ga);
     return 0;
 }

--- a/sam_opts.c
+++ b/sam_opts.c
@@ -1,0 +1,175 @@
+/*  sam_opts.c -- utilities to aid parsing common command line options.
+
+    Copyright (C) 2015 Genome Research Ltd.
+
+    Author: James Bonfield <jkb@sanger.ac.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.  */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "sam_opts.h"
+
+/*
+ * Assign a short option to each of the long options listed above.
+ *
+ * There should be one character per option. This will be one of:
+ * '.'    No short option has been assigned. Use --long-opt only.
+ * '-'    The long (and short) option has been disabled.
+ * <c>    Otherwise the short option is character <c>.
+ *
+ * Consider using varargs to supply a map, or some better tokenised
+ * string that allows things out of order.  It's all internal to 
+ * samtools though so we can change later without breaking the public
+ * API.
+ */
+void assign_short_opts(struct option lopts[], const char *shortopts) {
+    int i, j;
+    
+    // Assign sub-command specific short option codes
+    for (i=j=0; shortopts && shortopts[i]; i++,j++) {
+	lopts[j] = lopts[i];
+
+	if (shortopts[i] == '-')
+	    j--; // skip this option.
+	else if (shortopts[i] != '.')
+	    lopts[j].val = shortopts[i];
+    }
+    lopts[j] = lopts[i];
+}
+
+/*
+ * Processes a standard "global" samtools long option.
+ *
+ * The 'c' value is the return value from a getopt_long() call.  It is checked
+ * against the lopt[] array to find the corresponding value as this may have
+ * been reassigned by the individual subcommand.
+ *
+ * Having found the entry, the corresponding long form is used to apply the
+ * option, storing the setting in sam_global_args *ga.
+ *
+ * Returns 0 on success,
+ *        -1 on failure.
+ */
+int parse_sam_global_opt(int c, char *optarg, struct option *lopt, 
+			 sam_global_args *ga) {
+    int r = 0;
+
+    while (lopt->name) {
+	if (c != lopt->val) {
+	    lopt++;
+	    continue;
+	}
+
+	if (strcmp(lopt->name, "input-fmt") == 0) {
+	    r = hts_parse_format(&ga->in, optarg);
+	    break;
+	} else if (strcmp(lopt->name, "input-fmt-option") == 0) {
+	    r = hts_opt_add((hts_opt **)&ga->in.specific, optarg);
+	    break;
+	} else if (strcmp(lopt->name, "output-fmt") == 0) {
+	    r = hts_parse_format(&ga->out, optarg);
+	    break;
+	} else if (strcmp(lopt->name, "output-fmt-option") == 0) {
+	    r = hts_opt_add((hts_opt **)&ga->out.specific, optarg);
+	    break;
+	} else if (strcmp(lopt->name, "reference") == 0) {
+	    char ref[8192];
+	    ref[8191] = 0;
+	    snprintf(ref, 8191, "reference=%s", optarg);
+	    ga->reference = strdup(optarg);
+	    r  = hts_opt_add((hts_opt **)&ga->in.specific, ref);
+	    r |= hts_opt_add((hts_opt **)&ga->out.specific, ref);
+	    break;
+//	} else if (strcmp(lopt->name, "verbose") == 0) {
+//	    ga->verbosity++;
+//	    break;
+	}
+    }
+
+    if (!lopt->name) {
+	fprintf(stderr, "Unexpected global option: %s\n", lopt->name);
+	return -1;
+    }
+
+    return r;
+}
+
+/*
+ * Report the usage for global options.
+ *
+ * This accepts the same shortopts string as used by assign_short_opts()
+ * to determine which options need to be printed and how.
+ */
+void sam_global_opt_help(FILE *fp, char *shortopts) {
+    int i = 0;
+
+    struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
+    int nopts = sizeof(lopts)/sizeof(*lopts);
+
+    for (i = 0; shortopts && shortopts[i] && i < nopts; i++) {
+	if (shortopts[i] == '-')
+	    continue;
+
+	if (shortopts[i] == '.')
+	    fprintf(fp, "      --");
+	else
+	    fprintf(fp, "  -%c, --", shortopts[i]);
+
+	if (strcmp(lopts[i].name, "input-fmt") == 0)
+	    fprintf(fp,"input-fmt FORMAT[,OPT[=VAL]]...\n"
+		    "               Specify input format (SAM, BAM, CRAM)\n");
+	else if (strcmp(lopts[i].name, "input-fmt-option") == 0)
+	    fprintf(fp,"input-fmt-option OPT[=VAL]\n"
+		    "               Specify a single input file format option in the form\n"
+		    "               of OPTION or OPTION=VALUE\n");
+	else if (strcmp(lopts[i].name, "output-fmt") == 0)
+	    fprintf(fp,"output-fmt FORMAT[,OPT[=VAL]]...\n"
+		    "               Specify output format (SAM, BAM, CRAM)\n");
+	else if (strcmp(lopts[i].name, "output-fmt-option") == 0)
+	    fprintf(fp,"output-fmt-option OPT[=VAL]\n"
+		    "               Specify a single output file format option in the form\n"
+		    "               of OPTION or OPTION=VALUE\n");
+	else if (strcmp(lopts[i].name, "reference") == 0)
+	    fprintf(fp,"reference FILE\n"
+		    "               Reference sequence FASTA FILE [null]\n");
+//	else if (strcmp(lopts[i].name, "verbose") == 0)
+//	    fprintf(fp,"verbose\n"
+//		    "               Increment level of verbosity\n");
+    }
+}
+
+void sam_global_args_init(sam_global_args *ga) {
+    if (!ga)
+	return;
+    
+    memset(ga, 0, sizeof(*ga));
+}
+
+void sam_global_args_free(sam_global_args *ga) {
+    if (ga->in.specific)
+	hts_opt_free(ga->in.specific);
+
+    if (ga->out.specific)
+	hts_opt_free(ga->out.specific);
+
+    if (ga->reference)
+	free(ga->reference);
+}

--- a/sam_opts.h
+++ b/sam_opts.h
@@ -1,0 +1,109 @@
+/*  sam_opts.h -- utilities to aid parsing common command line options.
+
+    Copyright (C) 2015 Genome Research Ltd.
+
+    Author: James Bonfield <jkb@sanger.ac.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.  */
+
+#ifndef BAM_OPTS_H
+#define BAM_OPTS_H
+
+#include <stdio.h>
+#include <limits.h>
+#include <getopt.h>
+#include <htslib/hts.h>
+
+typedef struct sam_global_args {
+    htsFormat in;
+    htsFormat out;
+    char *reference;
+    //int verbosity;
+} sam_global_args;
+
+#define SAM_GLOBAL_ARGS_INIT {{0},{0}}
+
+enum {
+    SAM_OPT_INPUT_FMT = CHAR_MAX+1,
+    SAM_OPT_INPUT_FMT_OPTION,
+    SAM_OPT_OUTPUT_FMT,
+    SAM_OPT_OUTPUT_FMT_OPTION,
+    SAM_OPT_REFERENCE,
+    //SAM_OPT_VERBOSE
+};
+
+// Use this within an existing struct option lopts[] = {...}, used where
+// the subcommmand is already using some long options.
+//
+// NOTE: MUST use this as the first thing in struct option lopts[] array.
+#define SAM_GLOBAL_LOPTS \
+    {"input-fmt",         required_argument, NULL, SAM_OPT_INPUT_FMT}, \
+    {"input-fmt-option",  required_argument, NULL, SAM_OPT_INPUT_FMT_OPTION}, \
+    {"output-fmt",        required_argument, NULL, SAM_OPT_OUTPUT_FMT}, \
+    {"output-fmt-option", required_argument, NULL, SAM_OPT_OUTPUT_FMT_OPTION}, \
+    {"reference",         required_argument, NULL, SAM_OPT_REFERENCE}
+    //{"verbose",           no_argument,       NULL, SAM_OPT_VERBOSE}
+
+// Use this to completely assign all long options, used where the subcommand
+// doesn't have any long options of its own.
+//
+// Eg: struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
+#define SAM_GLOBAL_LOPTS_INIT {SAM_GLOBAL_LOPTS, {NULL,0,NULL,0}}
+
+
+/*
+ * Assign a short option to each of the long options listed above.
+ *
+ * There should be one character per option. This will be one of:
+ * '.'    No short option has been assigned. Use --long-opt only.
+ * '-'    The long (and short) option has been disabled.
+ * <c>    Otherwise the short option is character <c>.
+ */
+void assign_short_opts(struct option lopts[], const char *shortopts);
+
+
+/*
+ * Processes a standard "global" samtools long option.
+ *
+ * The 'c' value is the return value from a getopt_long() call.  It is checked
+ * against the lopt[] array to find the corresponding value as this may have
+ * been reassigned by the individual subcommand.
+ *
+ * Having found the entry, the corresponding long form is used to apply the
+ * option, storing the setting in sam_global_args *ga.
+ *
+ * Returns 0 on success,
+ *        -1 on failure.
+ */
+int parse_sam_global_opt(int c, char *optarg, struct option *lopt, 
+			 sam_global_args *ga);
+
+/*
+ * Report the usage for global options.
+ *
+ * This accepts the same shortopts string as used by assign_short_opts()
+ * to determine which options need to be printed and how.
+ */
+void sam_global_opt_help(FILE *fp, char *shortopts);
+
+
+void sam_global_args_init(sam_global_args *ga);
+void sam_global_args_free(sam_global_args *ga);
+
+#endif

--- a/sam_view.c
+++ b/sam_view.c
@@ -31,11 +31,13 @@ DEALINGS IN THE SOFTWARE.  */
 #include <inttypes.h>
 #include <stdbool.h>
 #include <assert.h>
+#include <getopt.h>
 #include "htslib/sam.h"
 #include "htslib/faidx.h"
 #include "htslib/kstring.h"
 #include "htslib/khash.h"
 #include "samtools.h"
+#include "sam_opts.h"
 KHASH_SET_INIT_STR(rg)
 
 typedef khash_t(rg) *rghash_t;
@@ -232,6 +234,7 @@ int main_samview(int argc, char *argv[])
     samFile *in = 0, *out = 0, *un_out=0;
     bam_hdr_t *header = NULL;
     char out_mode[5], *out_format = "", *fn_in = 0, *fn_out = 0, *fn_list = 0, *fn_ref = 0, *q, *fn_un_out = 0;
+    sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
 
     samview_settings_t settings = {
         .rghash = NULL,
@@ -246,10 +249,15 @@ int main_samview(int argc, char *argv[])
         .bed = NULL,
     };
 
+    static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
+
+    assign_short_opts(lopts, "-.O.T");
+
     /* parse command-line options */
-    /* TODO: convert this to getopt_long we're running out of letters */
     strcpy(out_mode, "w");
-    while ((c = getopt(argc, argv, "SbBcCt:h1Ho:q:f:F:ul:r:?T:R:L:s:@:m:x:U:")) >= 0) {
+    while ((c = getopt_long(argc, argv,
+                            "SbBcCt:h1Ho:q:f:F:ul:r:?T:R:L:s:@:m:x:U:",
+                            lopts, NULL)) >= 0) {
         switch (c) {
         case 's':
             if ((settings.subsam_seed = strtol(optarg, &q, 10)) != 0) {
@@ -298,7 +306,7 @@ int main_samview(int argc, char *argv[])
         //case 'X': out_format = "X"; break;
                  */
         case '?': is_long_help = 1; break;
-        case 'T': fn_ref = strdup(optarg); break;
+            //case 'T': fn_ref = strdup(optarg); break;
         case 'B': settings.remove_B = 1; break;
         case '@': n_threads = strtol(optarg, 0, 0); break;
         case 'x':
@@ -311,10 +319,12 @@ int main_samview(int argc, char *argv[])
                 settings.remove_aux[settings.remove_aux_len-1] = optarg;
             }
             break;
-        default: return usage(stderr, EXIT_FAILURE, is_long_help);
+        default:
+	    if (parse_sam_global_opt(c, optarg, lopts, &ga) != 0)
+                return usage(stderr, EXIT_FAILURE, is_long_help);
         }
     }
-    if (compress_level >= 0) out_format = "b";
+    if (compress_level >= 0 && !*out_format) out_format = "b";
     if (is_header_only) is_header = 1;
     strcat(out_mode, out_format);
     if (compress_level >= 0) {
@@ -326,13 +336,14 @@ int main_samview(int argc, char *argv[])
 
     fn_in = (optind < argc)? argv[optind] : "-";
     // generate the fn_list if necessary
-    if (fn_list == 0 && fn_ref) fn_list = samfaipath(fn_ref);
+    if (fn_list == 0 && ga.reference) fn_list = samfaipath(ga.reference);
     // open file handlers
-    if ((in = sam_open(fn_in, "r")) == 0) {
+    if ((in = sam_open_format(fn_in, "r", &ga.in)) == 0) {
         print_error_errno("failed to open \"%s\" for reading", fn_in);
         ret = 1;
         goto view_end;
     }
+
     if (fn_list) {
         if (hts_set_fai_filename(in, fn_list) != 0) {
             fprintf(stderr, "[main_samview] failed to use reference \"%s\".\n", fn_list);
@@ -354,7 +365,7 @@ int main_samview(int argc, char *argv[])
         header->l_text = l;
     }
     if (!is_count) {
-        if ((out = sam_open(fn_out? fn_out : "-", out_mode)) == 0) {
+        if ((out = sam_open_format(fn_out? fn_out : "-", out_mode, &ga.out)) == 0) {
             print_error_errno("failed to open \"%s\" for writing", fn_out? fn_out : "standard output");
             ret = 1;
             goto view_end;
@@ -366,7 +377,8 @@ int main_samview(int argc, char *argv[])
                 goto view_end;
             }
         }
-        if (*out_format || is_header)  {
+        if (*out_format || is_header ||
+            (ga.out.format != sam && ga.out.format != unknown_format))  {
             if (sam_hdr_write(out, header) != 0) {
                 fprintf(stderr, "[main_samview] failed to write the SAM header\n");
                 ret = 1;
@@ -374,7 +386,7 @@ int main_samview(int argc, char *argv[])
             }
         }
         if (fn_un_out) {
-            if ((un_out = sam_open(fn_un_out, out_mode)) == 0) {
+                if ((un_out = sam_open_format(fn_un_out, out_mode, &ga.out)) == 0) {
                 print_error_errno("failed to open \"%s\" for writing", fn_un_out);
                 ret = 1;
                 goto view_end;
@@ -388,6 +400,7 @@ int main_samview(int argc, char *argv[])
             }
         }
     }
+
     if (n_threads > 1) { if (out) hts_set_threads(out, n_threads); }
     if (is_header_only) goto view_end; // no need to print alignments
 
@@ -457,7 +470,8 @@ view_end:
     if (out) check_sam_close(out, fn_out, "standard output", &ret);
     if (un_out) check_sam_close(un_out, fn_un_out, "file", &ret);
 
-    free(fn_list); free(fn_ref); free(fn_out); free(settings.library);  free(fn_un_out);
+    free(fn_list); free(fn_out); free(settings.library);  free(fn_un_out);
+    sam_global_args_free(&ga);
     if ( header ) bam_hdr_destroy(header);
     if (settings.bed) bed_destroy(settings.bed);
     if (settings.rghash) {
@@ -512,11 +526,24 @@ static int usage(FILE *fp, int exit_status, int is_long_help)
 "  -?       print long help, including note about region specification\n"
 "  -S       ignored (input format is auto-detected)\n"
 "\n");
+
+    sam_global_opt_help(stderr, "-.O.T");
+
     if (is_long_help)
-        fprintf(fp,
+        fprintf(stderr,
 "Notes:\n"
 "\n"
 "  1. This command now auto-detects the input format (BAM/CRAM/SAM).\n"
+"     Further control over the CRAM format can be specified by using the\n"
+"     --output-fmt-option, e.g. to specify the number of sequences per slice\n"
+"     and to use avoid reference based compression:\n"
+"     `samtools view -C --output-fmt-option seqs_per_slice=5000 \\\n"
+"         --output-fmt-option no_ref -o out.cram in.bam'\n"
+"\n"
+"     Options can also be specified as a comma separated list within the\n"
+"     --output-fmt value too.  For example this is equivalent to the above\n"
+"     `samtools view --output-fmt cram,seqs_per_slice=5000,no_ref \\\n"
+"         -o out.cram in.bam'\n"
 "\n"
 "  2. The file supplied with `-t' is SPACE/TAB delimited with the first\n"
 "     two fields of each line consisting of the reference name and the\n"
@@ -566,6 +593,8 @@ static void bam2fq_usage(FILE *to)
     fprintf(to, "         -s FILE   write singleton reads to FILE [assume single-end]\n");
     fprintf(to, "         -t        copy RG, BC and QT tags to the FASTQ header line\n");
     fprintf(to, "\n");
+
+    sam_global_opt_help(to, "-.--.");
 }
 
 int main_bam2fq(int argc, char *argv[])
@@ -581,13 +610,23 @@ int main_bam2fq(int argc, char *argv[])
     char* fnse = NULL;
     bool has12 = true, use_oq = false, copy_tags = false;
     int c;
-    while ((c = getopt(argc, argv, "nOts:")) > 0) {
+
+    sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
+    static struct option lopts[] = SAM_GLOBAL_LOPTS_INIT;
+    assign_short_opts(lopts, "-.--.");
+
+    while ((c = getopt_long(argc, argv, "nOts:", lopts, NULL)) > 0) {
         switch (c) {
             case 'n': has12 = false; break;
             case 'O': use_oq = true; break;
             case 's': fnse = optarg; break;
             case 't': copy_tags = true; break;
-            default: bam2fq_usage(stderr); return 1;
+            case '?': bam2fq_usage(stderr); return 1;
+        
+            default:
+                if (parse_sam_global_opt(c, optarg, lopts, &ga) != 0) {
+                    bam2fq_usage(stderr); return 1;
+                }
         }
     }
 
@@ -602,13 +641,15 @@ int main_bam2fq(int argc, char *argv[])
         return 1;
     }
 
-    fp = sam_open(argv[optind], "r");
+    fp = sam_open_format(argv[optind], "r", &ga.in);
     if (fp == NULL) {
         print_error_errno("Cannot read file \"%s\"", argv[optind]);
         return 1;
     }
-    if (hts_set_opt(fp, CRAM_OPT_REQUIRED_FIELDS,
-                    SAM_QNAME | SAM_FLAG | SAM_SEQ | SAM_QUAL)) {
+
+    uint32_t rf = SAM_QNAME | SAM_FLAG | SAM_SEQ | SAM_QUAL;
+    if (use_oq) rf |= SAM_AUX;
+    if (hts_set_opt(fp, CRAM_OPT_REQUIRED_FIELDS, rf)) {
         fprintf(stderr, "Failed to set CRAM_OPT_REQUIRED_FIELDS value\n");
         return 1;
     }
@@ -634,8 +675,9 @@ int main_bam2fq(int argc, char *argv[])
     char* previous = NULL;
     kstring_t linebuf = { 0, 0, NULL };
     kputsn("", 0, &linebuf);
+    int ret;
 
-    while (sam_read1(fp, h, b) >= 0) {
+    while ((ret = sam_read1(fp, h, b)) >= 0) {
         if (b->core.flag&(BAM_FSECONDARY|BAM_FSUPPLEMENTARY)) continue; // skip secondary and supplementary alignments
         ++n_reads;
 
@@ -733,6 +775,11 @@ int main_bam2fq(int argc, char *argv[])
         }
     }
 
+    if (ret < -1) {
+        fprintf(stderr, "[bam2fq] ERROR: failed to decode sequence\n");
+        return 1;
+    }
+
     if (fpse) {
         if ( previous ) { // Nothing left to match it's a singleton
             ++n_singletons;
@@ -751,6 +798,7 @@ int main_bam2fq(int argc, char *argv[])
 
     fprintf(stderr, "[M::%s] processed %" PRId64 " reads\n", __func__, n_reads);
 
+    sam_global_args_free(&ga);
     free(buf);
     bam_destroy1(b);
     bam_hdr_destroy(h);

--- a/samtools.1
+++ b/samtools.1
@@ -1265,7 +1265,7 @@ BAM\(->SAM\(->BAM conversion.
 
 By default this command outputs the BAM or CRAM file to standard
 output (stdout), but for CRAM format files it has the option to
-perform an insitu edit, both reading and writing to the same file.  No
+perform an in-situ edit, both reading and writing to the same file.  No
 validity checking is performed on the header, nor that it is suitable
 to use with the sequence data itself.
 
@@ -1275,8 +1275,8 @@ to use with the sequence data itself.
 .B -P, --no-PG
 Do not generate an @PG header line.
 .TP 8
-.B -I, --insitu
-Perform the header edit insitu, if possible.  This only works on CRAM
+.B -I, --in-place
+Perform the header edit in-place, if possible.  This only works on CRAM
 files and only if there is sufficient room to store the new header.
 The amount of space available will differ for each CRAM file.
 .RE

--- a/test/split/test_expand_format_string.c
+++ b/test/split/test_expand_format_string.c
@@ -85,7 +85,7 @@ int main(int argc, char**argv)
 
     // test
     xfreopen(tempfname, "w", stderr); // Redirect stderr to pipe
-    char* output_1 = expand_format_string(format_string_1, basename_1, rg_id_1, rg_idx_1);
+    char* output_1 = expand_format_string(format_string_1, basename_1, rg_id_1, rg_idx_1, NULL);
     fclose(stderr);
 
     if (verbose) printf("END RUN test 1\n");

--- a/test/split/test_parse_args.c
+++ b/test/split/test_parse_args.c
@@ -38,7 +38,7 @@ bool check_test_1(const parsed_opts_t* opts) {
     if ( opts->merged_input_name != NULL
         || opts->unaccounted_header_name != NULL
         || opts->unaccounted_name != NULL
-        || strcmp(opts->output_format_string,"%*_%#.bam")
+        || strcmp(opts->output_format_string,"%*_%#.%f")
         || opts->verbose == true )
         return false;
     return true;
@@ -57,7 +57,7 @@ bool check_test_2(const parsed_opts_t* opts) {
         || strcmp(opts->merged_input_name, "merged.bam")
         || opts->unaccounted_header_name != NULL
         || opts->unaccounted_name != NULL
-        || strcmp(opts->output_format_string,"%*_%#.bam")
+        || strcmp(opts->output_format_string,"%*_%#.%f")
         || opts->verbose == true )
         return false;
     return true;

--- a/test/test.pl
+++ b/test/test.pl
@@ -2256,7 +2256,8 @@ sub test_reheader
 
     # Create local BAM and CRAM inputs
     system("$$opts{bin}/samtools view -b $fn.sam > $fn.bam")  == 0 or die "failed to create bam: $?";
-    system("$$opts{bin}/samtools view -C $fn.sam > $fn.cram") == 0 or die "failed to create cram: $?";
+    system("$$opts{bin}/samtools view -C --output-fmt-option version=2.1 $fn.sam > $fn.v21.cram") == 0 or die "failed to create cram: $?";
+    system("$$opts{bin}/samtools view -C --output-fmt-option version=3.0 $fn.sam > $fn.v30.cram") == 0 or die "failed to create cram: $?";
 
     # Fudge @PG lines.  The version number will differ each commit.
     # Also the pathname will differ for each install. We'll take it on faith
@@ -2270,13 +2271,25 @@ sub test_reheader
     test_cmd($opts,
 	     out=>'reheader/2_view1.sam.expected',
 	     err=>'reheader/2_view1.sam.expected.err',
-	     cmd=>"$$opts{bin}/samtools reheader $$opts{path}/reheader/hdr.sam $fn.cram | $$opts{bin}/samtools view -h | perl -pe 's/\tVN:.*//'",
+	     cmd=>"$$opts{bin}/samtools reheader $$opts{path}/reheader/hdr.sam $fn.v21.cram | $$opts{bin}/samtools view -h | perl -pe 's/\tVN:.*//'",
+	     expect_fail=>0);
+
+    test_cmd($opts,
+	     out=>'reheader/2_view1.sam.expected',
+	     err=>'reheader/2_view1.sam.expected.err',
+	     cmd=>"$$opts{bin}/samtools reheader $$opts{path}/reheader/hdr.sam $fn.v30.cram | $$opts{bin}/samtools view -h | perl -pe 's/\tVN:.*//'",
 	     expect_fail=>0);
 
     # Insitu testing
     test_cmd($opts,
 	     out=>'reheader/3_view1.sam.expected',
 	     err=>'reheader/3_view1.sam.expected.err',
-	     cmd=>"$$opts{bin}/samtools reheader --in-place $$opts{path}/reheader/hdr.sam $fn.cram && $$opts{bin}/samtools view -h $fn.cram | perl -pe 's/\tVN:.*//'",
+	     cmd=>"$$opts{bin}/samtools reheader --in-place $$opts{path}/reheader/hdr.sam $fn.v21.cram && $$opts{bin}/samtools view -h $fn.cram | perl -pe 's/\tVN:.*//'",
+	     expect_fail=>0);
+
+    test_cmd($opts,
+	     out=>'reheader/3_view1.sam.expected',
+	     err=>'reheader/3_view1.sam.expected.err',
+	     cmd=>"$$opts{bin}/samtools reheader --in-place $$opts{path}/reheader/hdr.sam $fn.v30.cram && $$opts{bin}/samtools view -h $fn.cram | perl -pe 's/\tVN:.*//'",
 	     expect_fail=>0);
 }

--- a/test/test.pl
+++ b/test/test.pl
@@ -164,7 +164,7 @@ sub test_cmd
     print "\t$args{cmd}\n";
 
     my ($ret,$out,$err) = _cmd("$args{cmd}");
-    if ( $args{want_fail}? ($ret == 0) : ($ret != 0) ) { failed($opts,%args,msg=>$test); return; }
+    if ( $args{want_fail}? ($ret == 0) : ($ret != 0) ) { failed($opts,%args,msg=>$test,reason=>"ERR: $err"); return; }
     if ( $$opts{redo_outputs} && -e "$$opts{path}/$args{out}" )
     {
         rename("$$opts{path}/$args{out}","$$opts{path}/$args{out}.old");
@@ -2284,12 +2284,12 @@ sub test_reheader
     test_cmd($opts,
 	     out=>'reheader/3_view1.sam.expected',
 	     err=>'reheader/3_view1.sam.expected.err',
-	     cmd=>"$$opts{bin}/samtools reheader --in-place $$opts{path}/reheader/hdr.sam $fn.v21.cram && $$opts{bin}/samtools view -h $fn.cram | perl -pe 's/\tVN:.*//'",
+	     cmd=>"$$opts{bin}/samtools reheader --in-place $$opts{path}/reheader/hdr.sam $fn.v21.cram && $$opts{bin}/samtools view -h $fn.v21.cram | perl -pe 's/\tVN:.*//'",
 	     expect_fail=>0);
 
     test_cmd($opts,
 	     out=>'reheader/3_view1.sam.expected',
 	     err=>'reheader/3_view1.sam.expected.err',
-	     cmd=>"$$opts{bin}/samtools reheader --in-place $$opts{path}/reheader/hdr.sam $fn.v30.cram && $$opts{bin}/samtools view -h $fn.cram | perl -pe 's/\tVN:.*//'",
+	     cmd=>"$$opts{bin}/samtools reheader --in-place $$opts{path}/reheader/hdr.sam $fn.v30.cram && $$opts{bin}/samtools view -h $fn.v30.cram | perl -pe 's/\tVN:.*//'",
 	     expect_fail=>0);
 }

--- a/test/test.pl
+++ b/test/test.pl
@@ -2277,6 +2277,6 @@ sub test_reheader
     test_cmd($opts,
 	     out=>'reheader/3_view1.sam.expected',
 	     err=>'reheader/3_view1.sam.expected.err',
-	     cmd=>"$$opts{bin}/samtools reheader --insitu $$opts{path}/reheader/hdr.sam $fn.cram && $$opts{bin}/samtools view -h $fn.cram | perl -pe 's/\tVN:.*//'",
+	     cmd=>"$$opts{bin}/samtools reheader --in-place $$opts{path}/reheader/hdr.sam $fn.cram && $$opts{bin}/samtools view -h $fn.cram | perl -pe 's/\tVN:.*//'",
 	     expect_fail=>0);
 }


### PR DESCRIPTION
NOTE: contains the merge of output-fmt-option and appropriate fixes to get this working with the reheader code.

This was necessary in order to be able to test both version 2.1 and version 3.0 CRAM file functionality in samtools reheader.  This is vital given the code has two explicit code paths for each format version, but without the output-fmt-option branch there is no way for samtools test harness to control the file format versions being used.