### PR TITLE
Fix warnings from adding HTS_RESULT_USED to htslib prototypes (rebased).

### DIFF
--- a/bam.c
+++ b/bam.c
@@ -34,15 +34,22 @@ char *bam_format1(const bam_header_t *header, const bam1_t *b)
 {
     kstring_t str;
     str.l = str.m = 0; str.s = NULL;
-    sam_format1(header, b, &str);
+    if (sam_format1(header, b, &str) < 0) {
+        free(str.s);
+        str.s = NULL;
+        return NULL;
+    }
     return str.s;
 }
 
-void bam_view1(const bam_header_t *header, const bam1_t *b)
+int bam_view1(const bam_header_t *header, const bam1_t *b)
 {
     char *s = bam_format1(header, b);
-    puts(s);
+    int ret = -1;
+    if (!s) return -1;
+    if (puts(s) != EOF) ret = 0;
     free(s);
+    return ret;
 }
 
 int bam_validate1(const bam_header_t *header, const bam1_t *b)

--- a/bam.h
+++ b/bam.h
@@ -322,8 +322,11 @@ extern "C" {
      */
     char *bam_format1(const bam_header_t *header, const bam1_t *b);
 
-    /*! @abstract     Formats a BAM record and writes it and \n to stdout */
-    void bam_view1(const bam_header_t *header, const bam1_t *b);
+    /*!
+      @abstract     Formats a BAM record and writes it and \n to stdout
+      @return       0 if successful, -1 on error
+    */
+    int bam_view1(const bam_header_t *header, const bam1_t *b);
 
     /*!
       @abstract       Check whether a BAM record is plausibly valid

--- a/bam_mate.c
+++ b/bam_mate.c
@@ -177,10 +177,10 @@ static void sync_mate(bam1_t* a, bam1_t* b)
 }
 
 // currently, this function ONLY works if each read has one hit
-static void bam_mating_core(samFile* in, samFile* out, int remove_reads, int proper_pair_check, int add_ct)
+static int bam_mating_core(samFile* in, samFile* out, int remove_reads, int proper_pair_check, int add_ct)
 {
     bam_hdr_t *header;
-    bam1_t *b[2];
+    bam1_t *b[2] = { NULL, NULL };
     int curr, has_prev, pre_end = 0, cur_end = 0;
     kstring_t str;
 
@@ -188,7 +188,7 @@ static void bam_mating_core(samFile* in, samFile* out, int remove_reads, int pro
     header = sam_hdr_read(in);
     if (header == NULL) {
         fprintf(stderr, "[bam_mating_core] ERROR: Couldn't read header\n");
-        exit(1);
+        return 1;
     }
     // Accept unknown, unsorted, or queryname sort order, but error on coordinate sorted.
     if ((header->l_text > 3) && (strncmp(header->text, "@HD", 3) == 0)) {
@@ -199,10 +199,13 @@ static void bam_mating_core(samFile* in, samFile* out, int remove_reads, int pro
         // (e.g. must ignore in a @CO comment line later in header)
         if ((p != 0) && (p < q)) {
             fprintf(stderr, "[bam_mating_core] ERROR: Coordinate sorted, require grouped/sorted by queryname.\n");
-            exit(1);
+            goto fail;
         }
     }
-    sam_hdr_write(out, header);
+    if (sam_hdr_write(out, header) < 0) {
+        fprintf(stderr, "[bam_mating_core] ERROR: Couldn't write header\n");
+        goto fail;
+    }
 
     b[0] = bam_init1();
     b[1] = bam_init1();
@@ -211,12 +214,14 @@ static void bam_mating_core(samFile* in, samFile* out, int remove_reads, int pro
         bam1_t *cur = b[curr], *pre = b[1-curr];
         if (cur->core.flag & BAM_FSECONDARY)
         {
-            if ( !remove_reads ) sam_write1(out, header, cur);
+            if ( !remove_reads ) {
+                if (sam_write1(out, header, cur) < 0) goto write_fail;
+            }
             continue; // skip secondary alignments
         }
         if (cur->core.flag & BAM_FSUPPLEMENTARY)
         {
-            sam_write1(out, header, cur);
+            if (sam_write1(out, header, cur) < 0) goto write_fail;
             continue; // pass supplementary alignments through unchanged (TODO:make them match read they came from)
         }
         if (cur->core.tid < 0 || cur->core.pos < 0) // If unmapped set the flag
@@ -253,14 +258,18 @@ static void bam_mating_core(samFile* in, samFile* out, int remove_reads, int pro
 
                 // Write out result
                 if ( !remove_reads ) {
-                    sam_write1(out, header, pre);
-                    sam_write1(out, header, cur);
+                    if (sam_write1(out, header, pre) < 0) goto write_fail;
+                    if (sam_write1(out, header, cur) < 0) goto write_fail;
                 } else {
                     // If we have to remove reads make sure we do it in a way that doesn't create orphans with bad flags
                     if(pre->core.flag&BAM_FUNMAP) cur->core.flag &= ~(BAM_FPAIRED|BAM_FMREVERSE|BAM_FPROPER_PAIR);
                     if(cur->core.flag&BAM_FUNMAP) pre->core.flag &= ~(BAM_FPAIRED|BAM_FMREVERSE|BAM_FPROPER_PAIR);
-                    if(!(pre->core.flag&BAM_FUNMAP)) sam_write1(out, header, pre);
-                    if(!(cur->core.flag&BAM_FUNMAP)) sam_write1(out, header, cur);
+                    if(!(pre->core.flag&BAM_FUNMAP)) {
+                        if (sam_write1(out, header, pre) < 0) goto write_fail;
+                    }
+                    if(!(cur->core.flag&BAM_FUNMAP)) {
+                        if (sam_write1(out, header, cur) < 0) goto write_fail;
+                    }
                 }
                 has_prev = 0;
             } else { // unpaired?  clear bad info and write it out
@@ -271,7 +280,9 @@ static void bam_mating_core(samFile* in, samFile* out, int remove_reads, int pro
                 }
                 pre->core.mtid = -1; pre->core.mpos = -1; pre->core.isize = 0;
                 pre->core.flag &= ~(BAM_FPAIRED|BAM_FMREVERSE|BAM_FPROPER_PAIR);
-                if ( !remove_reads || !(pre->core.flag&BAM_FUNMAP) ) sam_write1(out, header, pre);
+                if ( !remove_reads || !(pre->core.flag&BAM_FUNMAP) ) {
+                    if (sam_write1(out, header, pre) < 0) goto write_fail;
+                }
             }
         } else has_prev = 1;
         curr = 1 - curr;
@@ -287,12 +298,21 @@ static void bam_mating_core(samFile* in, samFile* out, int remove_reads, int pro
         pre->core.mtid = -1; pre->core.mpos = -1; pre->core.isize = 0;
         pre->core.flag &= ~(BAM_FPAIRED|BAM_FMREVERSE|BAM_FPROPER_PAIR);
 
-        sam_write1(out, header, pre);
+        if (sam_write1(out, header, pre) < 0) goto write_fail;
     }
     bam_hdr_destroy(header);
     bam_destroy1(b[0]);
     bam_destroy1(b[1]);
     free(str.s);
+    return 0;
+
+ write_fail:
+    fprintf(stderr, "[bam_mating_core] ERROR: Couldn't write to output file\n");
+ fail:
+    bam_hdr_destroy(header);
+    bam_destroy1(b[0]);
+    bam_destroy1(b[1]);
+    return 1;
 }
 
 void usage(FILE* where)
@@ -315,8 +335,8 @@ void usage(FILE* where)
 
 int bam_mating(int argc, char *argv[])
 {
-    samFile *in, *out;
-    int c, remove_reads = 0, proper_pair_check = 1, add_ct = 0;
+    samFile *in = NULL, *out = NULL;
+    int c, remove_reads = 0, proper_pair_check = 1, add_ct = 0, res = 1;
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
     char wmode[3] = {'w', 'b', 0};
     static const struct option lopts[] = {
@@ -333,30 +353,40 @@ int bam_mating(int argc, char *argv[])
             case 'c': add_ct = 1; break;
             default:  if (parse_sam_global_opt(c, optarg, lopts, &ga) == 0) break;
                       /* else fall-through */
-            case '?': usage(stderr); return 1;
+            case '?': usage(stderr); goto fail;
         }
     }
