### PR TITLE
Fix warnings from adding HTS_RESULT_USED to htslib prototypes.

### DIFF
--- a/bam.c
+++ b/bam.c
@@ -34,15 +34,22 @@ char *bam_format1(const bam_header_t *header, const bam1_t *b)
 {
     kstring_t str;
     str.l = str.m = 0; str.s = NULL;
-    sam_format1(header, b, &str);
+    if (sam_format1(header, b, &str) < 0) {
+        free(str.s);
+        str.s = NULL;
+        return NULL;
+    }
     return str.s;
 }
 
-void bam_view1(const bam_header_t *header, const bam1_t *b)
+int bam_view1(const bam_header_t *header, const bam1_t *b)
 {
     char *s = bam_format1(header, b);
-    puts(s);
+    int ret = -1;
+    if (!s) return -1;
+    if (puts(s) != EOF) ret = 0;
     free(s);
+    return ret;
 }
 
 int bam_validate1(const bam_header_t *header, const bam1_t *b)

--- a/bam.h
+++ b/bam.h
@@ -322,8 +322,11 @@ extern "C" {
      */
     char *bam_format1(const bam_header_t *header, const bam1_t *b);
 
-    /*! @abstract     Formats a BAM record and writes it and \n to stdout */
-    void bam_view1(const bam_header_t *header, const bam1_t *b);
+    /*!
+      @abstract     Formats a BAM record and writes it and \n to stdout
+      @return       0 if successful, -1 on error 
+    */
+    int bam_view1(const bam_header_t *header, const bam1_t *b);
 
     /*!
       @abstract       Check whether a BAM record is plausibly valid

--- a/bam_cat.c
+++ b/bam_cat.c
@@ -51,8 +51,8 @@ Illumina.
 
 int bam_cat(int nfn, char * const *fn, const bam_header_t *h, const char* outbam)
 {
-    BGZF *fp;
-    uint8_t *buf;
+    BGZF *fp, *in = NULL;
+    uint8_t *buf = NULL;
     uint8_t ebuf[BGZF_EMPTY_BLOCK_SIZE];
     const int es=BGZF_EMPTY_BLOCK_SIZE;
     int i;
@@ -65,15 +65,18 @@ int bam_cat(int nfn, char * const *fn, const bam_header_t *h, const char* outbam
     if (h) bam_header_write(fp, h);
 
     buf = (uint8_t*) malloc(BUF_SIZE);
+    if (!buf) {
+        fprintf(stderr, "[%s] Couldn't allocate buffer\n", __func__);
+        goto fail;
+    }
     for(i = 0; i < nfn; ++i){
-        BGZF *in;
         bam_header_t *old;
         int len,j;
 
         in = strcmp(fn[i], "-")? bgzf_open(fn[i], "r") : bgzf_fdopen(fileno(stdin), "r");
         if (in == 0) {
             fprintf(stderr, "[%s] ERROR: fail to open file '%s'.\n", __func__, fn[i]);
-            return -1;
+            goto fail;
         }
         if (in->is_write) return -1;
 
@@ -81,14 +84,13 @@ int bam_cat(int nfn, char * const *fn, const bam_header_t *h, const char* outbam
         if (old == NULL) {
             fprintf(stderr, "[%s] ERROR: couldn't read header for '%s'.\n",
                     __func__, fn[i]);
-            bgzf_close(in);
-            return -1;
+            goto fail;
         }
         if (h == 0 && i == 0) bam_header_write(fp, old);
 
         if (in->block_offset < in->block_length) {
-            bgzf_write(fp, in->uncompressed_block + in->block_offset, in->block_length - in->block_offset);
-            bgzf_flush(fp);
+            if (bgzf_write(fp, in->uncompressed_block + in->block_offset, in->block_length - in->block_offset) < 0) goto write_fail;
+            if (bgzf_flush(fp) != 0) goto write_fail;
         }
 
         j=0;
@@ -97,16 +99,19 @@ int bam_cat(int nfn, char * const *fn, const bam_header_t *h, const char* outbam
                 int diff=es-len;
                 if(j==0) {
                     fprintf(stderr, "[%s] ERROR: truncated file?: '%s'.\n", __func__, fn[i]);
-                    return -1;
+                    goto fail;
                 }
-                bgzf_raw_write(fp, ebuf, len);
+                if (bgzf_raw_write(fp, ebuf, len) < 0) goto write_fail;
+                
                 memcpy(ebuf,ebuf+len,diff);
                 memcpy(ebuf+diff,buf,len);
             } else {
-                if(j!=0) bgzf_raw_write(fp, ebuf, es);
+                if(j!=0) {
+                    if (bgzf_raw_write(fp, ebuf, es) < 0) goto write_fail;
+                }
                 len-= es;
                 memcpy(ebuf,buf+len,es);
-                bgzf_raw_write(fp, buf, len);
+                if (bgzf_raw_write(fp, buf, len) < 0) goto write_fail;
             }
             j=1;
         }
@@ -119,15 +124,27 @@ int bam_cat(int nfn, char * const *fn, const bam_header_t *h, const char* outbam
             if(((gzip1!=GZIPID1) || (gzip2!=GZIPID2)) || (isize!=0)) {
                 fprintf(stderr, "[%s] WARNING: Unexpected block structure in file '%s'.", __func__, fn[i]);
                 fprintf(stderr, " Possible output corruption.\n");
-                bgzf_raw_write(fp, ebuf, es);
+                if (bgzf_raw_write(fp, ebuf, es) < 0) goto write_fail;
             }
         }
         bam_header_destroy(old);
         bgzf_close(in);
+        in = NULL;
     }
     free(buf);
-    bgzf_close(fp);
+    if (bgzf_close(fp) < 0) {
+        fprintf(stderr, "[%s] Error on closing '%s'.\n", __func__, outbam);
+        return -1;
+    }
     return 0;
+
+ write_fail:
+    fprintf(stderr, "[%s] Error writing to '%s'.\n", __func__, outbam);
+ fail:
+    if (in) bgzf_close(in);
+    if (fp) bgzf_close(fp);
+    free(buf);
+    return -1;
 }
 
 

--- a/bam_md.c
+++ b/bam_md.c
@@ -332,11 +332,11 @@ int bam_prob_realn(bam1_t *b, const char *ref)
 int bam_fillmd(int argc, char *argv[])
 {
     int c, flt_flag, tid = -2, ret, len, is_bam_out, is_uncompressed, max_nm, is_realn, capQ, baq_flag;
-    samFile *fp, *fpout = 0;
-    bam_hdr_t *header;
-    faidx_t *fai;
+    samFile *fp = 0, *fpout = 0;
+    bam_hdr_t *header = NULL;
+    faidx_t *fai = 0;
     char *ref = 0, mode_w[8];
-    bam1_t *b;
+    bam1_t *b = NULL;
 
     flt_flag = UPDATE_NM | UPDATE_MD;
     is_bam_out = is_uncompressed = is_realn = max_nm = capQ = baq_flag = 0;
@@ -375,29 +375,50 @@ int bam_fillmd(int argc, char *argv[])
         return 1;
     }
     fp = sam_open(argv[optind], "r");
-    if (fp == 0) return 1;
+    if (fp == NULL) {
+        fprintf(stderr,
+                "[bam_fillmd] Failed to open input file '%s'\n", argv[optind]);
+        return 1;
+    }
 
     header = sam_hdr_read(fp);
     if (header == NULL || header->n_targets == 0) {
         fprintf(stderr, "[bam_fillmd] input SAM does not have header. Abort!\n");
-        return 1;
+        goto fail;
     }
 
     fpout = sam_open("-", mode_w);
-    sam_hdr_write(fpout, header);
+    if (fpout == NULL) {
+        fprintf(stderr, "[bam_fillmd] Failed to open output\n");
+        goto fail;
+    }
+    if (sam_hdr_write(fpout, header) < 0) {
+        fprintf(stderr, "[bam_fillmd] Failed to write sam header\n");
+        goto fail;
+    }
 
     fai = fai_load(argv[optind+1]);
+    if (!fai) {
+        fprintf(stderr, "[bam_fillmd] Failed to load reference index\n");
+        goto fail;
+    }
 
     b = bam_init1();
+    if (!b) {
+        fprintf(stderr, "[bam_fillmd] Failed to allocate bam struct\n");
+        goto fail;
+    }
     while ((ret = sam_read1(fp, header, b)) >= 0) {
         if (b->core.tid >= 0) {
             if (tid != b->core.tid) {
                 free(ref);
                 ref = fai_fetch(fai, header->target_name[b->core.tid], &len);
                 tid = b->core.tid;
-                if (ref == 0)
+                if (ref == 0) { // FIXME: Should this always be fatal?
                     fprintf(stderr, "[bam_fillmd] fail to find sequence '%s' in the reference.\n",
                             header->target_name[tid]);
+                    if (is_realn || capQ > 10) goto fail; // Would otherwise crash
+                }
             }
             if (is_realn) bam_prob_realn_core(b, ref, len, baq_flag);
             if (capQ > 10) {
@@ -406,7 +427,14 @@ int bam_fillmd(int argc, char *argv[])
             }
             if (ref) bam_fillmd1_core(b, ref, len, flt_flag, max_nm);
         }
-        sam_write1(fpout, header, b);
+        if (sam_write1(fpout, header, b) < 0) {
+            fprintf(stderr, "[bam_fillmd] failed to write to output file\n");
+            goto fail;
+        }
+    }
+    if (ret < -1) {
+        fprintf(stderr, "[bam_fillmd] Error reading input.\n");
+        goto fail;
     }
     bam_destroy1(b);
     bam_hdr_destroy(header);
@@ -414,6 +442,18 @@ int bam_fillmd(int argc, char *argv[])
     free(ref);
     fai_destroy(fai);
     sam_close(fp);
-    sam_close(fpout);
+    if (sam_close(fpout) < 0) {
+        fprintf(stderr, "[bam_fillmd] error when closing output file\n");
+        return 1;
+    }
     return 0;
+
+ fail:
+    free(ref);
+    if (b) bam_destroy1(b);
+    if (header) bam_hdr_destroy(header);
+    if (fai) fai_destroy(fai);
+    if (fp) sam_close(fp);
+    if (fpout) sam_close(fpout);
+    return 1;
 }

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -545,6 +545,7 @@ int* rtrans_build(int n, int n_targets, trans_tbl_t* translation_tbl)
     // Create reverse translation table for tids
     int* rtrans = (int*)malloc(sizeof(int32_t)*n*n_targets);
     const int32_t NOTID = INT32_MIN;
+    if (!rtrans) return NULL;
     memset_pattern4((void*)rtrans, &NOTID, sizeof(int32_t)*n*n_targets);
     int i;
     for (i = 0; i < n; ++i) {
@@ -605,8 +606,8 @@ int* rtrans_build(int n, int n_targets, trans_tbl_t* translation_tbl)
  */
 int bam_merge_core2(int by_qname, const char *out, const char *mode, const char *headers, int n, char * const *fn, int flag, const char *reg, int n_threads)
 {
-    samFile *fpout, **fp;
-    heap1_t *heap;
+    samFile *fpout, **fp = NULL;
+    heap1_t *heap = NULL;
     bam_hdr_t *hout = NULL;
     int i, j, *RG_len = NULL;
     uint64_t idx = 0;
@@ -614,6 +615,7 @@ int bam_merge_core2(int by_qname, const char *out, const char *mode, const char 
     hts_itr_t **iter = NULL;
     bam_hdr_t **hdr = NULL;
     trans_tbl_t *translation_tbl = NULL;
+    int *rtrans = NULL;
 
     // Is there a specified pre-prepared header to use for output?
     if (headers) {
@@ -632,19 +634,32 @@ int bam_merge_core2(int by_qname, const char *out, const char *mode, const char 
         }
     } else  {
         hout = bam_hdr_init();
+        if (!hout) {
+            fprintf(stderr, "[bam_merge_core] couldn't allocate bam header\n");
+            return -1;
+        }
         hout->text = strdup("");
+        if (!hout->text) goto mem_fail;
     }
 
     g_is_by_qname = by_qname;
     fp = (samFile**)calloc(n, sizeof(samFile*));
+    if (!fp) goto mem_fail;
     heap = (heap1_t*)calloc(n, sizeof(heap1_t));
+    if (!heap) goto mem_fail;
     iter = (hts_itr_t**)calloc(n, sizeof(hts_itr_t*));
+    if (!iter) goto mem_fail;
     hdr = (bam_hdr_t**)calloc(n, sizeof(bam_hdr_t*));
+    if (!hdr) goto mem_fail;
     translation_tbl = (trans_tbl_t*)calloc(n, sizeof(trans_tbl_t));
+    if (!translation_tbl) goto mem_fail;
     RG = (char**)calloc(n, sizeof(char*));
+    if (!RG) goto mem_fail;
+
     // prepare RG tag from file names
     if (flag & MERGE_RG) {
         RG_len = (int*)calloc(n, sizeof(int));
+        if (!RG_len) goto mem_fail;
         for (i = 0; i != n; ++i) {
             int l = strlen(fn[i]);
             const char *s = fn[i];
@@ -653,6 +668,7 @@ int bam_merge_core2(int by_qname, const char *out, const char *mode, const char 
             for (j = l - 1; j >= 0; --j) if (s[j] == '/') break;
             ++j; l -= j;
             RG[i] = (char*)calloc(l + 1, 1);
+            if (!RG[i]) goto mem_fail;
             RG_len[i] = l;
             strncpy(RG[i], s + j, l);
         }
@@ -662,27 +678,14 @@ int bam_merge_core2(int by_qname, const char *out, const char *mode, const char 
         bam_hdr_t *hin;
         fp[i] = sam_open(fn[i], "r");
         if (fp[i] == NULL) {
-            int j;
             fprintf(stderr, "[bam_merge_core] fail to open file %s\n", fn[i]);
-            for (j = 0; j < i; ++j) {
-                bam_hdr_destroy(hdr[i]);
-                sam_close(fp[j]);
-            }
-            free(fp); free(heap);
-            // FIXME: possible memory leak
-            return -1;
+            goto fail;
         }
         hin = sam_hdr_read(fp[i]);
         if (hin == NULL) {
             fprintf(stderr, "[bam_merge_core] failed to read header for '%s'\n",
                     fn[i]);
-            for (j = 0; j < i; ++j) {
-                bam_hdr_destroy(hdr[i]);
-                sam_close(fp[j]);
-            }
-            free(fp); free(heap);
-            // FIXME: possible memory leak
-            return -1;
+            goto fail;
         }
 
         trans_tbl_init(hout, hin, translation_tbl+i, flag & MERGE_COMBINE_RG, flag & MERGE_COMBINE_PG, RG[i]);
@@ -702,12 +705,16 @@ int bam_merge_core2(int by_qname, const char *out, const char *mode, const char 
 
     // If we're only merging a specified region move our iters to start at that point
     if (reg) {
-        int* rtrans = rtrans_build(n, hout->n_targets, translation_tbl);
-
         int tid, beg, end;
-        const char *name_lim = hts_parse_reg(reg, &beg, &end);
+        const char *name_lim;
+
+        rtrans = rtrans_build(n, hout->n_targets, translation_tbl);
+        if (!rtrans) goto mem_fail;
+
+        name_lim = hts_parse_reg(reg, &beg, &end);
         if (name_lim) {
             char *name = malloc(name_lim - reg + 1);
+            if (!name) goto mem_fail;
             memcpy(name, reg, name_lim - reg);
             name[name_lim - reg] = '\0';
             tid = bam_name2id(hout, name);
@@ -722,7 +729,7 @@ int bam_merge_core2(int by_qname, const char *out, const char *mode, const char 
         if (tid < 0) {
             if (name_lim) fprintf(stderr, "[%s] Region \"%s\" specifies an unknown reference name\n", __func__, reg);
             else fprintf(stderr, "[%s] Badly formatted region: \"%s\"\n", __func__, reg);
-            return -1;
+            goto fail;
         }
         for (i = 0; i < n; ++i) {
             hts_idx_t *idx = sam_index_load(fp[i], fn[i]);
@@ -731,7 +738,7 @@ int bam_merge_core2(int by_qname, const char *out, const char *mode, const char 
             if (idx == NULL) {
                 fprintf(stderr, "[%s] failed to load index for %s.  Random alignment retrieval only works for indexed BAM or CRAM files.\n",
                         __func__, fn[i]);
-                return -1;
+                goto fail;
             }
             if (mapped_tid != INT32_MIN) {
                 iter[i] = sam_itr_queryi(idx, mapped_tid, beg, end);
@@ -739,38 +746,57 @@ int bam_merge_core2(int by_qname, const char *out, const char *mode, const char 
                 iter[i] = sam_itr_queryi(idx, HTS_IDX_NONE, 0, 0);
             }
             hts_idx_destroy(idx);
-            if (iter[i] == NULL) break;
+            if (iter[i] == NULL) {
+                if (mapped_tid != INT32_MIN) {
+                    fprintf(stderr,
+                            "[%s] failed to get iterator over "
+                            "{%s, %d, %d, %d}\n",
+                            __func__, fn[i], mapped_tid, beg, end);
+                } else {
+                    fprintf(stderr,
+                            "[%s] failed to get iterator over "
+                            "{%s, HTS_IDX_NONE, 0, 0}\n",
+                            __func__, fn[i]);
+                }
+                goto fail;
+            }
         }
         free(rtrans);
+        rtrans = NULL;
     } else {
         for (i = 0; i < n; ++i) {
             if (hdr[i] == NULL) {
                 iter[i] = sam_itr_queryi(NULL, HTS_IDX_REST, 0, 0);
-                if (iter[i] == NULL) break;
+                if (iter[i] == NULL) {
+                    fprintf(stderr, "[%s] failed to get iterator\n", __func__);
+                    goto fail;
+                }
             }
             else iter[i] = NULL;
         }
     }
 
-    if (i < n) {
-        fprintf(stderr, "[%s] Memory allocation failed\n", __func__);
-        return -1;
-    }
-
     // Load the first read from each file into the heap
     for (i = 0; i < n; ++i) {
         heap1_t *h = heap + i;
+        int res;
         h->i = i;
         h->b = bam_init1();
-        if ((iter[i]? sam_itr_next(fp[i], iter[i], h->b) : sam_read1(fp[i], hdr[i], h->b)) >= 0) {
+        if (!h->b) goto mem_fail;
+        res = iter[i] ? sam_itr_next(fp[i], iter[i], h->b) : sam_read1(fp[i], hdr[i], h->b);
+        if (res >= 0) {
             bam_translate(h->b, translation_tbl + i);
             h->pos = ((uint64_t)h->b->core.tid<<32) | (uint32_t)((int32_t)h->b->core.pos+1)<<1 | bam_is_rev(h->b);
             h->idx = idx++;
         }
-        else {
+        else if (res == -1 && (!iter[i] || iter[i]->finished)) {
             h->pos = HEAP_EMPTY;
             bam_destroy1(h->b);
             h->b = NULL;
+        } else {
+            fprintf(stderr, "[%s] failed to read first record from %s\n",
+                    __func__, fn[i]);
+            goto fail;
         }
     }
 
@@ -779,7 +805,11 @@ int bam_merge_core2(int by_qname, const char *out, const char *mode, const char 
         fprintf(stderr, "[%s] fail to create the output file.\n", __func__);
         return -1;
     }
-    sam_hdr_write(fpout, hout);
+    if (sam_hdr_write(fpout, hout) != 0) {
+        fprintf(stderr, "[%s] failed to write header.\n", __func__);
+        sam_close(fpout);
+        return -1;
+    }
     if (!(flag & MERGE_UNCOMP)) hts_set_threads(fpout, n_threads);
 
     // Begin the actual merge
@@ -791,16 +821,24 @@ int bam_merge_core2(int by_qname, const char *out, const char *mode, const char 
             if (rg) bam_aux_del(b, rg);
             bam_aux_append(b, "RG", 'Z', RG_len[heap->i] + 1, (uint8_t*)RG[heap->i]);
         }
-        sam_write1(fpout, hout, b);
+        if (sam_write1(fpout, hout, b) < 0) {
+            fprintf(stderr, "[%s] failed to write to output file.\n", __func__);
+            sam_close(fpout);
+            return -1;
+        }
         if ((j = (iter[heap->i]? sam_itr_next(fp[heap->i], iter[heap->i], b) : sam_read1(fp[heap->i], hdr[heap->i], b))) >= 0) {
             bam_translate(b, translation_tbl + heap->i);
             heap->pos = ((uint64_t)b->core.tid<<32) | (uint32_t)((int)b->core.pos+1)<<1 | bam_is_rev(b);
             heap->idx = idx++;
-        } else if (j == -1) {
+        } else if (j == -1 && (!iter[heap->i] || iter[heap->i]->finished)) {
             heap->pos = HEAP_EMPTY;
             bam_destroy1(heap->b);
             heap->b = NULL;
-        } else fprintf(stderr, "[bam_merge_core] '%s' is truncated. Continue anyway.\n", fn[heap->i]);
+        } else {
+            fprintf(stderr, "[bam_merge_core] error: '%s' is truncated.\n",
+                    fn[heap->i]);
+            goto fail;
+        }
         ks_heapadjust(heap, 0, n, heap);
     }
 
@@ -816,9 +854,39 @@ int bam_merge_core2(int by_qname, const char *out, const char *mode, const char 
         sam_close(fp[i]);
     }
     bam_hdr_destroy(hout);
-    sam_close(fpout);
     free(RG); free(translation_tbl); free(fp); free(heap); free(iter); free(hdr);
+    if (sam_close(fpout) < 0) {
+        fprintf(stderr, "[bam_merge_core] error closing output file\n");
+        return -1;
+    }
     return 0;
+
+ mem_fail:
+    fprintf(stderr, "[bam_merge_core] Out of memory\n");
+
+ fail:
+    if (flag & MERGE_RG) {
+        if (RG) {
+            for (i = 0; i != n; ++i) free(RG[i]);
+        }
+        free(RG_len);
+    }
+    for (i = 0; i < n; ++i) {
+        if (translation_tbl) trans_tbl_destroy(translation_tbl + i);
+        if (iter && iter[i]) hts_itr_destroy(iter[i]);
+        if (hdr && hdr[i]) bam_hdr_destroy(hdr[i]);
+        if (fp && fp[i]) sam_close(fp[i]);
+        if (heap && heap[i].b) bam_destroy1(heap[i].b);
+    }
+    if (hout) bam_hdr_destroy(hout);
+    free(RG);
+    free(translation_tbl);
+    free(hdr);
+    free(iter);
+    free(heap);
+    free(fp);
+    free(rtrans);
+    return -1;
 }
 
 int bam_merge_core(int by_qname, const char *out, const char *headers, int n, char * const *fn, int flag, const char *reg)
@@ -994,29 +1062,34 @@ typedef struct {
     bam1_p *buf;
     const bam_hdr_t *h;
     int index;
+    int error;
 } worker_t;
 
-static void write_buffer(const char *fn, const char *mode, size_t l, bam1_p *buf, const bam_hdr_t *h, int n_threads)
+static int write_buffer(const char *fn, const char *mode, size_t l, bam1_p *buf, const bam_hdr_t *h, int n_threads)
 {
     size_t i;
     samFile* fp;
     fp = sam_open(fn, mode);
-    if (fp == NULL) return;
-    sam_hdr_write(fp, h);
+    if (fp == NULL) return -1;
+    if (sam_hdr_write(fp, h) != 0) return -1;
     if (n_threads > 1) hts_set_threads(fp, n_threads);
-    for (i = 0; i < l; ++i)
-        sam_write1(fp, h, buf[i]);
-    sam_close(fp);
+    for (i = 0; i < l; ++i) {
+        if (sam_write1(fp, h, buf[i]) < 0) return -1;
+    }
+    if (sam_close(fp) < 0) return -1;
+    return 0;
 }
 
 static void *worker(void *data)
 {
     worker_t *w = (worker_t*)data;
     char *name;
+    w->error = -1;
     ks_mergesort(sort, w->buf_len, w->buf, 0);
     name = (char*)calloc(strlen(w->prefix) + 20, 1);
+    if (!name) return 0;
     sprintf(name, "%s.%.4d.bam", w->prefix, w->index);
-    write_buffer(name, "wb1", w->buf_len, w->buf, w->h, 0);
+    w->error = write_buffer(name, "wb1", w->buf_len, w->buf, w->h, 0);
     free(name);
     return 0;
 }
@@ -1029,6 +1102,7 @@ static int sort_blocks(int n_files, size_t k, bam1_p *buf, const char *prefix, c
     pthread_t *tid;
     pthread_attr_t attr;
     worker_t *w;
+    int res = 0;
 
     if (n_threads < 1) n_threads = 1;
     if (k < n_threads * 64) n_threads = 1; // use a single thread if we only sort a small batch of records
@@ -1046,9 +1120,12 @@ static int sort_blocks(int n_files, size_t k, bam1_p *buf, const char *prefix, c
         b += w[i].buf_len; rest -= w[i].buf_len;
         pthread_create(&tid[i], &attr, worker, &w[i]);
     }
-    for (i = 0; i < n_threads; ++i) pthread_join(tid[i], 0);
+    for (i = 0; i < n_threads; ++i) {
+        pthread_join(tid[i], 0);
+        res |= w[i].error;
+    }
     free(tid); free(w);
-    return n_files + n_threads;
+    return res == 0 ? n_files + n_threads : -1;
 }
 
 /*!
@@ -1112,6 +1189,11 @@ int bam_sort_core_ext(int is_by_qname, const char *fn, const char *prefix, const
         ++k;
         if (mem >= max_mem) {
             n_files = sort_blocks(n_files, k, buf, prefix, header, n_threads);
+            if (n_files < 0) {
+                fprintf(stderr, "[bam_sort_core] error sorting blocks.\n");
+                ret = -1;
+                goto err;
+            }
             mem = k = 0;
         }
     }
@@ -1124,7 +1206,11 @@ int bam_sort_core_ext(int is_by_qname, const char *fn, const char *prefix, const
     // write the final output
     if (n_files == 0) { // a single block
         ks_mergesort(sort, k, buf, 0);
-        write_buffer(fnout, modeout, k, buf, header, n_threads);
+        if (write_buffer(fnout, modeout, k, buf, header, n_threads) != 0) {
+            fprintf(stderr, "[bam_sort_core] error writing final output.\n");
+            ret = -1;
+            goto err;
+        }
     } else { // then merge
         char **fns;
         n_files = sort_blocks(n_files, k, buf, prefix, header, n_threads);

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -1071,13 +1071,16 @@ static int write_buffer(const char *fn, const char *mode, size_t l, bam1_p *buf,
     samFile* fp;
     fp = sam_open(fn, mode);
     if (fp == NULL) return -1;
-    if (sam_hdr_write(fp, h) != 0) return -1;
+    if (sam_hdr_write(fp, h) != 0) goto fail;
     if (n_threads > 1) hts_set_threads(fp, n_threads);
     for (i = 0; i < l; ++i) {
-        if (sam_write1(fp, h, buf[i]) < 0) return -1;
+        if (sam_write1(fp, h, buf[i]) < 0) goto fail;
     }
     if (sam_close(fp) < 0) return -1;
     return 0;
+ fail:
+    sam_close(fp);
+    return -1;
 }
 
 static void *worker(void *data)

--- a/bamshuf.c
+++ b/bamshuf.c
@@ -75,14 +75,17 @@ KSORT_INIT(bamshuf, elem_t, elem_lt)
 
 static int bamshuf(const char *fn, int n_files, const char *pre, int clevel, int is_stdout)
 {
-    BGZF *fp, *fpw, **fpt;
-    char **fnt, modew[8];
-    bam1_t *b;
-    int i, l;
-    bam_hdr_t *h;
-    int64_t *cnt;
+    BGZF *fp, *fpw = NULL, **fpt = NULL;
+    char **fnt = NULL, modew[8];
+    bam1_t *b = NULL;
+    int i, l, r;
+    bam_hdr_t *h = NULL;
+    int64_t *cnt = NULL;
+    elem_t *a = NULL;
+    int64_t a_size = 0, a_first = 0, a_last = 0;
 
-    // split
+    // Read input, distribute reads pseudo-randomly into n_files temporary
+    // files.
     fp = strcmp(fn, "-")? bgzf_open(fn, "r") : bgzf_dopen(fileno(stdin), "r");
     if (fp == NULL) {
         print_error_errno("Cannot open input file \"%s\"", fn);
@@ -92,37 +95,67 @@ static int bamshuf(const char *fn, int n_files, const char *pre, int clevel, int
     h = bam_hdr_read(fp);
     if (h == NULL) {
         fprintf(stderr, "Couldn't read header for '%s'\n", fn);
-        return 1;
+        goto fail;
     }
     fnt = (char**)calloc(n_files, sizeof(char*));
+    if (!fnt) goto mem_fail;
     fpt = (BGZF**)calloc(n_files, sizeof(BGZF*));
+    if (!fpt) goto mem_fail;
     cnt = (int64_t*)calloc(n_files, 8);
+    if (!cnt) goto mem_fail;
+
     l = strlen(pre);
     for (i = 0; i < n_files; ++i) {
         fnt[i] = (char*)calloc(l + 10, 1);
+        if (!fnt[i]) goto mem_fail;
         sprintf(fnt[i], "%s.%.4d.bam", pre, i);
         fpt[i] = bgzf_open(fnt[i], "w1");
         if (fpt[i] == NULL) {
             print_error_errno("Cannot open intermediate file \"%s\"", fnt[i]);
-            return 1;
+            goto fail;
         }
-        bam_hdr_write(fpt[i], h);
+        if (bam_hdr_write(fpt[i], h) < 0) {
+            fprintf(stderr, "Couldn't write header for '%s'\n", fnt[i]);
+            goto fail;
+        }
     }
     b = bam_init1();
-    while (bam_read1(fp, b) >= 0) {
+    if (!b) goto mem_fail;
+    while ((r = bam_read1(fp, b)) >= 0) {
         uint32_t x;
         x = hash_X31_Wang(bam_get_qname(b)) % n_files;
-        bam_write1(fpt[x], b);
+        if (bam_write1(fpt[x], b) < 0) {
+            fprintf(stderr, "Couldn't write to '%s'\n", fnt[x]);
+            goto fail;
+        }
         ++cnt[x];
     }
-    bam_destroy1(b);
-    for (i = 0; i < n_files; ++i) bgzf_close(fpt[i]);
+    if (r < -1) {
+        fprintf(stderr, "Error reading input file\n");
+        goto fail;
+    } 
+    bam_destroy1(b); b = NULL;
+    for (i = 0; i < n_files; ++i) {
+        // Close split output
+        r = bgzf_close(fpt[i]);
+        fpt[i] = NULL;
+        if (r < 0) {
+            fprintf(stderr, "Error on closing '%s'\n", fnt[i]);
+            return 1;
+        }
+
+        // Find biggest count
+        if (a_size < cnt[i]) a_size = cnt[i];
+    }
     free(fpt);
+    fpt = NULL;
     bgzf_close(fp);
+    fp = NULL;
     // merge
     sprintf(modew, "w%d", (clevel >= 0 && clevel <= 9)? clevel : DEF_CLEVEL);
     if (!is_stdout) { // output to a file
         char *fnw = (char*)calloc(l + 5, 1);
+        if (!fnw) goto mem_fail;
         sprintf(fnw, "%s.bam", pre);
         fpw = bgzf_open(fnw, modew);
         free(fnw);
@@ -130,35 +163,89 @@ static int bamshuf(const char *fn, int n_files, const char *pre, int clevel, int
     if (fpw == NULL) {
         if (is_stdout) print_error_errno("Cannot open standard output");
         else print_error_errno("Cannot open output file \"%s.bam\"", pre);
-        return 1;
+        goto fail;
     }
 
-    bam_hdr_write(fpw, h);
+    if (bam_hdr_write(fpw, h) < 0) {
+        fprintf(stderr, "Couldn't write bam header\n");
+        goto fail;
+    }
     bam_hdr_destroy(h);
+    h = NULL;
+
+    a = malloc(a_size * sizeof(elem_t));
+    if (!a) goto mem_fail;
+
     for (i = 0; i < n_files; ++i) {
         int64_t j, c = cnt[i];
-        elem_t *a;
         fp = bgzf_open(fnt[i], "r");
-        bam_hdr_destroy(bam_hdr_read(fp));
-        a = (elem_t*)calloc(c, sizeof(elem_t));
+        if (NULL == fp) {
+            fprintf(stderr, "Couldn't open '%s'\n", fnt[i]);
+            goto fail;
+        }
+        bam_hdr_destroy(bam_hdr_read(fp)); // Skip over header
+
+        a_first = a_last = 0; // Track which bit of 'a' contains bam structs
+
+        // Slurp in one of the split files
         for (j = 0; j < c; ++j) {
             a[j].b = bam_init1();
-            assert(bam_read1(fp, a[j].b) >= 0);
+            if (!a[j].b) goto mem_fail;
+            a_last++;
+            if (bam_read1(fp, a[j].b) < 0) {
+                fprintf(stderr, "Error reading '%s'\n", fnt[i]);
+                goto fail;
+            }
             a[j].key = hash_X31_Wang(bam_get_qname(a[j].b));
         }
         bgzf_close(fp);
         unlink(fnt[i]);
         free(fnt[i]);
-        ks_introsort(bamshuf, c, a);
+        fnt[i] = NULL;
+
+        ks_introsort(bamshuf, c, a); // Shuffle all the reads
+
+        // Write them out again
         for (j = 0; j < c; ++j) {
-            bam_write1(fpw, a[j].b);
+            if (bam_write1(fpw, a[j].b) < 0) {
+                fprintf(stderr, "Error writing to output\n");
+                goto fail;
+            }
             bam_destroy1(a[j].b);
+            a_first++;
+        }
+    }
+    
+    free(a); free(fnt); free(cnt);
+    if (bgzf_close(fpw) < 0) {
+        fprintf(stderr, "Error on closing output\n");
+        return 1;
+    }
+    return 0;
+
+ mem_fail:
+    fprintf(stderr, "Out of memory\n");
+
+ fail:
+    if (fp) bgzf_close(fp);
+    if (fpw) bgzf_close(fpw);
+    if (h) bam_hdr_destroy(h);
+    if (b) bam_destroy1(b);
+    for (i = 0; i < n_files; ++i) {
+        if (fnt) free(fnt[i]);
+        if (fpt && fpt[i]) bgzf_close(fpt[i]);
+    }
+    if (a) {
+        int64_t j;
+        for (j = a_first; j < a_last; j++) {
+            if (a[j].b) bam_destroy1(a[j].b);
         }
         free(a);
     }
-    bgzf_close(fpw);
-    free(fnt); free(cnt);
-    return 0;
+    free(fnt);
+    free(fpt);
+    free(cnt);
+    return 1;
 }
 
 int main_bamshuf(int argc, char *argv[])

--- a/faidx.c
+++ b/faidx.c
@@ -67,7 +67,9 @@ int faidx_main(int argc, char *argv[])
         error(NULL);
     if ( argc==2 )
     {
-        fai_build(argv[optind]);
+        if (fai_build(argv[optind]) != 0) {
+            error("Could not build fai index %s.fai\n", argv[optind]);
+        }
         return 0;
     }
 

--- a/phase.c
+++ b/phase.c
@@ -52,6 +52,7 @@ typedef struct {
     samFile* fp;
     bam_hdr_t* fp_hdr;
     char *pre;
+    char *out_name[3];
     samFile* out[3];
     bam_hdr_t* out_hdr[3];
     // alignment queue
@@ -332,7 +333,7 @@ static int clean_seqs(int vpos, nseq_t *hash)
     return ret;
 }
 
-static void dump_aln(phaseg_t *g, int min_pos, const nseq_t *hash)
+static int dump_aln(phaseg_t *g, int min_pos, const nseq_t *hash)
 {
     int i, is_flip, drop_ambi;
     drop_ambi = g->flag & FLAG_DROP_AMBI;
@@ -360,12 +361,18 @@ static void dump_aln(phaseg_t *g, int min_pos, const nseq_t *hash)
             if (which < 2 && is_flip) which = 1 - which; // increase the randomness
         }
         if (which == 3) which = (drand48() < 0.5);
-        sam_write1(g->out[which], g->out_hdr[which], b);
+        if (sam_write1(g->out[which], g->out_hdr[which], b) < 0) {
+            fprintf(stderr, "[%s] error writing to '%s'\n",
+                    __func__, g->out_name[which]);
+            return -1;
+            
+        }
         bam_destroy1(b);
         g->b[i] = 0;
     }
     memmove(g->b, g->b + i, (g->n - i) * sizeof(void*));
     g->n -= i;
+    return 0;
 }
 
 static int phase(phaseg_t *g, const char *chr, int vpos, uint64_t *cns, nseq_t *hash)
@@ -392,7 +399,7 @@ static int phase(phaseg_t *g, const char *chr, int vpos, uint64_t *cns, nseq_t *
                 else f->phased = 1, f->phase = f->seq[0] - 1;
             }
         }
-        dump_aln(g, min_pos, hash);
+        if (dump_aln(g, min_pos, hash) < 0) return -1;
         ++g->vpos_shift;
         return 1;
     }
@@ -450,7 +457,7 @@ static int phase(phaseg_t *g, const char *chr, int vpos, uint64_t *cns, nseq_t *
     printf("//\n");
     fflush(stdout);
     g->vpos_shift += vpos;
-    dump_aln(g, min_pos, hash);
+    if (dump_aln(g, min_pos, hash) < 0) return -1;
     return vpos;
 }
 
@@ -580,9 +587,14 @@ int main_phase(int argc, char *argv[])
         return 1;
     }
     g.fp = sam_open(argv[optind], "r");
+    if (!g.fp) {
+        fprintf(stderr, "[%s] Couldn't open '%s'\n", __func__, argv[optind]);
+        return 1;
+    }
     g.fp_hdr = sam_hdr_read(g.fp);
     if (g.fp_hdr == NULL) {
-        fprintf(stderr, "Failed to read header for '%s'\n", argv[optind]);
+        fprintf(stderr, "[%s] Failed to read header for '%s'\n",
+                __func__, argv[optind]);
         return 1;
     }
     if (fn_list) { // read the list of sites to phase
@@ -590,15 +602,30 @@ int main_phase(int argc, char *argv[])
         free(fn_list);
     } else g.flag &= ~FLAG_LIST_EXCL;
     if (g.pre) { // open BAMs to write
-        char *s = (char*)malloc(strlen(g.pre) + 20);
-        strcpy(s, g.pre); strcat(s, ".0.bam"); g.out[0] = sam_open(s, "wb");
-        strcpy(s, g.pre); strcat(s, ".1.bam"); g.out[1] = sam_open(s, "wb");
-        strcpy(s, g.pre); strcat(s, ".chimera.bam"); g.out[2] = sam_open(s, "wb");
+        char *suffixes[3] = { ".0.bam", ".1.bam", ".chimera.bam" };
+        size_t prefix_len = strlen(g.pre);
+
         for (c = 0; c <= 2; ++c) {
+            size_t len = prefix_len + strlen(suffixes[c]) + 1;
+            g.out_name[c] = (char *) malloc(len);
+            if (NULL == g.out_name[c]) {
+                perror(NULL);
+                return 1;
+            }
+            snprintf(g.out_name[c], len, "%s%s", g.pre, suffixes[c]);
+            g.out[c] = sam_open(g.out_name[c], "wb");
+            if (NULL == g.out[c]) {
+                fprintf(stderr, "[%s] Failed to open output file '%s'\n",
+                        __func__, g.out_name[c]);
+                return 1;
+            }
             g.out_hdr[c] = bam_hdr_dup(g.fp_hdr);
-            sam_hdr_write(g.out[c], g.out_hdr[c]);
+            if (sam_hdr_write(g.out[c], g.out_hdr[c]) < 0) {
+                fprintf(stderr, "[%s] Failed to write header for '%s'\n",
+                        __func__, g.out_name[c]);
+                return 1;
+            }
         }
-        free(s);
     }
 
     iter = bam_plp_init(readaln, &g);
@@ -628,7 +655,10 @@ int main_phase(int argc, char *argv[])
             g.vpos_shift = 0;
             if (lasttid >= 0) {
                 seqs = shrink_hash(seqs);
-                phase(&g, g.fp_hdr->target_name[lasttid], vpos, cns, seqs);
+                if (phase(&g, g.fp_hdr->target_name[lasttid],
+                          vpos, cns, seqs) < 0) {
+                    return -1;
+                }
                 update_vpos(0x7fffffff, seqs);
             }
             lasttid = tid;
@@ -697,14 +727,20 @@ int main_phase(int argc, char *argv[])
         }
         if (dophase) {
             seqs = shrink_hash(seqs);
-            phase(&g, g.fp_hdr->target_name[tid], vpos, cns, seqs);
+            if (phase(&g, g.fp_hdr->target_name[tid], vpos, cns, seqs) < 0) {
+                return 1;
+            }
             update_vpos(vpos, seqs);
             cns[0] = cns[vpos];
             vpos = 0;
         }
         ++vpos;
     }
-    if (tid >= 0) phase(&g, g.fp_hdr->target_name[tid], vpos, cns, seqs);
+    if (tid >= 0) {
+        if (phase(&g, g.fp_hdr->target_name[tid], vpos, cns, seqs) < 0) {
+            return 1;
+        }
+    }
     bam_hdr_destroy(g.fp_hdr);
     bam_plp_destroy(iter);
     sam_close(g.fp);
@@ -714,11 +750,18 @@ int main_phase(int argc, char *argv[])
     errmod_destroy(em);
     free(bases);
     if (g.pre) {
+        int res = 0;
         for (c = 0; c <= 2; ++c) {
-            sam_close(g.out[c]);
+            if (sam_close(g.out[c]) < 0) {
+                fprintf(stderr, "[%s] error on closing '%s'\n",
+                        __func__, g.out_name[c]);
+                res = 1;
+            }
             bam_hdr_destroy(g.out_hdr[c]);
+            free(g.out_name[c]);
         }
         free(g.pre); free(g.b);
+        if (res) return 1;
     }
     return 0;
 }

--- a/sam.c
+++ b/sam.c
@@ -31,7 +31,7 @@ DEALINGS IN THE SOFTWARE.  */
 int samthreads(samfile_t *fp, int n_threads, int n_sub_blks)
 {
     if (hts_get_format(fp->file)->format != bam || !fp->is_write) return -1;
-    bgzf_mt(fp->x.bam, n_threads, n_sub_blks);
+    if (bgzf_mt(fp->x.bam, n_threads, n_sub_blks) < 0) return -1;
     return 0;
 }
 
@@ -42,6 +42,10 @@ samfile_t *samopen(const char *fn, const char *mode, const void *aux)
     if (hts_fp == NULL)  return NULL;
 
     samfile_t *fp = malloc(sizeof (samfile_t));
+    if (!fp) {
+        sam_close(hts_fp);
+        return NULL;
+    }
     fp->file = hts_fp;
     fp->x.bam = hts_fp->fp.bgzf;
     if (strchr(mode, 'r')) {
@@ -66,7 +70,17 @@ samfile_t *samopen(const char *fn, const char *mode, const void *aux)
         enum htsExactFormat fmt = hts_get_format(fp->file)->format;
         fp->header = (bam_hdr_t *)aux;  // For writing, we won't free it
         fp->is_write = 1;
-        if (!(fmt == text_format || fmt == sam) || strchr(mode, 'h')) sam_hdr_write(fp->file, fp->header);
+        if (!(fmt == text_format || fmt == sam) || strchr(mode, 'h')) {
+            if (sam_hdr_write(fp->file, fp->header) < 0) {
+                if (bam_verbose >= 1) {
+                    fprintf(stderr, "[samopen] Couldn't write header\n");
+                    bam_hdr_destroy(fp->header);
+                    sam_close(hts_fp);
+                    free(fp);
+                    return NULL;
+                }
+            }
+        }
     }
 
     return fp;


### PR DESCRIPTION
Companion to pull request https://github.com/samtools/htslib/pull/242.  Add checks to return values from
functions now marked with HTS_RESULT_USED in htslib.  Also fix some other
obvious places where errors were not handled correctly.  Try to improve
clean-up code so that memory is not leaked and files are closed, even when
exiting due to an error.