### PR TITLE
faidx with long opts + output filename + line length

### DIFF
--- a/faidx.c
+++ b/faidx.c
@@ -21,7 +21,13 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
 THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.  */
+DEALINGS IN THE SOFTWARE.
+
+History:
+
+  * 2016-01-12: Pierre Lindenbaum @yokofakun : added options -o -n 
+
+*/
 
 #include <ctype.h>
 #include <string.h>
@@ -30,7 +36,11 @@ DEALINGS IN THE SOFTWARE.  */
 #include <stdint.h>
 #include <unistd.h>
 #include <stdarg.h>
+#include <errno.h>
+#include <getopt.h>
 #include <htslib/faidx.h>
+
+#define DEFAULT_FASTA_LINE_LEN 60
 
 static void error(const char *format, ...)
 {
@@ -44,7 +54,9 @@ static void error(const char *format, ...)
     else
     {
         fprintf(stderr, "\n");
-        fprintf(stderr, "Usage:   samtools faidx <file.fa|file.fa.gz> [<reg> [...]]\n");
+        fprintf(stderr, "Usage:\n\n");
+        fprintf(stderr, " Build Index:\n\n  samtools faidx <file.fa|file.fa.gz>\n\n");
+        fprintf(stderr, " Query Index:\n\n  samtools faidx [-n|--length line_len number] [-o|--output output.fa] <file.fa|file.fa.gz> [<reg> [...]]\n\n",DEFAULT_FASTA_LINE_LEN);
         fprintf(stderr, "\n");
     }
     exit(-1);
@@ -54,42 +66,73 @@ static void error(const char *format, ...)
 int faidx_main(int argc, char *argv[])
 {
     int c;
-    while((c  = getopt(argc, argv, "h")) >= 0)
-    {
-        switch(c)
-        {
-            case 'h':
-            default:
-                error(NULL);
+    int line_len = DEFAULT_FASTA_LINE_LEN ;/* fasta line len */
+    char* output_file = NULL; /* output file (default is stdout ) */
+    FILE* file_out = stdout;/* output stream */
+    
+    static const struct option lopts[] = {
+        { "output", required_argument, NULL, 'o' },
+        { "help",   no_argument,       NULL, 'h' },
+        { "length", required_argument, NULL, 'n' },
+        { NULL, 0, NULL, 0 }
+    };
+
+    while ((c = getopt_long(argc, argv, "ho:n:", lopts, NULL)) >= 0) {
+        switch (c) {
+            case 'o': output_file = optarg; break;
+            case 'n': line_len = atoi(optarg);
+                      if(line_len<1) {
+                        fprintf(stderr,"[faidx] bad line length '%s', using default:%d\n",optarg,DEFAULT_FASTA_LINE_LEN);
+                        line_len= DEFAULT_FASTA_LINE_LEN ;
+                        }
+                      break;
+            case '?': fprintf(stderr,"[faidx] unknown option '%c'\n",optopt); return EXIT_FAILURE;break;
+            case 'h': error(NULL);
+            default:  break;
         }
     }
+
+    
     if ( argc==optind )
         error(NULL);
-    if ( argc==2 )
+    if ( optind+1 == argc )
     {
         fai_build(argv[optind]);
         return 0;
     }
 
     faidx_t *fai = fai_load(argv[optind]);
-    if ( !fai ) error("Could not load fai index of %s\n", argv[optind]);
-
+    if ( !fai ) error("[faidx] Could not load fai index of %s\n", argv[optind]);
+    
+    /** output file provided by user */
+    if( output_file != NULL ) {
+          if( strcmp( output_file, argv[optind] ) == 0 ) {
+               fprintf(stderr,"[faidx] same input/output : %s\n", output_file);
+               return EXIT_FAILURE;
+               }
+          file_out = fopen( output_file, "w" );
+          if( file_out == NULL) {
+               fprintf(stderr,"[faidx] Cannot open \"%s\" for writing :%s.\n", output_file, strerror(errno) );
+               return EXIT_FAILURE;
+               }
+          }
     while ( ++optind<argc )
     {
-        printf(">%s\n", argv[optind]);
+        fprintf(file_out, ">%s\n", argv[optind]);
         int i, j, seq_len;
         char *seq = fai_fetch(fai, argv[optind], &seq_len);
-        if ( seq_len < 0 ) error("Failed to fetch sequence in %s\n", argv[optind]);
-        for (i=0; i<seq_len; i+=60)
+        if ( seq_len < 0 ) error("[faidx] Failed to fetch sequence in %s\n", argv[optind]);
+        for (i=0; i<seq_len; i+= line_len)
         {
-            for (j=0; j<60 && i+j<seq_len; j++)
-                putchar(seq[i+j]);
-            putchar('\n');
+            for (j=0; j<line_len && i+j<seq_len; j++)
+                fputc(seq[i+j],file_out);
+            fputc('\n',file_out);
         }
         free(seq);
     }
     fai_destroy(fai);
-
+    fflush(file_out);
+    if( output_file != NULL) fclose(file_out);
     return 0;
 }
 

--- a/test/test.pl
+++ b/test/test.pl
@@ -458,6 +458,7 @@ sub test_faidx
     cmd("$$opts{bin}/samtools faidx $$opts{tmp}/faidx.fa");
     cmd("cat $$opts{tmp}/faidx.fa | $$opts{bgzip} -ci -I $$opts{tmp}/faidx.fa.gz.gzi > $$opts{tmp}/faidx.fa.gz");
     cmd("$$opts{bin}/samtools faidx $$opts{tmp}/faidx.fa.gz");
+    cmd("$$opts{bin}/samtools faidx --length 5 --output $$opts{tmp}/output_faidx.fa $$opts{tmp}/faidx.fa 1:1-104 && test -f $$opts{tmp}/output_faidx.fa");
 
     for my $reg ('3:11-13','2:998-1003','1:100-104','1:99998-100007')
     {


### PR DESCRIPTION
some Minor changes in faidx:
- added support for long_opt
- added option -o|--output (default:stdout)
- added option -n|--length to specify the length of the lines in the fasta output