-    if (optind+1 >= argc) { usage(stderr); return 1; }
+    if (optind+1 >= argc) { usage(stderr); goto fail; }
 
     // init
     if ((in = sam_open_format(argv[optind], "rb", &ga.in)) == NULL) {
         fprintf(stderr, "[bam_mating] cannot open input file\n");
-        return 1;
+        goto fail;
     }
     sam_open_mode(wmode+1, argv[optind+1], NULL);
     if ((out = sam_open_format(argv[optind+1], wmode, &ga.out)) == NULL) {
         fprintf(stderr, "[bam_mating] cannot open output file\n");
-        return 1;
+        goto fail;
     }
 
     // run
-    bam_mating_core(in, out, remove_reads, proper_pair_check, add_ct);
+    res = bam_mating_core(in, out, remove_reads, proper_pair_check, add_ct);
 
     // cleanup
-    sam_close(in); sam_close(out);
-    sam_global_args_free(&ga);
+    sam_close(in);
+    if (sam_close(out) < 0) {
+        fprintf(stderr, "[bam_mating] error while closing output file\n");
+        res = 1;
+    }
 
-    return 0;
+    sam_global_args_free(&ga);
+    return res;
+
+ fail:
+    if (in) sam_close(in);
+    if (out) sam_close(out);
+    sam_global_args_free(&ga);
+    return 1;
 }
 
 

