### PR TITLE
Remove `samtools sort` legacy usage [Fixes #418,#356,#349,#295]

### DIFF
--- a/samtools.1
+++ b/samtools.1
@@ -328,7 +328,8 @@ samtools sort
 .RB [ -O
 .IR format ]
 .RB [ -n ]
-.BI "-T " out.prefix
+.RB [-T
+.IR out.prefix]
 .RB [ -@
 .IR threads "] [" in.sam | in.bam | in.cram ]
 .ad
@@ -398,47 +399,12 @@ must be used.
 .BI "-T " PREFIX
 Write temporary files to
 .IB PREFIX . nnnn .bam.
-This option is required.
+The option defaults to
+.IB <in.bam> . tmp . nnnn .bam.
 .TP
 .BI "-@ " INT
 Set number of sorting and compression threads.
 By default, operation is single-threaded.
-.PP
-For compatibility with existing scripts,
-.B samtools sort
-also accepts the previous less flexible way of specifying the final and
-temporary output filenames:
-.PP
-samtools sort
-.RB [ -nof "] [" -m
-.IR maxMem ]
-.I in.bam out.prefix
-
-The sorted BAM output is written to
-.IB out.prefix .bam
-(or as determined by the
-.B -o
-and
-.B -f
-options below) and any temporary files are written alongside as
-.IB out.prefix . %d .bam.
-
-.TP 5
-.B -o
-Output the final alignment to the standard output.
-.TP
-.B -f
-Use
-.I out.prefix
-as the full output path and do not append
-.B .bam
-suffix.
-.TP
-.BR -l ", " -m ", " -n ", " -@
-Accepted with the same meanings as above.
-.PP
-This will eventually be removed; you should move to using the more flexible
-newer style of invocation.
 .RE
 
 .TP \"-------- index


### PR DESCRIPTION
* Removes checking for `modern` or `legacy` usage and assumes all usage follows `modern` syntax.
* `-T` is no longer required and is set to `<in.bam>.tmp.NNNN.bam` by default.
* Without `-O`, output format inferred from input with `sam_open_mode`. For `stdin`, bam output is assumed unless specified.
* Updates `samtools.1` and `bam_sort.c` usage syntax.

## Behaviour
#### Unambiguous legacy `-o` flag
When `-o` appears to be used as a flag (precedes another flag such as `-n`), the operation aborts:
```
$ samtools sort -o -n test_input_1_b.bam
[bam_sort] -o specifies output filename, got option '-n', aborting...
```

#### Ambiguous legacy `-o` flag
When `-o` appears to be used as a flag but could also be interpreted as valid `modern` usage, `getopt` swallows the argument and prevents it from being used as the input file anyway:
```
$ samtools sort -n -o test_input_1_b.bam
[bam_sort] No input specified, aborting...
```

#### Unambiguous `-o` with PREFIX
Where `-o` is deemed to look like a flag, attempting to specify a prefix without `-T` aborts with warning:
```
$ samtools sort -o -n test_input_1_b.bam prefix
[bam_sort] Use -T to specify a PREFIX
```

#### Ambiguous `-o` with PREFIX
`samtools` attempts to open the `prefix` file as input and will write to `-o`.
```
$ samtools sort -n -o test_input_1_b.bam prefix
[E::hts_open] fail to open file 'prefix'
[bam_sort_core] fail to open file prefix
```
**This has the potential to clobber the input file specified to `-o` but only if `PREFIX` is a file that already exists, which is an unlikely property of prefix**

#### Compatible with `stdin`
Uses `isatty` to detect whether or not a user has failed to specify a filename because they are forgetful or because there is input expected via `stdin`:
```
$ samtools sort -n -o out
[bam_sort] No input specified, aborting...
```
```
$ cat test_input_1_a.sam | samtools sort -n -o out
$ ll out
-rw-r--r--. 1 sam sam 784 Jul 27 16:58 out
```

