### PR TITLE
Fixes #450

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,14 +146,14 @@ bam_import.o: bam_import.c $(HTSDIR)/htslib/kstring.h $(bam_h) $(HTSDIR)/htslib/
 bam_index.o: bam_index.c $(htslib_hts_h) $(htslib_sam_h) $(HTSDIR)/htslib/khash.h
 bam_lpileup.o: bam_lpileup.c $(bam_plbuf_h) $(bam_lpileup_h) $(HTSDIR)/htslib/ksort.h
 bam_mate.o: bam_mate.c $(sam_opts_h) $(HTSDIR)/htslib/kstring.h $(htslib_sam_h)
-bam_md.o: bam_md.c $(htslib_faidx_h) $(htslib_sam_h) kprobaln.h
+bam_md.o: bam_md.c $(htslib_faidx_h) $(htslib_sam_h) kprobaln.h $(sam_opts_h)
 bam_pileup.o: bam_pileup.c $(sam_h)
 bam_plbuf.o: bam_plbuf.c $(htslib_hts_h) $(htslib_sam_h) $(bam_plbuf_h)
 bam_plcmd.o: bam_plcmd.c $(htslib_sam_h) $(htslib_faidx_h) $(HTSDIR)/htslib/kstring.h $(HTSDIR)/htslib/khash_str2int.h sam_header.h samtools.h $(sam_opts_h) $(bam2bcf_h) $(sample_h)
 bam_quickcheck.o: bam_quickcheck.c $(htslib_hts_h) $(htslib_sam_h) $(htslib_bgzf_h)
 bam_reheader.o: bam_reheader.c $(htslib_bgzf_h) $(htslib_sam_h) $(htslib_hfile_h) $(htslib_cram_h) samtools.h
-bam_rmdup.o: bam_rmdup.c $(sam_h) $(HTSDIR)/htslib/khash.h
-bam_rmdupse.o: bam_rmdupse.c $(sam_h) $(HTSDIR)/htslib/khash.h $(HTSDIR)/htslib/klist.h
+bam_rmdup.o: bam_rmdup.c $(bam_h) $(sam_opts_h) $(HTSDIR)/htslib/khash.h
+bam_rmdupse.o: bam_rmdupse.c $(bam_h) $(HTSDIR)/htslib/khash.h $(HTSDIR)/htslib/klist.h
 bam_sort.o: bam_sort.c $(HTSDIR)/htslib/ksort.h $(HTSDIR)/htslib/khash.h $(HTSDIR)/htslib/klist.h $(HTSDIR)/htslib/kstring.h $(htslib_sam_h) $(sam_opts_h)
 bam_split.o: bam_split.c $(htslib_sam_h) $(HTSDIR)/htslib/khash.h $(HTSDIR)/htslib/kstring.h $(sam_opts_h)
 bam_stat.o: bam_stat.c $(htslib_sam_h) samtools.h
@@ -169,7 +169,7 @@ cut_target.o: cut_target.c $(htslib_sam_h) errmod.h $(htslib_faidx_h) $(sam_opts
 dict.o: dict.c $(htslib_kseq_h) $(htslib_hts_h)
 errmod.o: errmod.c errmod.h $(HTSDIR)/htslib/ksort.h
 kprobaln.o: kprobaln.c kprobaln.h
-padding.o: padding.c $(HTSDIR)/htslib/kstring.h $(htslib_sam_h) $(htslib_faidx_h) sam_header.h
+padding.o: padding.c $(HTSDIR)/htslib/kstring.h $(htslib_sam_h) $(htslib_faidx_h) sam_header.h $(sam_opts_h)
 phase.o: phase.c $(htslib_sam_h) errmod.h $(sam_opts_h) $(HTSDIR)/htslib/kseq.h $(HTSDIR)/htslib/khash.h $(HTSDIR)/htslib/ksort.h
 sam.o: sam.c $(htslib_faidx_h) $(sam_h)
 sam_header.o: sam_header.c sam_header.h $(HTSDIR)/htslib/khash.h

--- a/bam.c
+++ b/bam.c
@@ -61,19 +61,64 @@ int bam_validate1(const bam_header_t *header, const bam1_t *b)
     return 1;
 }
 