--- a/bam_md.c
+++ b/bam_md.c
@@ -349,11 +349,11 @@ int calmd_usage() {
 int bam_fillmd(int argc, char *argv[])
 {
     int c, flt_flag, tid = -2, ret, len, is_bam_out, is_uncompressed, max_nm, is_realn, capQ, baq_flag;
-    samFile *fp, *fpout = 0;
-    bam_hdr_t *header;
-    faidx_t *fai;
-    char *ref = 0, mode_w[8], *ref_file;
-    bam1_t *b;
+    samFile *fp = NULL, *fpout = NULL;
+    bam_hdr_t *header = NULL;
+    faidx_t *fai = NULL;
+    char *ref = NULL, mode_w[8], *ref_file;
+    bam1_t *b = NULL;
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
 
     static const struct option lopts[] = {
@@ -391,35 +391,52 @@ int bam_fillmd(int argc, char *argv[])
     if (optind + (ga.reference == NULL) >= argc)
         return calmd_usage();
     fp = sam_open_format(argv[optind], "r", &ga.in);
-    if (fp == 0) return 1;
+    if (fp == NULL) {
+        fprintf(stderr,
+                "[bam_fillmd] Failed to open input file '%s'\n", argv[optind]);
+        return 1;
+    }
 
     header = sam_hdr_read(fp);
     if (header == NULL || header->n_targets == 0) {
         fprintf(stderr, "[bam_fillmd] input SAM does not have header. Abort!\n");
-        return 1;
+        goto fail;
     }
 
     fpout = sam_open_format("-", mode_w, &ga.out);
-    sam_hdr_write(fpout, header);
+    if (fpout == NULL) {
+        fprintf(stderr, "[bam_fillmd] Failed to open output\n");
+        goto fail;
+    }
+    if (sam_hdr_write(fpout, header) < 0) {
+        fprintf(stderr, "[bam_fillmd] Failed to write sam header\n");
+        goto fail;
+    }
 
     ref_file = argc > optind + 1 ? argv[optind+1] : ga.reference;
     fai = fai_load(ref_file);
 
     if (!fai) {
         perror(ref_file);
-        return 1;
+        goto fail;
     }
 
     b = bam_init1();
+    if (!b) {
+        fprintf(stderr, "[bam_fillmd] Failed to allocate bam struct\n");
+        goto fail;
+    }
     while ((ret = sam_read1(fp, header, b)) >= 0) {
         if (b->core.tid >= 0) {
             if (tid != b->core.tid) {
                 free(ref);
                 ref = fai_fetch(fai, header->target_name[b->core.tid], &len);
                 tid = b->core.tid;
-                if (ref == 0)
+                if (ref == 0) { // FIXME: Should this always be fatal?
                     fprintf(stderr, "[bam_fillmd] fail to find sequence '%s' in the reference.\n",
                             header->target_name[tid]);
+                    if (is_realn || capQ > 10) goto fail; // Would otherwise crash
+                }
             }
             if (is_realn) bam_prob_realn_core(b, ref, len, baq_flag);
             if (capQ > 10) {
@@ -428,7 +445,14 @@ int bam_fillmd(int argc, char *argv[])
             }
             if (ref) bam_fillmd1_core(b, ref, len, flt_flag, max_nm);
         }
-        sam_write1(fpout, header, b);
+        if (sam_write1(fpout, header, b) < 0) {
+            fprintf(stderr, "[bam_fillmd] failed to write to output file\n");
+            goto fail;
+        }
+    }
+    if (ret < -1) {
+        fprintf(stderr, "[bam_fillmd] Error reading input.\n");
+        goto fail;
     }
     bam_destroy1(b);
     bam_hdr_destroy(header);
@@ -436,6 +460,18 @@ int bam_fillmd(int argc, char *argv[])
     free(ref);
     fai_destroy(fai);
     sam_close(fp);
-    sam_close(fpout);
+    if (sam_close(fpout) < 0) {
+        fprintf(stderr, "[bam_fillmd] error when closing output file\n");
+        return 1;
+    }
     return 0;
+
+ fail:
+    free(ref);
+    if (b) bam_destroy1(b);
+    if (header) bam_hdr_destroy(header);
+    if (fai) fai_destroy(fai);
+    if (fp) sam_close(fp);
+    if (fpout) sam_close(fpout);
+    return 1;
 }

--- a/bam_rmdup.c
+++ b/bam_rmdup.c
@@ -60,14 +60,24 @@ static inline void stack_insert(tmp_stack_t *stack, bam1_t *b)
     stack->a[stack->n++] = b;
 }
 
-static inline void dump_best(tmp_stack_t *stack, samFile *out, bam_hdr_t *hdr)
+static inline int dump_best(tmp_stack_t *stack, samFile *out, bam_hdr_t *hdr)
 {
     int i;
     for (i = 0; i != stack->n; ++i) {
-        sam_write1(out, hdr, stack->a[i]);
+        if (sam_write1(out, hdr, stack->a[i]) < 0) return -1;
         bam_destroy1(stack->a[i]);
+        stack->a[i] = NULL;
     }
     stack->n = 0;
+    return 0;
+}
+
+static inline void clear_stack(tmp_stack_t *stack) {
+    int i;
+    if (!stack->a) return;
+    for (i = 0; i != stack->n; ++i) {
+        bam_destroy1(stack->a[i]);
+    }
 }
 
 static void clear_del_set(khash_t(name) *del_set)
@@ -114,25 +124,29 @@ static inline int sum_qual(const bam1_t *b)
     return q;
 }
 
-void bam_rmdup_core(samFile *in, bam_hdr_t *hdr, samFile *out)
+int bam_rmdup_core(samFile *in, bam_hdr_t *hdr, samFile *out)
 {
-    bam1_t *b;
-    int last_tid = -1, last_pos = -1;
+    bam1_t *b = NULL;
+    int last_tid = -1, last_pos = -1, r;
     tmp_stack_t stack;
     khint_t k;
-    khash_t(lib) *aux;
-    khash_t(name) *del_set;
+    khash_t(lib) *aux = NULL;
+    khash_t(name) *del_set = NULL;
 
+    memset(&stack, 0, sizeof(tmp_stack_t));
     aux = kh_init(lib);
     del_set = kh_init(name);
     b = bam_init1();
-    memset(&stack, 0, sizeof(tmp_stack_t));
+    if (!aux || !del_set || !b) {
+        perror(__func__);
+        goto fail;
+    }
 
     kh_resize(name, del_set, 4 * BUFFER_SIZE);
-    while (sam_read1(in, hdr, b) >= 0) {
+    while ((r = sam_read1(in, hdr, b)) >= 0) {
         bam1_core_t *c = &b->core;
         if (c->tid != last_tid || last_pos != c->pos) {
-            dump_best(&stack, out, hdr); // write the result
+            if (dump_best(&stack, out, hdr) < 0) goto write_fail; // write the result
             clear_best(aux, BUFFER_SIZE);
             if (c->tid != last_tid) {
                 clear_best(aux, 0);
@@ -141,8 +155,10 @@ void bam_rmdup_core(samFile *in, bam_hdr_t *hdr, samFile *out)
                     clear_del_set(del_set);
                 }
                 if ((int)c->tid == -1) { // append unmapped reads
-                    sam_write1(out, hdr, b);
-                    while (sam_read1(in, hdr, b) >= 0) sam_write1(out, hdr, b);
+                    if (sam_write1(out, hdr, b) < 0) goto write_fail;
+                    while ((r = sam_read1(in, hdr, b)) >= 0) {
+                        if (sam_write1(out, hdr, b) < 0) goto write_fail;
+                    }
                     break;
                 }
                 last_tid = c->tid;
@@ -150,7 +166,7 @@ void bam_rmdup_core(samFile *in, bam_hdr_t *hdr, samFile *out)
             }
         }
         if (!(c->flag&BAM_FPAIRED) || (c->flag&(BAM_FUNMAP|BAM_FMUNMAP)) || (c->mtid >= 0 && c->tid != c->mtid)) {
-            sam_write1(out, hdr, b);
+            if (sam_write1(out, hdr, b) < 0) goto write_fail;
         } else if (c->isize > 0) { // paired, head
             uint64_t key = (uint64_t)c->pos<<32 | c->isize;
             const char *lib;
@@ -178,19 +194,26 @@ void bam_rmdup_core(samFile *in, bam_hdr_t *hdr, samFile *out)
             if (k != kh_end(del_set)) {
                 free((char*)kh_key(del_set, k));
                 kh_del(name, del_set, k);
-            } else sam_write1(out, hdr, b);
+            } else {
+                if (sam_write1(out, hdr, b) < 0) goto write_fail;
+            }
         }
         last_pos = c->pos;
+    }
+    if (r < -1) {
+        fprintf(stderr, "[%s] failed to read input file\n", __func__);
+        goto fail;
     }
 
     for (k = kh_begin(aux); k != kh_end(aux); ++k) {
         if (kh_exist(aux, k)) {
             lib_aux_t *q = &kh_val(aux, k);
-            dump_best(&stack, out, hdr);
+            if (dump_best(&stack, out, hdr) < 0) goto write_fail;
             fprintf(stderr, "[bam_rmdup_core] %lld / %lld = %.4lf in library '%s'\n", (long long)q->n_removed,
                     (long long)q->n_checked, (double)q->n_removed/q->n_checked, kh_key(aux, k));
             kh_destroy(pos, q->best_hash);
             free((char*)kh_key(aux, k));
+            kh_del(lib, aux, k);
         }
     }
     kh_destroy(lib, aux);
