### PR TITLE
Rename bamshuf to collate

### DIFF
--- a/bamshuf.c
+++ b/bamshuf.c
@@ -1,4 +1,4 @@
-/*  bamshuf.c -- bamshuf subcommand.
+/*  bamshuf.c -- collate subcommand.
 
     Copyright (C) 2012 Broad Institute.
     Copyright (C) 2013 Genome Research Ltd.
@@ -87,7 +87,7 @@ static int bamshuf(const char *fn, int n_files, const char *pre, int clevel,
     // split
     fp = sam_open_format(fn, "r", &ga->in);
     if (fp == NULL) {
-        print_error_errno("bamshuf", "Cannot open input file \"%s\"", fn);
+        print_error_errno("collate", "Cannot open input file \"%s\"", fn);
         return 1;
     }
 
@@ -106,7 +106,7 @@ static int bamshuf(const char *fn, int n_files, const char *pre, int clevel,
         sprintf(fnt[i], "%s.%.4d.bam", pre, i);
         fpt[i] = sam_open(fnt[i], "wb1");
         if (fpt[i] == NULL) {
-            print_error_errno("bamshuf", "Cannot open intermediate file \"%s\"", fnt[i]);
+            print_error_errno("collate", "Cannot open intermediate file \"%s\"", fnt[i]);
             return 1;
         }
         sam_hdr_write(fpt[i], h);
@@ -135,8 +135,8 @@ static int bamshuf(const char *fn, int n_files, const char *pre, int clevel,
         free(fnw);
     } else fpw = sam_open_format("-", modew, &ga->out); // output to stdout
     if (fpw == NULL) {
-        if (is_stdout) print_error_errno("bamshuf", "Cannot open standard output");
-        else print_error_errno("bamshuf", "Cannot open output file \"%s.bam\"", pre);
+        if (is_stdout) print_error_errno("collate", "Cannot open standard output");
+        else print_error_errno("collate", "Cannot open output file \"%s.bam\"", pre);
         return 1;
     }
 
@@ -172,7 +172,7 @@ static int bamshuf(const char *fn, int n_files, const char *pre, int clevel,
 
 static int usage(FILE *fp, int n_files) {
     fprintf(fp,
-            "Usage:   samtools bamshuf [-Ou] [-n nFiles] [-c cLevel] <in.bam> <out.prefix>\n\n"
+            "Usage:   samtools collate [-Ou] [-n nFiles] [-c cLevel] <in.bam> <out.prefix>\n\n"
             "Options:\n"
             "      -O       output to stdout\n"
             "      -u       uncompressed BAM output\n"

--- a/bamtk.c
+++ b/bamtk.c
@@ -121,7 +121,7 @@ static void usage(FILE *fp)
 "     addreplacerg   adds or replaces RG tags\n"
 "\n"
 "  -- File operations\n"
-"     bamshuf        shuffle and group alignments by name\n"
+"     collate        shuffle and group alignments by name\n"
 "     cat            concatenate BAMs\n"
 "     merge          merge sorted alignments\n"
 "     mpileup        multi-way pileup\n"
@@ -197,7 +197,8 @@ int main(int argc, char *argv[])
     else if (strcmp(argv[1], "pad2unpad") == 0) ret = main_pad2unpad(argc-1, argv+1);
     else if (strcmp(argv[1], "depad") == 0)     ret = main_pad2unpad(argc-1, argv+1);
     else if (strcmp(argv[1], "bedcov") == 0)    ret = main_bedcov(argc-1, argv+1);
-    else if (strcmp(argv[1], "bamshuf") == 0)   ret = main_bamshuf(argc-1, argv+1);
+    else if (strcmp(argv[1], "bamshuf") == 0)   ret = main_bamshuf(argc-1, argv+1); // Depreciated
+    else if (strcmp(argv[1], "collate") == 0)   ret = main_bamshuf(argc-1, argv+1);
     else if (strcmp(argv[1], "stats") == 0)     ret = main_stats(argc-1, argv+1);
     else if (strcmp(argv[1], "flags") == 0)     ret = main_flags(argc-1, argv+1);
     else if (strcmp(argv[1], "split") == 0)     ret = main_split(argc-1, argv+1);

--- a/samtools.1
+++ b/samtools.1
@@ -85,7 +85,7 @@ samtools fasta input.bam > output.fasta
 .PP
 samtools addreplacerg -r 'ID:fish' -r 'LB:1334' -r 'SM:alpha' -o output.bam input.bam
 .PP
-samtools bamshuf aln.sorted.bam reads.together.bam
+samtools collate aln.sorted.bam aln.name_collated.bam
 .PP
 samtools depad input.bam
 
@@ -1342,16 +1342,16 @@ can be specified in hex by beginning with `0x' (i.e. /^0x[0-9A-F]+/)
 or in octal by beginning with `0' (i.e. /^0[0-7]+/) [0].
 .RE
 
-.TP \"-------- bamshuf
-.B bamshuf
-samtools bamshuf
+.TP \"-------- collate
+.B collate
+samtools collate
 .RI [ options ]
 .IR in.sam | in.bam | in.cram " [" out.prefix "]"
 
-Shuffles and groups alignments by name. A faster alternative to a full
-query name sort, bamshuf ensures that reads of the same name are grouped
-together in contiguous groups, but doesn't make any guarantees about the
-order of read names between groups.
+Shuffles and groups reads together by their name. A faster alternative to
+a full query name sort, collate ensures that reads of the same name are
+grouped together in contiguous groups, but doesn't make any guarantees
+about the order of read names between groups.
 
 The output from this command should be suitable for any operation that
 requires all reads from the same template to be grouped together.


### PR DESCRIPTION
Now that bamshuf can handle CRAM files we have renamed it so that it has a more appropriate name.