### PR TITLE
Fix how stats handles Supp reads on alternate haplotypes

### DIFF
--- a/stats.c
+++ b/stats.c
@@ -1628,7 +1628,7 @@ int main_stats(int argc, char *argv[])
                       if (info->fai==NULL)
                           error("Could not load faidx: %s\n", optarg);
                       break;
-            case  1 : info->gcd_bin_size = atof(optarg); break;
+            case '1': info->gcd_bin_size = atof(optarg); break;
             case 'c': if ( sscanf(optarg,"%d,%d,%d",&info->cov_min,&info->cov_max,&info->cov_step)!= 3 )
                           error("Unable to parse -c %s\n", optarg);
                       break;


### PR DESCRIPTION
Fix how stats handles Supp reads on alternate haplotypes by treating them similar to reads flagged secondary.
Fix typo in getopt_long case statement where it's case 1 rather than case '1'