### PR TITLE
Add manpage for wgsim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,7 +271,7 @@ misc/maq2sam-long.o: misc/maq2sam.c
 install: $(PROGRAMS) $(BUILT_MISC_PROGRAMS)
 	$(INSTALL_DIR) $(DESTDIR)$(bindir) $(DESTDIR)$(man1dir)
 	$(INSTALL_PROGRAM) $(PROGRAMS) $(MISC_PROGRAMS) $(DESTDIR)$(bindir)
-	$(INSTALL_DATA) samtools.1 $(DESTDIR)$(man1dir)
+	$(INSTALL_DATA) samtools.1 misc/wgsim.1 $(DESTDIR)$(man1dir)
 
 
 testclean:

--- a/misc/wgsim.1
+++ b/misc/wgsim.1
@@ -1,0 +1,55 @@
+.TH WGSIM: "1" "July 2015" "wgsim" "User Commands"
+.SH NAME
+wgsim \-\- Whole-genome sequencing read simulator
+.PP
+Version: 0.3.1\-r13
+.SH SYNOPSIS
+.B wgsim
+[\fI\,options\/\fR] \fI\,<in.ref.fa> <out.read1.fq> <out.read2.fq>\/\fR
+.PP
+<in.ref.fa> must be a fasta file containing a reference genome.
+.PP
+<out.read1.fq> and <out.read2.fq> are the first and second read output files.
+.SH OPTIONS
+.TP
+\fB\-e\fR FLOAT
+base error rate [0.000]
+.TP
+\fB\-d\fR INT
+outer distance between the two ends [500]
+.TP
+\fB\-s\fR INT
+standard deviation [50]
+.TP
+\fB\-N\fR INT
+number of read pairs [1000000]
+.TP
+\fB\-1\fR INT
+length of the first read [70]
+.TP
+\fB\-2\fR INT
+length of the second read [70]
+.TP
+\fB\-r\fR FLOAT
+rate of mutations [0.0010]
+.TP
+\fB\-R\fR FLOAT
+fraction of indels [0.15]
+.TP
+\fB\-X\fR FLOAT
+probability an indel is extended [0.30]
+.TP
+\fB\-S\fR INT
+seed for random generator [\-1]
+.TP
+\fB\-A\fR FLOAT
+disgard if the fraction of ambiguous bases higher than FLOAT [0.05]
+.TP
+\fB\-h\fR
+haplotype mode
+.TP
+Parameter defaults are given in square brackets.
+.SH AUTHOR
+Copyright Genome Research Limited, Heng Li 2008-2011
+.TP
+wgsim is part of samtools, https://github.com/samtools/samtools


### PR DESCRIPTION
@jkbonfield This adds a manpage for wgsim, and installs it via `make install`