### PR TITLE
samtools depth usage typo and longer line wrapping

### DIFF
--- a/bam2depth.c
+++ b/bam2depth.c
@@ -112,9 +112,9 @@ int main_depth(int argc, char *argv[])
         fprintf(stderr, "   -Q <int>            mapping quality threshold\n");
         fprintf(stderr, "   -r <chr:from-to>    region\n");
         fprintf(stderr, "\n");
-        fprintf(stderr, "The output is a simple tab-separated table with three columns, the\n");
-        fprintf(stderr, "the reference name, position, and coverage depth. Note that positions\n");
-        fprintf(stderr, "with zero coverage may be omitted.\n");
+        fprintf(stderr, "The output is a simple tab-separated table with three columns, the reference\n");
+        fprintf(stderr, "name, position, and coverage depth. Note that positions with zero coverage may\n");
+        fprintf(stderr, "may be omitted.\n");
         fprintf(stderr, "\n");
         return 1;
     }


### PR DESCRIPTION
Fixes my typo (repeated 'the') and makes the usage text line wrapping use longer lines.

FAO: @jkbonfield who kindly merged the original version https://github.com/samtools/samtools/commit/41044e3603bc6df34d0858fb436b5ada776167f0