@@ -199,9 +222,32 @@ void bam_rmdup_core(samFile *in, bam_hdr_t *hdr, samFile *out)
     kh_destroy(name, del_set);
     free(stack.a);
     bam_destroy1(b);
+    return 0;
+
+ write_fail:
+    fprintf(stderr, "[%s] failed to write record\n", __func__);
+ fail:
+    clear_stack(&stack);
+    free(stack.a);
+    if (aux) {
+        for (k = kh_begin(aux); k != kh_end(aux); ++k) {
+            if (kh_exist(aux, k)) {
+                lib_aux_t *q = &kh_val(aux, k);
+                kh_destroy(pos, q->best_hash);
+                free((char*)kh_key(aux, k));
+            }
+        }
+        kh_destroy(lib, aux);
+    }
+    if (del_set) {
+        clear_del_set(del_set);
+        kh_destroy(name, del_set);
+    }
+    bam_destroy1(b);
+    return 1;
 }
 
-void bam_rmdupse_core(samFile *in, bam_hdr_t *hdr, samFile *out, int force_se);
+int bam_rmdupse_core(samFile *in, bam_hdr_t *hdr, samFile *out, int force_se);
 
 static int rmdup_usage(void) {
     fprintf(stderr, "\n");
@@ -239,6 +285,10 @@ int bam_rmdup(int argc, char *argv[])
         return rmdup_usage();
 
     in = sam_open_format(argv[optind], "r", &ga.in);
+    if (!in) {
+        fprintf(stderr, "[bam_rmdup] failed to open input file\n");
+        return 1;
+    }
     header = sam_hdr_read(in);
     if (header == NULL || header->n_targets == 0) {
         fprintf(stderr, "[bam_rmdup] input SAM does not have header. Abort!\n");
@@ -247,15 +297,25 @@ int bam_rmdup(int argc, char *argv[])
 
     sam_open_mode(wmode+1, argv[optind+1], NULL);
     out = sam_open_format(argv[optind+1], wmode, &ga.out);
-    if (in == 0 || out == 0) {
-        fprintf(stderr, "[bam_rmdup] fail to read/write input files\n");
+    if (!out) {
+        fprintf(stderr, "[bam_rmdup] failed to open output file\n");
         return 1;
     }
-    sam_hdr_write(out, header);
+    if (sam_hdr_write(out, header) < 0) {
+        fprintf(stderr, "[bam_rmdup] failed to write header\n");
+        return 1;
+    }
 
-    if (is_se) bam_rmdupse_core(in, header, out, force_se);
-    else bam_rmdup_core(in, header, out);
+    if (is_se) {
+        if (bam_rmdupse_core(in, header, out, force_se)) return 1;
+    } else {
+        if (bam_rmdup_core(in, header, out)) return 1;
+    }
     bam_hdr_destroy(header);
-    sam_close(in); sam_close(out);
+    sam_close(in);
+    if (sam_close(out) < 0) {
+        fprintf(stderr, "[bam_rmdup] error closing output file\n");
+        return 1;
+    }
     return 0;
 }

--- a/bam_rmdupse.c
+++ b/bam_rmdupse.c
@@ -93,8 +93,8 @@ static void clear_besthash(besthash_t *h, int32_t pos)
             kh_del(best, h, k);
 }
 
-static void dump_alignment(samFile *out, bam_hdr_t *hdr,
-                           queue_t *queue, int32_t pos, khash_t(lib) *h)
+static int dump_alignment(samFile *out, bam_hdr_t *hdr,
+                          queue_t *queue, int32_t pos, khash_t(lib) *h)
 {
     if (queue->size > QUEUE_CLEAR_SIZE || pos == MAX_POS) {
         khint_t k;
@@ -108,7 +108,7 @@ static void dump_alignment(samFile *out, bam_hdr_t *hdr,
                 continue;
             }
             if ((q->b->core.flag&BAM_FREVERSE) && q->endpos > pos) break;
-            sam_write1(out, hdr, q->b);
+            if (sam_write1(out, hdr, q->b) < 0) return 1;
             q->b->l_data = 0;
             kl_shift(q, queue, 0);
         }
@@ -119,28 +119,39 @@ static void dump_alignment(samFile *out, bam_hdr_t *hdr,
             }
         }
     }
+    return 0;
 }
 
-void bam_rmdupse_core(samFile *in, bam_hdr_t *hdr, samFile *out, int force_se)
+int bam_rmdupse_core(samFile *in, bam_hdr_t *hdr, samFile *out, int force_se)
 {
-    bam1_t *b;
-    queue_t *queue;
+    bam1_t *b = NULL;
+    queue_t *queue = NULL;
     khint_t k;
-    int last_tid = -2;
-    khash_t(lib) *aux;
+    int last_tid = -2, r;
+    khash_t(lib) *aux = NULL;
 
     aux = kh_init(lib);
     b = bam_init1();
     queue = kl_init(q);
-    while (sam_read1(in, hdr, b) >= 0) {
+    if (!aux || !b || !queue) {
+        perror(__func__);
+        goto fail;
+    }
+
+    while ((r = sam_read1(in, hdr, b)) >= 0) {
         bam1_core_t *c = &b->core;
         int endpos = bam_endpos(b);
         int score = sum_qual(b);
 
         if (last_tid != c->tid) {
-            if (last_tid >= 0) dump_alignment(out, hdr, queue, MAX_POS, aux);
+            if (last_tid >= 0) {
+                if (dump_alignment(out, hdr, queue, MAX_POS, aux))
+                    goto write_fail;
+            }
             last_tid = c->tid;
-        } else dump_alignment(out, hdr, queue, c->pos, aux);
+        } else {
+            if (dump_alignment(out, hdr, queue, c->pos, aux)) goto write_fail;
+        }
         if ((c->flag&BAM_FUNMAP) || ((c->flag&BAM_FPAIRED) && !force_se)) {
             push_queue(queue, b, endpos, score);
         } else {
@@ -170,7 +181,12 @@ void bam_rmdupse_core(samFile *in, bam_hdr_t *hdr, samFile *out, int force_se)
             } else kh_val(h, k) = push_queue(queue, b, endpos, score);
         }
     }