+#ifndef MIN
+#define MIN(a,b) ((a)<(b)?(a):(b))
+#endif
+
 // FIXME: we should also check the LB tag associated with each alignment
 const char *bam_get_library(bam_header_t *h, const bam1_t *b)
 {
-#if 0
-    const uint8_t *rg;
-    if (h->dict == 0) h->dict = sam_header_parse2(h->text);
-    if (h->rg2lib == 0) h->rg2lib = sam_header2tbl(h->dict, "RG", "ID", "LB");
-    rg = bam_aux_get(b, "RG");
-    return (rg == 0)? 0 : sam_tbl_get(h->rg2lib, (const char*)(rg + 1));
-#else
-    fprintf(stderr, "Samtools-htslib-API: bam_get_library() not yet implemented\n");
-    abort();
-#endif
+    // Slow and inefficient.  Rewrite once we get a proper header API.
+    const char *rg;
+    char *cp = h->text;
+    rg = (char *)bam_aux_get(b, "RG");
+
+    if (!rg)
+        return NULL;
+    else
+        rg++;
+
+    // Header is guaranteed to be nul terminated, so this is valid.
+    while (*cp) {
+        char *ID, *LB;
+        char last = '\t';
+
+        // Find a @RG line
+        if (strncmp(cp, "@RG", 3) != 0) {
+            while (*cp && *cp != '\n') cp++; // skip line
+            if (*cp) cp++;
+            continue;
+        }
+
+        // Find ID: and LB: keys
+        cp += 4;
+        ID = LB = NULL;
+        while (*cp && *cp != '\n') {
+            if (last == '\t') {
+                if (strncmp(cp, "LB:", 3) == 0)
+                    LB = cp+3;
+                else if (strncmp(cp, "ID:", 3) == 0)
+                    ID = cp+3;
+            }
+            last = *cp++;
+        }
+
+        // Check it's the correct ID
+        if (strncmp(rg, ID, strlen(rg)) != 0 || ID[strlen(rg)] != '\t')
+            continue;
+
+        // Valid until next query
+        static char LB_text[1024];
+        for (cp = LB; *cp && *cp != '\t' && *cp != '\n'; cp++)
+            ;
+        strncpy(LB_text, LB, MIN(cp-LB, 1023));
+        LB_text[MIN(cp-LB, 1023)] = 0;
+
+        // Return it; valid until the next query.
+        return LB_text;
+    }
+
+    return NULL;
 }
 
 int bam_fetch(bamFile fp, const bam_index_t *idx, int tid, int beg, int end, void *data, bam_fetch_f func)

--- a/bam_mate.c
+++ b/bam_mate.c
@@ -318,6 +318,7 @@ int bam_mating(int argc, char *argv[])
     samFile *in, *out;
     int c, remove_reads = 0, proper_pair_check = 1, add_ct = 0;
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
+    char wmode[3] = {'w', 'b', 0};
     static const struct option lopts[] = {
         SAM_OPT_GLOBAL_OPTIONS('-', 0, 'O', 0, 0),
         { NULL, 0, NULL, 0 }
@@ -342,7 +343,8 @@ int bam_mating(int argc, char *argv[])
         fprintf(stderr, "[bam_mating] cannot open input file\n");
         return 1;
     }
-    if ((out = sam_open_format(argv[optind+1], "wb", &ga.out)) == NULL) {
+    sam_open_mode(wmode+1, argv[optind+1], NULL);
+    if ((out = sam_open_format(argv[optind+1], wmode, &ga.out)) == NULL) {
         fprintf(stderr, "[bam_mating] cannot open output file\n");
         return 1;
     }

--- a/bam_md.c
+++ b/bam_md.c
@@ -32,6 +32,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include "htslib/sam.h"
 #include "htslib/kstring.h"
 #include "kprobaln.h"
+#include "sam_opts.h"
 
 #define USE_EQUAL 1
 #define DROP_TAG  2
@@ -329,19 +330,40 @@ int bam_prob_realn(bam1_t *b, const char *ref)
     return bam_prob_realn_core(b, ref, INT_MAX, 1);
 }
 
+int calmd_usage() {
+    fprintf(stderr, "\n");
+    fprintf(stderr, "Usage:   samtools calmd [-eubrS] <aln.bam> <ref.fasta>\n\n");
+    fprintf(stderr, "Options: -e       change identical bases to '='\n");
+    fprintf(stderr, "         -u       uncompressed BAM output (for piping)\n");
+    fprintf(stderr, "         -b       compressed BAM output\n");
+    fprintf(stderr, "         -S       ignored (input format is auto-detected)\n");
+    fprintf(stderr, "         -A       modify the quality string\n");
+    fprintf(stderr, "         -r       compute the BQ tag (without -A) or cap baseQ by BAQ (with -A)\n");
+    fprintf(stderr, "         -E       extended BAQ for better sensitivity but lower specificity\n\n");
+
+    sam_global_opt_help(stderr, "-....");
+    return 1;
+}
+
 int bam_fillmd(int argc, char *argv[])
 {
     int c, flt_flag, tid = -2, ret, len, is_bam_out, is_uncompressed, max_nm, is_realn, capQ, baq_flag;
     samFile *fp, *fpout = 0;
     bam_hdr_t *header;
     faidx_t *fai;
-    char *ref = 0, mode_w[8];
+    char *ref = 0, mode_w[8], *ref_file;
     bam1_t *b;
+    sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
+
+    static const struct option lopts[] = {
+        SAM_OPT_GLOBAL_OPTIONS('-', 0, 0, 0, 0),
+        { NULL, 0, NULL, 0 }
+    };
 
     flt_flag = UPDATE_NM | UPDATE_MD;
     is_bam_out = is_uncompressed = is_realn = max_nm = capQ = baq_flag = 0;
     strcpy(mode_w, "w");
-    while ((c = getopt(argc, argv, "EqreuNhbSC:n:Ad")) >= 0) {
+    while ((c = getopt_long(argc, argv, "EqreuNhbSC:n:Ad", lopts, NULL)) >= 0) {
         switch (c) {
         case 'r': is_realn = 1; break;
         case 'e': flt_flag |= USE_EQUAL; break;
@@ -356,25 +378,18 @@ int bam_fillmd(int argc, char *argv[])
         case 'C': capQ = atoi(optarg); break;
         case 'A': baq_flag |= 1; break;
         case 'E': baq_flag |= 2; break;
-        default: fprintf(stderr, "[bam_fillmd] unrecognized option '-%c'\n", c); return 1;
+        default:  if (parse_sam_global_opt(c, optarg, lopts, &ga) == 0) break;
+            fprintf(stderr, "[bam_fillmd] unrecognized option '-%c'\n\n", c);
+            /* else fall-through */
+        case '?': return calmd_usage();
         }
     }
     if (is_bam_out) strcat(mode_w, "b");
     else strcat(mode_w, "h");
     if (is_uncompressed) strcat(mode_w, "0");
-    if (optind + 1 >= argc) {
-        fprintf(stderr, "\n");
-        fprintf(stderr, "Usage:   samtools calmd [-eubrS] <aln.bam> <ref.fasta>\n\n");
-        fprintf(stderr, "Options: -e       change identical bases to '='\n");
-        fprintf(stderr, "         -u       uncompressed BAM output (for piping)\n");
-        fprintf(stderr, "         -b       compressed BAM output\n");
-        fprintf(stderr, "         -S       ignored (input format is auto-detected)\n");
-        fprintf(stderr, "         -A       modify the quality string\n");
-        fprintf(stderr, "         -r       compute the BQ tag (without -A) or cap baseQ by BAQ (with -A)\n");
-        fprintf(stderr, "         -E       extended BAQ for better sensitivity but lower specificity\n\n");
-        return 1;
-    }
-    fp = sam_open(argv[optind], "r");
+    if (optind + (ga.reference == NULL) >= argc)
+        return calmd_usage();
+    fp = sam_open_format(argv[optind], "r", &ga.in);
     if (fp == 0) return 1;
 
     header = sam_hdr_read(fp);
@@ -383,10 +398,16 @@ int bam_fillmd(int argc, char *argv[])
         return 1;
     }
 
-    fpout = sam_open("-", mode_w);
+    fpout = sam_open_format("-", mode_w, &ga.out);
     sam_hdr_write(fpout, header);
 
-    fai = fai_load(argv[optind+1]);
+    ref_file = argc > optind + 1 ? argv[optind+1] : ga.reference;
+    fai = fai_load(ref_file);
+
+    if (!fai) {
+        perror(ref_file);
+        return 1;
+    }
 
     b = bam_init1();
     while ((ret = sam_read1(fp, header, b)) >= 0) {

--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -990,6 +990,12 @@ int bam_mpileup(int argc, char *argv[])
             return 1;
         }
     }
