### PR TITLE
Update merge -cp usage

### DIFF
--- a/bam_sort.c
+++ b/bam_sort.c
@@ -1361,8 +1361,8 @@ static void merge_usage(FILE *to)
     fprintf(to, "  -@ INT         number of BAM compression threads [0]\n");
     fprintf(to, "  -R STR         merge file in the specified region STR [all]\n");
     fprintf(to, "  -h FILE        copy the header in FILE to <out.bam> [in1.bam]\n");
-    fprintf(to, "  -c             combine RG tags with colliding IDs rather than amending them\n");
-    fprintf(to, "  -p             combine PG tags with colliding IDs rather than amending them\n");
+    fprintf(to, "  -c             for each RG ID use RG line of 1st file it is in rather than uniquifying them\n");
+    fprintf(to, "  -p             for each PG ID use PG line of 1st file it is in rather than uniquifying them\n");
     fprintf(to, "  -s VALUE       override random seed\n");
     fprintf(to, "  -b FILE        list of input BAM filenames, one per line [null]\n");
     sam_global_opt_help(to, "-.O..");

--- a/samtools.1
+++ b/samtools.1
@@ -798,10 +798,13 @@ Attach an RG tag to each alignment. The tag value is inferred from file names.
 Uncompressed BAM output
 .TP
 .B -c
-Combine RG tags with colliding IDs rather than adding a suffix to differentiate them.
+For each RG ID in the set of files to merge use RG line of the first file
+we find it in rather than adding a suffix to differentiate them. This and the
+following option is to be used when the files to be merged were originally one file.
 .TP
 .B -p
-Combine PG tags with colliding IDs rather than adding a suffix to differentiate them.
+For each RG ID in the set of files to merge use RG line of the first file
+we find it in rather than adding a suffix to differentiate them.
 .RE
 
 .TP \"-------- faidx


### PR DESCRIPTION
Update merge -cp usage to clarify we use the first line with a given ID rather than merging the actual lines (fixes #482)