-    dump_alignment(out, hdr, queue, MAX_POS, aux);
+    if (r < -1) {
+        fprintf(stderr, "[%s] error reading input file\n", __func__);
+        goto fail;
+    }
+
+    if (dump_alignment(out, hdr, queue, MAX_POS, aux)) goto write_fail;
 
     for (k = kh_begin(aux); k != kh_end(aux); ++k) {
         if (kh_exist(aux, k)) {
@@ -179,9 +195,29 @@ void bam_rmdupse_core(samFile *in, bam_hdr_t *hdr, samFile *out, int force_se)
                     (long long)q->n_checked, (double)q->n_removed/q->n_checked, kh_key(aux, k));
             kh_destroy(best, q->left); kh_destroy(best, q->rght);
             free((char*)kh_key(aux, k));
+            kh_del(lib, aux, k);
         }
     }
     kh_destroy(lib, aux);
     bam_destroy1(b);
     kl_destroy(q, queue);
+    return 0;
+
+ write_fail:
+    fprintf(stderr, "[%s] failed to write record\n", __func__);
+ fail:
+    if (aux) {
+        for (k = kh_begin(aux); k != kh_end(aux); ++k) {
+            if (kh_exist(aux, k)) {
+                lib_aux_t *q = &kh_val(aux, k);
+                kh_destroy(best, q->left);
+                kh_destroy(best, q->rght);
+                free((char*)kh_key(aux, k));
+            }
+        }
+        kh_destroy(lib, aux);
+    }
+    bam_destroy1(b);
+    kl_destroy(q, queue);
+    return 1;
 }

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -1600,13 +1600,16 @@ static int write_buffer(const char *fn, const char *mode, size_t l, bam1_p *buf,
     samFile* fp;
     fp = sam_open_format(fn, mode, fmt);
     if (fp == NULL) return -1;
-    if (sam_hdr_write(fp, h) != 0) return -1;
+    if (sam_hdr_write(fp, h) != 0) goto fail;
     if (n_threads > 1) hts_set_threads(fp, n_threads);
     for (i = 0; i < l; ++i) {
-        if (sam_write1(fp, h, buf[i]) < 0) return -1;
+        if (sam_write1(fp, h, buf[i]) < 0) goto fail;
     }
     if (sam_close(fp) < 0) return -1;
     return 0;
+ fail:
+    sam_close(fp);
+    return -1;
 }
 
 static void *worker(void *data)

--- a/bam_split.c
+++ b/bam_split.c
@@ -55,6 +55,7 @@ struct state {
     bam_hdr_t* unaccounted_header;
     size_t output_count;
     char** rg_id;
+    char **rg_output_file_name;
     samFile** rg_output_file;
     bam_hdr_t** rg_output_header;
     kh_c2i_t* rg_hash;
@@ -62,7 +63,7 @@ struct state {
 
 typedef struct state state_t;
 
-static int cleanup_state(state_t* status);
+static int cleanup_state(state_t* status, bool check_close);
 static void cleanup_opts(parsed_opts_t* opts);
 
 static void usage(FILE *write_to)
@@ -334,7 +335,7 @@ static state_t* init(parsed_opts_t* opts)
     if (retval->merged_input_header == NULL) {
         fprintf(stderr, "Could not read header for file '%s'\n",
                 opts->merged_input_name);
-        cleanup_state(retval);
+        cleanup_state(retval, false);
         return NULL;
     }
 
@@ -343,14 +344,14 @@ static state_t* init(parsed_opts_t* opts)
             samFile* hdr_load = sam_open_format(opts->unaccounted_header_name, "r", &opts->ga.in);
             if (!hdr_load) {
                 fprintf(stderr, "Could not open unaccounted header file (%s)\n", opts->unaccounted_header_name);
-                cleanup_state(retval);
+                cleanup_state(retval, false);
                 return NULL;
             }
             retval->unaccounted_header = sam_hdr_read(hdr_load);
             if (retval->unaccounted_header == NULL) {
                 fprintf(stderr, "Could not read header for file '%s'\n",
                         opts->unaccounted_header_name);
-                cleanup_state(retval);
+                cleanup_state(retval, false);
                 return NULL;
             }
             sam_close(hdr_load);
@@ -361,7 +362,7 @@ static state_t* init(parsed_opts_t* opts)
         retval->unaccounted_file = sam_open_format(opts->unaccounted_name, "wb", &opts->ga.out);
         if (retval->unaccounted_file == NULL) {
             fprintf(stderr, "Could not open unaccounted output file: %s\n", opts->unaccounted_name);
-            cleanup_state(retval);
+            cleanup_state(retval, false);
             return NULL;
         }
     }
@@ -370,12 +371,13 @@ static state_t* init(parsed_opts_t* opts)
     if (!count_RG(retval->merged_input_header, &retval->output_count, &retval->rg_id)) return NULL;
     if (opts->verbose) fprintf(stderr, "@RG's found %zu\n",retval->output_count);
 
+    retval->rg_output_file_name = (char **)calloc(retval->output_count, sizeof(char *));
     retval->rg_output_file = (samFile**)calloc(retval->output_count, sizeof(samFile*));
     retval->rg_output_header = (bam_hdr_t**)calloc(retval->output_count, sizeof(bam_hdr_t*));
     retval->rg_hash = kh_init_c2i();
-    if (!retval->rg_output_file || !retval->rg_output_header) {
+    if (!retval->rg_output_file_name || !retval->rg_output_file || !retval->rg_output_header || !retval->rg_hash) {
         fprintf(stderr, "Could not allocate memory for output file array. Out of memory?");
-        cleanup_state(retval);
+        cleanup_state(retval, false);
         return NULL;
     }
 
@@ -383,7 +385,7 @@ static state_t* init(parsed_opts_t* opts)
     char* input_base_name = strdup(dirsep? dirsep+1 : opts->merged_input_name);
     if (!input_base_name) {
         fprintf(stderr, "Out of memory\n");
-        cleanup_state(retval);
+        cleanup_state(retval, false);
         return NULL;
     }
     char* extension = strrchr(input_base_name, '.');
@@ -400,15 +402,16 @@ static state_t* init(parsed_opts_t* opts)
 
         if ( output_filename == NULL ) {
             fprintf(stderr, "Error expanding output filename format string.\r\n");
-            cleanup_state(retval);
+            cleanup_state(retval, false);
             free(input_base_name);
             return NULL;
         }
 
+        retval->rg_output_file_name[i] = output_filename;
         retval->rg_output_file[i] = sam_open_format(output_filename, "wb", &opts->ga.out);
         if (retval->rg_output_file[i] == NULL) {
             fprintf(stderr, "Could not open output file: %s\r\n", output_filename);
-            cleanup_state(retval);
+            cleanup_state(retval, false);
             free(input_base_name);
             return NULL;
         }
@@ -422,12 +425,10 @@ static state_t* init(parsed_opts_t* opts)
         retval->rg_output_header[i] = bam_hdr_dup(retval->merged_input_header);
         if ( !filter_header_rg(retval->rg_output_header[i], retval->rg_id[i]) ) {
             fprintf(stderr, "Could not rewrite header for file: %s\r\n", output_filename);
-            cleanup_state(retval);
-            free(output_filename);
+            cleanup_state(retval, false);
             free(input_base_name);
             return NULL;
         }
-        free(output_filename);
     }
 
     free(input_base_name);
@@ -444,7 +445,8 @@ static bool split(state_t* state)
     size_t i;
     for (i = 0; i < state->output_count; i++) {
         if (sam_hdr_write(state->rg_output_file[i], state->rg_output_header[i]) != 0) {
-            fprintf(stderr, "Could not write output file header\n");
+            fprintf(stderr, "Could not write output file header for '%s'\n",
+                    state->rg_output_file_name[i]);
             return false;
         }
     }
@@ -457,7 +459,7 @@ static bool split(state_t* state)
         bam_destroy1(file_read);
         file_read = NULL;
         if (r < -1) {
-            fprintf(stderr, "Could not write read sequence\n");
+            fprintf(stderr, "Could not read first input record\n");
             return false;
         }
     }
