### PR TITLE
Prevents unintended free in finish_merged_header when n_targets == 0

### DIFF
--- a/bam_sort.c
+++ b/bam_sort.c
@@ -860,6 +860,7 @@ static bam_hdr_t * finish_merged_header(merged_header_t *merged_hdr) {
     char      *text;
     char     **target_name;
     uint32_t  *target_len;
+    size_t     targets_sz = merged_hdr->n_targets ? merged_hdr->n_targets : 1;
     bam_hdr_t *hdr;
 
     // Check output text size
@@ -879,9 +880,9 @@ static bam_hdr_t * finish_merged_header(merged_header_t *merged_hdr) {
 
     // Try to shrink targets arrays to correct size
     target_name = realloc(merged_hdr->target_name,
-                          merged_hdr->n_targets * sizeof(*target_name));
+                          targets_sz * sizeof(*target_name));
     target_len = realloc(merged_hdr->target_len,
-                         merged_hdr->n_targets * sizeof(*target_len));
+                         targets_sz * sizeof(*target_len));
 
     // Transfer targets arrays to new header
     hdr->n_targets   = merged_hdr->n_targets;


### PR DESCRIPTION
finish_merged_header reallocs the target_name and target_len arrays to
be exactly n_targets in size.  This caused a problem when n_targets == 0
as realloc(ptr, 0) frees ptr.  To stop this from happening, make sure we
always allocate at least one element.

Fixes #495
