### PR TITLE
set a matrix.include for all os options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,22 @@
 # Control file for continuous integration testing at http://travis-ci.org/
 
-os:
-  - linux
-  - osx
-
 language: c
-compiler:
-  - clang
-  - gcc
 
-matrix:
-  include:
+matrix: 
+  include: 
+    - os: linux 
+      compiler: clang
+    - os: linux 
+      compiler: gcc
     # An unoptimised C99 build, for detecting non-static inline functions
-    - compiler: gcc
-      env: CFLAGS="-std=gnu99 -O0"
-
+    - os: linux
+      compiler: gcc
+      env: CFLAGS="-std=gnu99 -O0
+    - os: osx
+      compiler: clang
+    - os: osx
+      compiler: gcc
+      
 env:
   global:
     - HTSDIR=./htslib


### PR DESCRIPTION
Hey Samtools and @lbergelson, @jmarshall!

This is María from Travis CI support team. 

This should fix the 5th stuck build in samtools/samtools as it was getting unrouted in our new [Precise GCE infrastructure](https://blog.travis-ci.com/2015-11-27-moving-to-a-more-elastic-future)

E.g. https://travis-ci.org/samtools/samtools/jobs/97105647 out of https://travis-ci.org/samtools/samtools/builds/97105640 :) 

Hope this helps!