@@ -478,7 +480,9 @@ static bool split(state_t* state)
             // if found write to the appropriate untangled bam
             int i = kh_val(state->rg_hash,iter);
             if (sam_write1(state->rg_output_file[i], state->rg_output_header[i], file_read) < 0) {
-                fprintf(stderr, "Could not write sequence\n");
+                fprintf(stderr, "Could not write to output file '%s'\n",
+                        state->rg_output_file_name[i]);
+                bam_destroy1(file_read);
                 return false;
             }
         } else {
@@ -493,7 +497,8 @@ static bool split(state_t* state)
                 return false;
             } else {
                 if (sam_write1(state->unaccounted_file, state->unaccounted_header, file_read) < 0) {
-                    fprintf(stderr, "Could not write sequence\n");
+                    fprintf(stderr, "Could not write to unaccounted output file\n");
+                    bam_destroy1(file_read);
                     return false;
                 }
             }
@@ -505,7 +510,7 @@ static bool split(state_t* state)
             bam_destroy1(file_read);
             file_read = NULL;
             if (r < -1) {
-                fprintf(stderr, "Could not write read sequence\n");
+                fprintf(stderr, "Could not read input record\n");
                 return false;
             }
         }
@@ -514,23 +519,38 @@ static bool split(state_t* state)
     return true;
 }
 
