### PR TITLE
Clarify `samtools sort` usage

### DIFF
--- a/bam_sort.c
+++ b/bam_sort.c
@@ -1163,14 +1163,15 @@ int bam_sort_core(int is_by_qname, const char *fn, const char *prefix, size_t ma
 static int sort_usage(FILE *fp, int status)
 {
     fprintf(fp,
-"Usage: samtools sort [options...] [in.bam]\n"
+"Usage: samtools sort -T PREFIX [options...] [in.bam]\n"
 "Options:\n"
 "  -l INT     Set compression level, from 0 (uncompressed) to 9 (best)\n"
 "  -m INT     Set maximum memory per thread; suffix K/M/G recognized [768M]\n"
 "  -n         Sort by read name\n"
 "  -o FILE    Write final output to FILE rather than standard output\n"
-"  -O FORMAT  Write output as FORMAT ('sam'/'bam'/'cram')   (either -O or\n"
-"  -T PREFIX  Write temporary files to PREFIX.nnnn.bam       -T is required)\n"
+"  -O FORMAT  Write output as FORMAT ('sam'/'bam'/'cram') if not same as input\n"
+"  -T PREFIX  Write temporary files to PREFIX.nnnn.bam\n"
+"             Note that -T is a required option for non-legacy usage\n"
 "  -@ INT     Set number of sorting and compression threads [1]\n"
 "\n"
 "Legacy usage: samtools sort [options...] <in.bam> <out.prefix>\n"
@@ -1233,9 +1234,15 @@ int bam_sort(int argc, char *argv[])
     strcpy(modeout, "w");
     if (sam_open_mode(&modeout[1], fnout, fmtout) < 0) {
         if (fmtout) fprintf(stderr, "[bam_sort] can't parse output format \"%s\"\n", fmtout);
-        else fprintf(stderr, "[bam_sort] can't determine output format\n");
-        ret = EXIT_FAILURE;
-        goto sort_end;
+        else{
+            // If modern but not supplied with -O, attempt to infer format
+            // with input before aborting with failure (if not modern, abort anyway)
+            if (!(modern && sam_open_mode(&modeout[1], argv[optind], fmtout) >= 0)){
+                fprintf(stderr, "[bam_sort] can't determine output format\n");
+                ret = EXIT_FAILURE;
+                goto sort_end;
+            }
+        }
     }
     if (level >= 0) sprintf(strchr(modeout, '\0'), "%d", level < 9? level : 9);
 


### PR DESCRIPTION
In the hope of closing #418, #295 and finally putting end-user confusion of
`samtools sort` to bed, I present the following minor patch:

* Add `-T PREFIX` to example usage to clarify it is in theory a
  "required option" to use non-legacy functionality.
* Add note below description of `-T` that it is a required option for
  non-legacy functionality.
* If the modern flag is up without setting output format with -O, recall
  `sam_open_mode` with the input file as `fnout` to automatically infer the
  output file format to match the input, thus no longer requiring -O for
  modern usage.