### PR TITLE
Make merge allow input files with no @HD line

### DIFF
--- a/bam_sort.c
+++ b/bam_sort.c
@@ -344,8 +344,7 @@ static int trans_tbl_add_hd(merged_header_t* merged_hdr,
     if (merged_hdr->have_hd) return 0;
 
     if (hdr_line_match(translate->text, "@HD", NULL, &match) != 0) {
-        fprintf(stderr, "[%s] No @HD tag found.\n", __func__);
-        return -1;
+        return 0;
     }
 
     if (match_to_ks(translate->text, &match, &merged_hdr->out_hd)) goto memfail;
@@ -1199,6 +1198,17 @@ int bam_merge_core2(int by_qname, const char *out, const char *mode,
         if ((translation_tbl+i)->lost_coord_sort && !by_qname) {
             fprintf(stderr, "[bam_merge_core] Order of targets in file %s caused coordinate sort to be lost\n", fn[i]);
         }
+    }
+
+    // Did we get an @HD line?
+    if (!merged_hdr->have_hd) {
+        fprintf(stderr, "[W::%s] No @HD tag found.\n", __func__);
+        /* FIXME:  Should we add an @HD line here, and if so what should
+           we put in it? Ideally we want a way of getting htslib to tell
+           us the SAM version number to assume given no @HD line.  Is
+           it also safe to assume that the output is coordinate sorted?
+           SO: is optional so we don't have to have it.*/
+        /* ksprintf(&merged_hdr->out_hd, "@HD\tVN:1.5\tSO:coordinate\n"); */
     }
 
     // Transform the header into standard form


### PR DESCRIPTION
Remove check added in 55c852f that required the first SAM header to have an
@HD line when merging.  Previous versions worked if no @HD lines were
present; this allows the new header merge code to do so as well.

The new behaviour is that the first @HD line found on either the file
given in the '-h' option, or any of the input files, will be used.  If no
@HD line is found the program will complain, but it will continue and
exit successfully (assuming it otherwise worked).

Some code is included to add an @HD if none was present on the inputs, but
it's currently commented out pending discussion.

Fixes #475