-static int cleanup_state(state_t* status)
+static int cleanup_state(state_t* status, bool check_close)
 {
     int ret = 0;
 
     if (!status) return 0;
     if (status->unaccounted_header) bam_hdr_destroy(status->unaccounted_header);
-    if (status->unaccounted_file) ret |= sam_close(status->unaccounted_file);
+    if (status->unaccounted_file) {
+        if (sam_close(status->unaccounted_file) < 0 && check_close) {
+            fprintf(stderr, "Error on closing unaccounted file\n");
+            ret = -1;
+        }
+    }
     sam_close(status->merged_input_file);
     size_t i;
     for (i = 0; i < status->output_count; i++) {
-        bam_hdr_destroy(status->rg_output_header[i]);
-        ret |= sam_close(status->rg_output_file[i]);
-        free(status->rg_id[i]);
+        if (status->rg_output_header && status->rg_output_header[i])
+            bam_hdr_destroy(status->rg_output_header[i]);
+        if (status->rg_output_file && status->rg_output_file[i]) {
+            if (sam_close(status->rg_output_file[i]) < 0 && check_close) {
+                fprintf(stderr, "Error on closing output file '%s'\n",
+                        status->rg_output_file_name[i]);
+                ret = -1;
+            }
+        }
+        if (status->rg_id) free(status->rg_id[i]);
+        if (status->rg_output_file_name) free(status->rg_output_file_name[i]);
     }
-    bam_hdr_destroy(status->merged_input_header);
+    if (status->merged_input_header)
+        bam_hdr_destroy(status->merged_input_header);
     free(status->rg_output_header);
     free(status->rg_output_file);
+    free(status->rg_output_file_name);
     kh_destroy_c2i(status->rg_hash);
     free(status->rg_id);
     free(status);
@@ -553,13 +573,17 @@ int main_split(int argc, char** argv)
 {
     int ret = 1;
     parsed_opts_t* opts = parse_args(argc, argv);
-    if (!opts ) goto cleanup_opts;
+    if (!opts) goto cleanup_opts;
     state_t* status = init(opts);
     if (!status) goto cleanup_opts;
 
-    if (split(status)) ret = 0;
+    if (!split(status)) {
+        cleanup_state(status, false);
+        goto cleanup_opts;
+    }
 
-    ret |= (cleanup_state(status) != 0);
+    ret = cleanup_state(status, true);
+
 cleanup_opts:
     cleanup_opts(opts);
 

--- a/bamshuf.c
+++ b/bamshuf.c
@@ -77,14 +77,17 @@ KSORT_INIT(bamshuf, elem_t, elem_lt)
 static int bamshuf(const char *fn, int n_files, const char *pre, int clevel,
                    int is_stdout, sam_global_args *ga)
 {
-    samFile *fp, *fpw, **fpt;
-    char **fnt, modew[8];
-    bam1_t *b;
-    int i, l;
-    bam_hdr_t *h;
-    int64_t *cnt;
+    samFile *fp, *fpw = NULL, **fpt = NULL;
+    char **fnt = NULL, modew[8];
+    bam1_t *b = NULL;
+    int i, l, r;
+    bam_hdr_t *h = NULL;
+    int64_t *cnt = NULL;
+    elem_t *a = NULL;
+    int64_t a_size = 0, a_first = 0, a_last = 0;
 
-    // split
+    // Read input, distribute reads pseudo-randomly into n_files temporary
+    // files.
     fp = sam_open_format(fn, "r", &ga->in);
     if (fp == NULL) {
         print_error_errno("bamshuf", "Cannot open input file \"%s\"", fn);
@@ -94,39 +97,69 @@ static int bamshuf(const char *fn, int n_files, const char *pre, int clevel,
     h = sam_hdr_read(fp);
     if (h == NULL) {
         fprintf(stderr, "Couldn't read header for '%s'\n", fn);
-        return 1;
+        goto fail;
     }
     fnt = (char**)calloc(n_files, sizeof(char*));
+    if (!fnt) goto mem_fail;
     fpt = (samFile**)calloc(n_files, sizeof(samFile*));
+    if (!fpt) goto mem_fail;
     cnt = (int64_t*)calloc(n_files, 8);
+    if (!cnt) goto mem_fail;
+
     l = strlen(pre);
 
     for (i = 0; i < n_files; ++i) {
         fnt[i] = (char*)calloc(l + 10, 1);
+        if (!fnt[i]) goto mem_fail;
         sprintf(fnt[i], "%s.%.4d.bam", pre, i);
         fpt[i] = sam_open(fnt[i], "wb1");
         if (fpt[i] == NULL) {
             print_error_errno("bamshuf", "Cannot open intermediate file \"%s\"", fnt[i]);
-            return 1;
+            goto fail;
         }
-        sam_hdr_write(fpt[i], h);
+        if (sam_hdr_write(fpt[i], h) < 0) {
+            fprintf(stderr, "Couldn't write header for '%s'\n", fnt[i]);
+            goto fail;
+        }
     }
     b = bam_init1();
-    while (sam_read1(fp, h, b) >= 0) {
+    if (!b) goto mem_fail;
+    while ((r = sam_read1(fp, h, b)) >= 0) {
         uint32_t x;
         x = hash_X31_Wang(bam_get_qname(b)) % n_files;
-        sam_write1(fpt[x], h, b);
+        if (sam_write1(fpt[x], h, b) < 0) {
+            fprintf(stderr, "Couldn't write to '%s'\n", fnt[x]);
+            goto fail;
+        }
         ++cnt[x];
     }
     bam_destroy1(b);
-    for (i = 0; i < n_files; ++i) sam_close(fpt[i]);
-    free(fpt);
-    sam_close(fp);
+    b = NULL;
+    if (r < -1) {
+        fprintf(stderr, "Error reading input file\n");
+        goto fail;
+    }
+    for (i = 0; i < n_files; ++i) {
+        // Close split output
+        r = sam_close(fpt[i]);
+        fpt[i] = NULL;
+        if (r < 0) {
+            fprintf(stderr, "Error on closing '%s'\n", fnt[i]);
+            return 1;
+        }
 
+        // Find biggest count
+        if (a_size < cnt[i]) a_size = cnt[i];
+    }
+    free(fpt);
+    fpt = NULL;
+    sam_close(fp);
+    fp = NULL;
     // merge
     sprintf(modew, "wb%d", (clevel >= 0 && clevel <= 9)? clevel : DEF_CLEVEL);
     if (!is_stdout) { // output to a file
         char *fnw = (char*)calloc(l + 5, 1);
+        if (!fnw) goto mem_fail;
         if (ga->out.format == unknown_format)
             sprintf(fnw, "%s.bam", pre); // "wb" above makes BAM the default
         else
@@ -137,37 +170,91 @@ static int bamshuf(const char *fn, int n_files, const char *pre, int clevel,
     if (fpw == NULL) {
         if (is_stdout) print_error_errno("bamshuf", "Cannot open standard output");
         else print_error_errno("bamshuf", "Cannot open output file \"%s.bam\"", pre);
-        return 1;
+        goto fail;
     }
 
-    sam_hdr_write(fpw, h);
+    if (sam_hdr_write(fpw, h) < 0) {
+        fprintf(stderr, "Couldn't write header\n");
+        goto fail;
+    }
+
+    a = malloc(a_size * sizeof(elem_t));
+    if (!a) goto mem_fail;
+
     for (i = 0; i < n_files; ++i) {
         int64_t j, c = cnt[i];
-        elem_t *a;
         fp = sam_open_format(fnt[i], "r", &ga->in);
-        bam_hdr_destroy(sam_hdr_read(fp));
-        a = (elem_t*)calloc(c, sizeof(elem_t));
+        if (NULL == fp) {
+            fprintf(stderr, "Couldn't open '%s'\n", fnt[i]);
+            goto fail;
+        }
+        bam_hdr_destroy(sam_hdr_read(fp)); // Skip over header
+
+        a_first = a_last = 0; // Track which bit of 'a' contains bam structs
+
+        // Slurp in one of the split files
         for (j = 0; j < c; ++j) {
             a[j].b = bam_init1();
-            sam_read1(fp, h, a[j].b);
+            if (!a[j].b) goto mem_fail;
+            a_last++;
+            if (sam_read1(fp, h, a[j].b) < 0) {
+                fprintf(stderr, "Error reading '%s'\n", fnt[i]);
+                goto fail;
+            }
             a[j].key = hash_X31_Wang(bam_get_qname(a[j].b));
         }
         sam_close(fp);
         unlink(fnt[i]);
         free(fnt[i]);
-        ks_introsort(bamshuf, c, a);
+        fnt[i] = NULL;
+
+        ks_introsort(bamshuf, c, a); // Shuffle all the reads
+
+        // Write them out again
         for (j = 0; j < c; ++j) {
-            sam_write1(fpw, h, a[j].b);
+            if (sam_write1(fpw, h, a[j].b) < 0) {
+                fprintf(stderr, "Error writing to output\n");
+                goto fail;
+            }
             bam_destroy1(a[j].b);
+            a_first++;
+        }
+    }
+
+    bam_hdr_destroy(h);
+    free(a); free(fnt); free(cnt);
+    sam_global_args_free(ga);
+    if (sam_close(fpw) < 0) {
+        fprintf(stderr, "Error on closing output\n");
+        return 1;
+    }
+
+    return 0;
+
+ mem_fail:
+    fprintf(stderr, "Out of memory\n");
+
+ fail:
+    if (fp) sam_close(fp);
+    if (fpw) sam_close(fpw);
+    if (h) bam_hdr_destroy(h);
+    if (b) bam_destroy1(b);
+    for (i = 0; i < n_files; ++i) {
+        if (fnt) free(fnt[i]);
+        if (fpt && fpt[i]) sam_close(fpt[i]);
+    }
+    if (a) {
+        int64_t j;
+        for (j = a_first; j < a_last; j++) {
+            if (a[j].b) bam_destroy1(a[j].b);
         }
         free(a);
     }
-    sam_close(fpw);
-    bam_hdr_destroy(h);
-    free(fnt); free(cnt);
+    free(fnt);
+    free(fpt);
+    free(cnt);
     sam_global_args_free(ga);
-
-    return 0;
+    return 1;
 }
 
 static int usage(FILE *fp, int n_files) {

--- a/faidx.c
+++ b/faidx.c
@@ -67,7 +67,9 @@ int faidx_main(int argc, char *argv[])
         error(NULL);
     if ( argc==2 )
     {
-        fai_build(argv[optind]);
+        if (fai_build(argv[optind]) != 0) {
+            error("Could not build fai index %s.fai\n", argv[optind]);
+        }
         return 0;
     }
 

--- a/padding.c
+++ b/padding.c
@@ -191,6 +191,10 @@ int bam_pad2unpad(samFile *in, samFile *out,  bam_hdr_t *h, faidx_t *fai)
     int ret = 0, n2 = 0, m2 = 0, *posmap = 0;
 
     b = bam_init1();
+    if (!b) {
+        fprintf(stderr, "[depad] Couldn't allocate bam struct\n");
+        return -1;
+    }
     r.l = r.m = q.l = q.m = 0; r.s = q.s = 0;
     int read_ret;
     while ((read_ret = sam_read1(in, h, b)) >= 0) { // read one alignment from `in'
@@ -357,7 +361,10 @@ int bam_pad2unpad(samFile *in, samFile *out,  bam_hdr_t *h, faidx_t *fai)
         b->core.bin = bam_reg2bin(b->core.pos, bam_endpos(b));
 
     next_seq:
-        sam_write1(out, h, b);
+        if (sam_write1(out, h, b) < 0) {
+            fprintf(stderr, "[depad] error writing to output.\n");
+            return -1;
+        }
     }
     if (read_ret < -1) {
         fprintf(stderr, "[depad] truncated file.\n");
@@ -572,7 +579,10 @@ depad_end:
     if (fai) fai_destroy(fai);
     if (h) bam_hdr_destroy(h);
     sam_close(in);
-    sam_close(out);
+    if (sam_close(out) < 0) {
+        fprintf(stderr, "[depad] error on closing output file.\n");
+        ret = 1;
+    }
     free(fn_list); free(fn_out);
     return ret;
 }

--- a/sam.c
+++ b/sam.c
@@ -31,7 +31,7 @@ DEALINGS IN THE SOFTWARE.  */
 int samthreads(samfile_t *fp, int n_threads, int n_sub_blks)
 {
     if (hts_get_format(fp->file)->format != bam || !fp->is_write) return -1;
-    bgzf_mt(fp->x.bam, n_threads, n_sub_blks);
+    if (bgzf_mt(fp->x.bam, n_threads, n_sub_blks) < 0) return -1;
     return 0;
 }
 
@@ -42,6 +42,10 @@ samfile_t *samopen(const char *fn, const char *mode, const void *aux)
     if (hts_fp == NULL)  return NULL;
 
     samfile_t *fp = malloc(sizeof (samfile_t));
+    if (!fp) {
+        sam_close(hts_fp);
+        return NULL;
+    }
     fp->file = hts_fp;
     fp->x.bam = hts_fp->fp.bgzf;
     if (strchr(mode, 'r')) {
@@ -66,7 +70,17 @@ samfile_t *samopen(const char *fn, const char *mode, const void *aux)
         enum htsExactFormat fmt = hts_get_format(fp->file)->format;
         fp->header = (bam_hdr_t *)aux;  // For writing, we won't free it
         fp->is_write = 1;
-        if (!(fmt == text_format || fmt == sam) || strchr(mode, 'h')) sam_hdr_write(fp->file, fp->header);
+        if (!(fmt == text_format || fmt == sam) || strchr(mode, 'h')) {
+            if (sam_hdr_write(fp->file, fp->header) < 0) {
+                if (bam_verbose >= 1) {
+                    fprintf(stderr, "[samopen] Couldn't write header\n");
+                    bam_hdr_destroy(fp->header);
+                    sam_close(hts_fp);
+                    free(fp);
+                    return NULL;
+                }
+            }
+        }
     }
 
     return fp;


### PR DESCRIPTION
Companion to pull request samtools/htslib#271. Add checks to return values from
functions now marked with HTS_RESULT_USED in htslib. Also fix some other
obvious places where errors were not handled correctly. Try to improve
clean-up code so that memory is not leaked and files are closed, even when
exiting due to an error.
