### PR TITLE
Enable travis OS X to test cross platform bugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 # Control file for continuous integration testing at http://travis-ci.org/
 
+os:
+  - linux
+  - osx
+
 language: c
 compiler:
   - clang


### PR DESCRIPTION
-Enable travis "osx" platform
-Add brew install xz to "osx"
-Disable sudo so that we deploy onto travis container infrastructure.