+    if (!mplp.fai && mplp.ga.reference) {
+        mplp.fai_fname = mplp.ga.reference;
+        mplp.fai = fai_load(mplp.fai_fname);
+        if (mplp.fai == NULL) return 1;
+    }
+
     if ( !(mplp.flag&MPLP_REALN) && mplp.flag&MPLP_REDO_BAQ )
     {
         fprintf(stderr,"Error: The -B option cannot be combined with -E\n");

--- a/bam_rmdup.c
+++ b/bam_rmdup.c
@@ -218,6 +218,7 @@ int bam_rmdup(int argc, char *argv[])
     int c, is_se = 0, force_se = 0;
     samFile *in, *out;
     bam_hdr_t *header;
+    char wmode[3] = {'w', 'b', 0};
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
 
     static const struct option lopts[] = {
@@ -225,7 +226,7 @@ int bam_rmdup(int argc, char *argv[])
         { NULL, 0, NULL, 0 }
     };
 
-    while ((c = getopt(argc, argv, "sS")) >= 0) {
+    while ((c = getopt_long(argc, argv, "sS", lopts, NULL)) >= 0) {
         switch (c) {
         case 's': is_se = 1; break;
         case 'S': force_se = is_se = 1; break;
@@ -244,7 +245,8 @@ int bam_rmdup(int argc, char *argv[])
         return 1;
     }
 
-    out = sam_open_format(argv[optind+1], "w", &ga.out);
+    sam_open_mode(wmode+1, argv[optind+1], NULL);
+    out = sam_open_format(argv[optind+1], wmode, &ga.out);
     if (in == 0 || out == 0) {
         fprintf(stderr, "[bam_rmdup] fail to read/write input files\n");
         return 1;

--- a/bam_rmdup.c
+++ b/bam_rmdup.c
@@ -28,7 +28,9 @@ DEALINGS IN THE SOFTWARE.  */
 #include <stdio.h>
 #include <zlib.h>
 #include <unistd.h>
-#include "sam.h"
+#include "htslib/sam.h"
+#include "sam_opts.h"
+#include "bam.h" // for bam_get_library
 
 typedef bam1_t *bam1_p;
 
@@ -58,11 +60,11 @@ static inline void stack_insert(tmp_stack_t *stack, bam1_t *b)
     stack->a[stack->n++] = b;
 }
 
-static inline void dump_best(tmp_stack_t *stack, samfile_t *out)
+static inline void dump_best(tmp_stack_t *stack, samFile *out, bam_hdr_t *hdr)
 {
     int i;
     for (i = 0; i != stack->n; ++i) {
-        samwrite(out, stack->a[i]);
+        sam_write1(out, hdr, stack->a[i]);
         bam_destroy1(stack->a[i]);
     }
     stack->n = 0;
@@ -107,12 +109,12 @@ static void clear_best(khash_t(lib) *aux, int max)
 static inline int sum_qual(const bam1_t *b)
 {
     int i, q;
-    uint8_t *qual = bam1_qual(b);
+    uint8_t *qual = bam_get_qual(b);
     for (i = q = 0; i < b->core.l_qseq; ++i) q += qual[i];
     return q;
 }
 
-void bam_rmdup_core(samfile_t *in, samfile_t *out)
+void bam_rmdup_core(samFile *in, bam_hdr_t *hdr, samFile *out)
 {
     bam1_t *b;
     int last_tid = -1, last_pos = -1;
@@ -127,10 +129,10 @@ void bam_rmdup_core(samfile_t *in, samfile_t *out)
     memset(&stack, 0, sizeof(tmp_stack_t));
 
     kh_resize(name, del_set, 4 * BUFFER_SIZE);
-    while (samread(in, b) >= 0) {
+    while (sam_read1(in, hdr, b) >= 0) {
         bam1_core_t *c = &b->core;
         if (c->tid != last_tid || last_pos != c->pos) {
-            dump_best(&stack, out); // write the result
+            dump_best(&stack, out, hdr); // write the result
             clear_best(aux, BUFFER_SIZE);
             if (c->tid != last_tid) {
                 clear_best(aux, 0);
@@ -139,22 +141,22 @@ void bam_rmdup_core(samfile_t *in, samfile_t *out)
                     clear_del_set(del_set);
                 }
                 if ((int)c->tid == -1) { // append unmapped reads
-                    samwrite(out, b);
-                    while (samread(in, b) >= 0) samwrite(out, b);
+                    sam_write1(out, hdr, b);
+                    while (sam_read1(in, hdr, b) >= 0) sam_write1(out, hdr, b);
                     break;
                 }
                 last_tid = c->tid;
-                fprintf(stderr, "[bam_rmdup_core] processing reference %s...\n", in->header->target_name[c->tid]);
+                fprintf(stderr, "[bam_rmdup_core] processing reference %s...\n", hdr->target_name[c->tid]);
             }
         }
         if (!(c->flag&BAM_FPAIRED) || (c->flag&(BAM_FUNMAP|BAM_FMUNMAP)) || (c->mtid >= 0 && c->tid != c->mtid)) {
-            samwrite(out, b);
+            sam_write1(out, hdr, b);
         } else if (c->isize > 0) { // paired, head
             uint64_t key = (uint64_t)c->pos<<32 | c->isize;
             const char *lib;
             lib_aux_t *q;
             int ret;
-            lib = bam_get_library(in->header, b);
+            lib = bam_get_library(hdr, b);
             q = lib? get_aux(aux, lib) : get_aux(aux, "\t");
             ++q->n_checked;
             k = kh_put(pos, q->best_hash, key, &ret);
@@ -162,21 +164,21 @@ void bam_rmdup_core(samfile_t *in, samfile_t *out)
                 bam1_t *p = kh_val(q->best_hash, k);
                 ++q->n_removed;
                 if (sum_qual(p) < sum_qual(b)) { // the current alignment is better; this can be accelerated in principle
-                    kh_put(name, del_set, strdup(bam1_qname(p)), &ret); // p will be removed
+                    kh_put(name, del_set, strdup(bam_get_qname(p)), &ret); // p will be removed
                     bam_copy1(p, b); // replaced as b
-                } else kh_put(name, del_set, strdup(bam1_qname(b)), &ret); // b will be removed
+                } else kh_put(name, del_set, strdup(bam_get_qname(b)), &ret); // b will be removed
                 if (ret == 0)
-                    fprintf(stderr, "[bam_rmdup_core] inconsistent BAM file for pair '%s'. Continue anyway.\n", bam1_qname(b));
+                    fprintf(stderr, "[bam_rmdup_core] inconsistent BAM file for pair '%s'. Continue anyway.\n", bam_get_qname(b));
             } else { // not found in best_hash
                 kh_val(q->best_hash, k) = bam_dup1(b);
                 stack_insert(&stack, kh_val(q->best_hash, k));
             }
         } else { // paired, tail
-            k = kh_get(name, del_set, bam1_qname(b));
+            k = kh_get(name, del_set, bam_get_qname(b));
             if (k != kh_end(del_set)) {
                 free((char*)kh_key(del_set, k));
                 kh_del(name, del_set, k);
-            } else samwrite(out, b);
+            } else sam_write1(out, hdr, b);
         }
         last_pos = c->pos;
     }
@@ -184,7 +186,7 @@ void bam_rmdup_core(samfile_t *in, samfile_t *out)
     for (k = kh_begin(aux); k != kh_end(aux); ++k) {
         if (kh_exist(aux, k)) {
             lib_aux_t *q = &kh_val(aux, k);
-            dump_best(&stack, out);
+            dump_best(&stack, out, hdr);
             fprintf(stderr, "[bam_rmdup_core] %lld / %lld = %.4lf in library '%s'\n", (long long)q->n_removed,
                     (long long)q->n_checked, (double)q->n_removed/q->n_checked, kh_key(aux, k));
             kh_destroy(pos, q->best_hash);
@@ -199,33 +201,59 @@ void bam_rmdup_core(samfile_t *in, samfile_t *out)
     bam_destroy1(b);
 }
 
-void bam_rmdupse_core(samfile_t *in, samfile_t *out, int force_se);
+void bam_rmdupse_core(samFile *in, bam_hdr_t *hdr, samFile *out, int force_se);
+
+static int rmdup_usage(void) {
+    fprintf(stderr, "\n");
+    fprintf(stderr, "Usage:  samtools rmdup [-sS] <input.srt.bam> <output.bam>\n\n");
+    fprintf(stderr, "Option: -s    rmdup for SE reads\n");
+    fprintf(stderr, "        -S    treat PE reads as SE in rmdup (force -s)\n\n");
+
+    sam_global_opt_help(stderr, "-....");
+    return 1;
+}
 
 int bam_rmdup(int argc, char *argv[])
 {
     int c, is_se = 0, force_se = 0;
-    samfile_t *in, *out;
+    samFile *in, *out;
+    bam_hdr_t *header;
+    sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
+
+    static const struct option lopts[] = {
+        SAM_OPT_GLOBAL_OPTIONS('-', 0, 0, 0, 0),
+        { NULL, 0, NULL, 0 }
+    };
+
     while ((c = getopt(argc, argv, "sS")) >= 0) {
         switch (c) {
         case 's': is_se = 1; break;
         case 'S': force_se = is_se = 1; break;
+        default:  if (parse_sam_global_opt(c, optarg, lopts, &ga) == 0) break;
+            /* else fall-through */
+        case '?': return rmdup_usage();
         }
     }
-    if (optind + 2 > argc) {
-        fprintf(stderr, "\n");
-        fprintf(stderr, "Usage:  samtools rmdup [-sS] <input.srt.bam> <output.bam>\n\n");
-        fprintf(stderr, "Option: -s    rmdup for SE reads\n");
-        fprintf(stderr, "        -S    treat PE reads as SE in rmdup (force -s)\n\n");
+    if (optind + 2 > argc)
+        return rmdup_usage();
+
+    in = sam_open_format(argv[optind], "r", &ga.in);
+    header = sam_hdr_read(in);
+    if (header == NULL || header->n_targets == 0) {
+        fprintf(stderr, "[bam_rmdup] input SAM does not have header. Abort!\n");
         return 1;
     }
-    in = samopen(argv[optind], "rb", 0);
-    out = samopen(argv[optind+1], "wb", in->header);
+
+    out = sam_open_format(argv[optind+1], "w", &ga.out);
     if (in == 0 || out == 0) {
         fprintf(stderr, "[bam_rmdup] fail to read/write input files\n");
         return 1;
     }
-    if (is_se) bam_rmdupse_core(in, out, force_se);
-    else bam_rmdup_core(in, out);
-    samclose(in); samclose(out);
+    sam_hdr_write(out, header);
+
+    if (is_se) bam_rmdupse_core(in, header, out, force_se);
+    else bam_rmdup_core(in, header, out);
+    bam_hdr_destroy(header);
+    sam_close(in); sam_close(out);
     return 0;
 }

--- a/bam_rmdupse.c
+++ b/bam_rmdupse.c
@@ -24,7 +24,9 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.  */
 
 #include <math.h>
-#include "sam.h"
+#include <stdio.h>
+#include "bam.h" // for bam_calend and bam_get_library
+#include "htslib/sam.h"
 #include "htslib/khash.h"
 #include "htslib/klist.h"
 
@@ -68,7 +70,7 @@ static lib_aux_t *get_aux(khash_t(lib) *aux, const char *lib)
 static inline int sum_qual(const bam1_t *b)
 {
     int i, q;
-    uint8_t *qual = bam1_qual(b);
+    uint8_t *qual = bam_get_qual(b);
     for (i = q = 0; i < b->core.l_qseq; ++i) q += qual[i];
     return q;
 }
@@ -91,7 +93,8 @@ static void clear_besthash(besthash_t *h, int32_t pos)
             kh_del(best, h, k);
 }
 
-static void dump_alignment(samfile_t *out, queue_t *queue, int32_t pos, khash_t(lib) *h)
+static void dump_alignment(samFile *out, bam_hdr_t *hdr,
+                           queue_t *queue, int32_t pos, khash_t(lib) *h)
 {
     if (queue->size > QUEUE_CLEAR_SIZE || pos == MAX_POS) {
         khint_t k;
@@ -100,13 +103,13 @@ static void dump_alignment(samfile_t *out, queue_t *queue, int32_t pos, khash_t(
             if (queue->head == queue->tail) break;
             q = &kl_val(queue->head);
             if (q->discarded) {
-                q->b->data_len = 0;
+                q->b->l_data = 0;
                 kl_shift(q, queue, 0);
                 continue;
             }
             if ((q->b->core.flag&BAM_FREVERSE) && q->endpos > pos) break;
-            samwrite(out, q->b);
-            q->b->data_len = 0;
+            sam_write1(out, hdr, q->b);
+            q->b->l_data = 0;
             kl_shift(q, queue, 0);
         }
         for (k = kh_begin(h); k != kh_end(h); ++k) {
@@ -118,7 +121,7 @@ static void dump_alignment(samfile_t *out, queue_t *queue, int32_t pos, khash_t(
     }
 }
 
-void bam_rmdupse_core(samfile_t *in, samfile_t *out, int force_se)
+void bam_rmdupse_core(samFile *in, bam_hdr_t *hdr, samFile *out, int force_se)
 {
     bam1_t *b;
     queue_t *queue;
@@ -129,15 +132,15 @@ void bam_rmdupse_core(samfile_t *in, samfile_t *out, int force_se)
     aux = kh_init(lib);
     b = bam_init1();
     queue = kl_init(q);
-    while (samread(in, b) >= 0) {
+    while (sam_read1(in, hdr, b) >= 0) {
         bam1_core_t *c = &b->core;
-        int endpos = bam_calend(c, bam1_cigar(b));
+        int endpos = bam_calend(c, bam_get_cigar(b));
         int score = sum_qual(b);
 
         if (last_tid != c->tid) {
-            if (last_tid >= 0) dump_alignment(out, queue, MAX_POS, aux);
+            if (last_tid >= 0) dump_alignment(out, hdr, queue, MAX_POS, aux);
             last_tid = c->tid;
-        } else dump_alignment(out, queue, c->pos, aux);
+        } else dump_alignment(out, hdr, queue, c->pos, aux);
         if ((c->flag&BAM_FUNMAP) || ((c->flag&BAM_FPAIRED) && !force_se)) {
             push_queue(queue, b, endpos, score);
         } else {
@@ -146,7 +149,7 @@ void bam_rmdupse_core(samfile_t *in, samfile_t *out, int force_se)
             besthash_t *h;
             uint32_t key;
             int ret;
-            lib = bam_get_library(in->header, b);
+            lib = bam_get_library(hdr, b);
             q = lib? get_aux(aux, lib) : get_aux(aux, "\t");
             ++q->n_checked;
             h = (c->flag&BAM_FREVERSE)? q->rght : q->left;
@@ -167,7 +170,7 @@ void bam_rmdupse_core(samfile_t *in, samfile_t *out, int force_se)
             } else kh_val(h, k) = push_queue(queue, b, endpos, score);
         }
     }
-    dump_alignment(out, queue, MAX_POS, aux);
+    dump_alignment(out, hdr, queue, MAX_POS, aux);
 
     for (k = kh_begin(aux); k != kh_end(aux); ++k) {
         if (kh_exist(aux, k)) {

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -1443,6 +1443,7 @@ int bam_merge(int argc, char *argv[])
         return 1;
     }
     strcpy(mode, "wb");
+    sam_open_mode(mode+1, argv[optind], NULL);
     if (level >= 0) sprintf(strchr(mode, '\0'), "%d", level < 9? level : 9);
     if (bam_merge_core2(is_by_qname, argv[optind], mode, fn_headers,
                         fn_size+nargcfiles, fn, flag, reg, n_threads,
@@ -1809,7 +1810,8 @@ int bam_sort(int argc, char *argv[])
         tmpprefix = argv[optind+1];
     }
 
-    strcpy(modeout, "w");
+    strcpy(modeout, "wb");
+    sam_open_mode(modeout+1, fnout, NULL);
     if (level >= 0) sprintf(strchr(modeout, '\0'), "%d", level < 9? level : 9);
 
     if (tmpprefix == NULL) {

--- a/bam_tview.c
+++ b/bam_tview.c
@@ -354,7 +354,7 @@ int bam_tview_main(int argc, char *argv[])
 {
     int view_mode=display_ncurses;
     tview_t* tv=NULL;
-    char *samples=NULL, *position=NULL;
+    char *samples=NULL, *position=NULL, *ref;
     int c;
 
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
@@ -385,24 +385,20 @@ int bam_tview_main(int argc, char *argv[])
     }
     if (argc==optind) error(NULL);
 
+    ref = (optind+1>=argc)? ga.reference : argv[optind+1];
+
     switch(view_mode)
     {
         case display_ncurses:
-            tv = curses_tv_init(argv[optind],
-                                (optind+1>=argc)? 0 : argv[optind+1],
-                                samples, &ga.in);
+            tv = curses_tv_init(argv[optind], ref, samples, &ga.in);
             break;
 
         case display_text:
-            tv = text_tv_init(argv[optind],
-                              (optind+1>=argc)? 0 : argv[optind+1],
-                              samples, &ga.in);
+            tv = text_tv_init(argv[optind], ref, samples, &ga.in);
             break;
 
         case display_html:
-            tv = html_tv_init(argv[optind],
-                              (optind+1>=argc)? 0 : argv[optind+1],
-                              samples, &ga.in);
+            tv = html_tv_init(argv[optind], ref, samples, &ga.in);
             break;
     }
     if (tv==NULL)

--- a/bamtk.c
+++ b/bamtk.c
@@ -140,7 +140,7 @@ static void usage(FILE *fp)
 "     flags          explain BAM flags\n"
 "     tview          text alignment viewer\n"
 "     view           SAM<->BAM<->CRAM conversion\n"
-//"     depad          convert padded BAM to unpadded BAM\n" // not stable
+"     depad          convert padded BAM to unpadded BAM\n"
 "\n");
 #ifdef _WIN32
     fprintf(fp,

--- a/cut_target.c
+++ b/cut_target.c
@@ -175,7 +175,7 @@ int main_cut_target(int argc, char *argv[])
 
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
     static const struct option lopts[] = {
-        SAM_OPT_GLOBAL_OPTIONS('-', 0, '-', '-', 0),
+        SAM_OPT_GLOBAL_OPTIONS('-', 0, '-', '-', 'f'),
         { NULL, 0, NULL, 0 }
     };
 
@@ -188,17 +188,18 @@ int main_cut_target(int argc, char *argv[])
             case '0': g_param.e[1][0] = atoi(optarg); break; // emission SCORE
             case '1': g_param.e[1][1] = atoi(optarg); break;
             case '2': g_param.e[1][2] = atoi(optarg); break;
-            case 'f': g.fai = fai_load(optarg);
-                if (g.fai == 0) fprintf(stderr, "[%s] fail to load the fasta index.\n", __func__);
-                break;
             default:  if (parse_sam_global_opt(c, optarg, lopts, &ga) == 0) break;
                       /* else fall-through */
             case '?': usage=1; break;
         }
     }
+    if (ga.reference) {
+        g.fai = fai_load(ga.reference);
+        if (g.fai == 0) fprintf(stderr, "[%s] fail to load the fasta index.\n", __func__);
+    }
     if (usage || argc == optind) {
-        fprintf(stderr, "Usage: samtools targetcut [-Q minQ] [-i inPen] [-0 em0] [-1 em1] [-2 em2] [-f ref] [--reference ref.fa] <in.bam>\n");
-        sam_global_opt_help(stderr, "-.--.");
+        fprintf(stderr, "Usage: samtools targetcut [-Q minQ] [-i inPen] [-0 em0] [-1 em1] [-2 em2] <in.bam>\n");
+        sam_global_opt_help(stderr, "-.--f");
         return 1;
     }
     l = max_l = 0; cns = 0;

--- a/padding.c
+++ b/padding.c
@@ -31,6 +31,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <htslib/sam.h>
 #include <htslib/faidx.h>
 #include "sam_header.h"
+#include "sam_opts.h"
 
 #define bam_reg2bin(b,e) hts_reg2bin((b),(e), 14, 5)
 
@@ -474,33 +475,43 @@ int main_pad2unpad(int argc, char *argv[])
     samFile *in = 0, *out = 0;
     bam_hdr_t *h = 0, *h_fix = 0;
     faidx_t *fai = 0;
-    int c, is_bamin = 1, compress_level = -1, is_long_help = 0;
-    char in_mode[5], out_mode[6], *fn_out = 0, *fn_list = 0, *fn_ref = 0;
-    int out_format = 'b', ret=0;
+    int c, compress_level = -1, is_long_help = 0;
+    char in_mode[5], out_mode[6], *fn_out = 0, *fn_list = 0;
+    int ret=0;
+    sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
+
+    static const struct option lopts[] = {
+        SAM_OPT_GLOBAL_OPTIONS('-', 0, 0, 0, 'T'),
+        { NULL, 0, NULL, 0 }
+    };
 
     /* parse command-line options */
     /* TODO: add --output-fmt-option long opts once that branch is merged */
     strcpy(in_mode, "r"); strcpy(out_mode, "w");
-    while ((c = getopt(argc, argv, "SCso:u1T:?")) >= 0) {
+    while ((c = getopt_long(argc, argv, "SCso:u1T:?", lopts, NULL)) >= 0) {
         switch (c) {
-        case 'S': is_bamin = 0; break;
-        case 'C': out_format = 'c';break;
-        case 's': assert(compress_level == -1); out_format = 0; break;
+        case 'S': break;
+        case 'C': hts_parse_format(&ga.out, "cram"); break;
+        case 's': assert(compress_level == -1); hts_parse_format(&ga.out, "sam"); break;
         case 'o': fn_out = strdup(optarg); break;
-        case 'u': compress_level = 0; break;
-        case '1': compress_level = 1; break;
-        case 'T': fn_ref = strdup(optarg); break;
+        case 'u':
+            compress_level = 0;
+            if (ga.out.format == unknown_format)
+                hts_parse_format(&ga.out, "bam");
+            break;
+        case '1':
+            compress_level = 1;
+            if (ga.out.format == unknown_format)
+                hts_parse_format(&ga.out, "bam");
+            break;
         case '?': is_long_help = 1; break;
-        default: return usage(is_long_help);
+        default:  if (parse_sam_global_opt(c, optarg, lopts, &ga) == 0) break;
+            fprintf(stderr, "[bam_fillmd] unrecognized option '-%c'\n\n", c);
+            return usage(is_long_help);
         }
     }
     if (argc == optind) return usage(is_long_help);
 
-    if (is_bamin) strcat(in_mode, "b");
-    if (out_format) {
-        char o[2] = {out_format, '\0'};
-        strcat(out_mode, o);
-    }
     strcat(out_mode, "h");
     if (compress_level >= 0) {
         char tmp[2];
@@ -509,12 +520,12 @@ int main_pad2unpad(int argc, char *argv[])
     }
 
     // Load FASTA reference (also needed for SAM -> BAM if missing header)
-    if (fn_ref) {
-        fn_list = samfaipath(fn_ref);
-        fai = fai_load(fn_ref);
+    if (ga.reference) {
+        fn_list = samfaipath(ga.reference);
+        fai = fai_load(ga.reference);
     }
     // open file handlers
-    if ((in = sam_open(argv[optind], in_mode)) == 0) {
+    if ((in = sam_open_format(argv[optind], in_mode, &ga.in)) == 0) {
         fprintf(stderr, "[depad] failed to open \"%s\" for reading.\n", argv[optind]);
         ret = 1;
         goto depad_end;
@@ -529,13 +540,13 @@ int main_pad2unpad(int argc, char *argv[])
         ret = 1;
         goto depad_end;
     }
-    if (fn_ref) {
+    if (fai) {
         h_fix = fix_header(h, fai);
     } else {
         fprintf(stderr, "[depad] Warning - reference lengths will not be corrected without FASTA reference\n");
         h_fix = h;
     }
-    if ((out = sam_open(fn_out? fn_out : "-", out_mode)) == 0) {
+    if ((out = sam_open_format(fn_out? fn_out : "-", out_mode, &ga.out)) == 0) {
         fprintf(stderr, "[depad] failed to open \"%s\" for writing.\n", fn_out? fn_out : "standard output");
         ret = 1;
         goto depad_end;
@@ -543,7 +554,7 @@ int main_pad2unpad(int argc, char *argv[])
 
     // Reference-based CRAM won't work unless we also create a new reference.
     // We could embed this, but for now we take the easy option.
-    if (out_format == 'c')
+    if (ga.out.format == cram)
         hts_set_opt(out, CRAM_OPT_NO_REF, 1);
 
     if (sam_hdr_write(out, h_fix) != 0) {
@@ -569,14 +580,19 @@ static int usage(int is_long_help)
 {
     fprintf(stderr, "\n");
     fprintf(stderr, "Usage:   samtools depad <in.bam>\n\n");
-    fprintf(stderr, "Options: -s       output is SAM (default is BAM)\n");
-    fprintf(stderr, "         -S       input is SAM (default is BAM)\n");
-    fprintf(stderr, "         -u       uncompressed BAM output (can't use with -s)\n");
-    fprintf(stderr, "         -1       fast compression BAM output (can't use with -s)\n");
-    fprintf(stderr, "         -T FILE  padded reference sequence file [null]\n");
-    fprintf(stderr, "         -o FILE  output file name [stdout]\n");
-    fprintf(stderr, "         -?       longer help\n");
+    fprintf(stderr, "Options: \n");
+    fprintf(stderr, "  -s           Output is SAM (default is BAM)\n");
+    fprintf(stderr, "  -S           Input is SAM (default is BAM)\n");
+    fprintf(stderr, "  -u           Uncompressed BAM output (can't use with -s)\n");
+    fprintf(stderr, "  -1           Fast compression BAM output (can't use with -s)\n");
+    fprintf(stderr, "  -T, --reference FILE\n");
+    fprintf(stderr, "               Padded reference sequence file [null]\n");
+    fprintf(stderr, "  -o FILE      Output file name [stdout]\n");
+    fprintf(stderr, "  -?           Longer help\n");
     fprintf(stderr, "\n");
+
+    sam_global_opt_help(stderr, "-...-");
+
     if (is_long_help)
         fprintf(stderr, "Notes:\n\
 \n\

--- a/padding.c
+++ b/padding.c
@@ -546,6 +546,8 @@ int main_pad2unpad(int argc, char *argv[])
         fprintf(stderr, "[depad] Warning - reference lengths will not be corrected without FASTA reference\n");
         h_fix = h;
     }
+    char wmode[2];
+    strcat(out_mode, sam_open_mode(wmode, fn_out, NULL)==0 ? wmode : "b");
     if ((out = sam_open_format(fn_out? fn_out : "-", out_mode, &ga.out)) == 0) {
         fprintf(stderr, "[depad] failed to open \"%s\" for writing.\n", fn_out? fn_out : "standard output");
         ret = 1;

--- a/samtools.1
+++ b/samtools.1
@@ -1387,6 +1387,11 @@ Generate the MD tag. If the MD tag is already present, this command will
 give a warning if the MD tag generated is different from the existing
 tag. Output SAM by default.
 
+Calmd can also read and write CRAM files although in most cases it is
+pointless as CRAM recalculates MD and NM tags on the fly.  The one
+exception to this case is where both input and output CRAM files
+have been / are being created with the \fIno_ref\fR option.
+
 .B OPTIONS:
 .RS
 .TP 8

--- a/test/test.pl
+++ b/test/test.pl
@@ -1664,7 +1664,7 @@ sub test_view
         ['rg_both2', { read_groups => { grp1 => 1, grp2 => 1, grp3 => 1 }},
          ['-r', 'grp2', '-R', $fogn], 0],
         # Libraries
-        ['lib2', { libraries => { 'Library 2' => 1 }}, ['-l', 'Library 2'], 1],
+        ['lib2', { libraries => { 'Library 2' => 1 }}, ['-l', 'Library 2'], 0],
         # Mapping qualities
         ['mq50',  { min_map_qual => 50 },  ['-q', 50], 0],
         ['mq99',  { min_map_qual => 99 },  ['-q', 99], 0],


### PR DESCRIPTION
At least partially.

Added global I/O options to calmd (mostly pointless), depad (now also in the standard list of sub-commands) and rmdup.  Rmdup now actually "works" too due to  finally implementing bam_get_library().

Made the --reference and other options mostly do the same thing.  Mpileup still treats these differently (as it changes the output), while some other tools process them as a separate argument permitting them to both be specified and differ, but accepting --reference as a default for the reference option.  The reason is that --reference MUST much the reference used when encoding a cram, but we may wish to use a subtly different reference for the actual tool (SNP comparison, etc).

Samtools cat and index are unchanged as they operate on low level file blocks and so the global options are inappropriate.

NOTE: I haven't yet done anything with sam_open_mode(). 