### PR TITLE
Extended view -x to handle tag-lists and also added a whitelist equivalent.

### DIFF
--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -362,7 +362,19 @@ in octal by beginning with `0' (i.e. /^0[0-7]+/), as a decimal number
 not beginning with '0' or as a comma-separated list of flag names.
 .TP
 .BI "-x " STR ", --remove-tag " STR
-Read tag to exclude from output (repeatable) [null]
+Read tag(s) to exclude from output (repeatable) [null].  This can be a
+single tag or a comma separated list.  Alternatively the option itself
+can be repeated multiple times.
+
+If the list starts with a `^' then it is negated and treated as a
+request to remove all tags except those in \fISTR\fR. The list may be
+empty, so \fB-x ^\fR will remove all tags.
+.TP
+.BI --keep-tag " STR
+This keeps \fIonly\fR tags listed in \fISTR\fR and is directly equivalent
+to \fB--remove-tag ^\fR\fISTR\fR.  Specifying an empty list will remove
+all tags.  If both \fB--keep-tag\fR and \fB--remove-tag\fR are
+specified then \fB--keep-tag\fR has precedence.
 .TP
 .BR -B ", " --remove-B
 Collapse the backward CIGAR operation.

--- a/test/test.pl
+++ b/test/test.pl
@@ -2124,6 +2124,13 @@ sub test_view
         ['tags1', { strip_tags => { fa => 1 } }, ['-x', 'fa'], 0],
         ['tags2', { strip_tags => { fa => 1, ha => 1 } },
          ['-x', 'fa', '-x', 'ha'], 0],
+        ['tags2', { strip_tags => { fa => 1, ha => 1 } },
+         ['-x', 'fa,ha'], 0],
+        ['tags2', { strip_tags => { fa => 1, ha => 1 } },
+        # All tags in test file bar fa and ha, negated
+         ['-x', '^RG,BC,NM,MD,H0,aa,ab,za,ba,bb,bc,bd,be,bf,bg,ia'], 0],
+        ['tags2', { strip_tags => { fa => 1, ha => 1 } },
+         ['--keep-tag', 'RG,BC,NM,MD,H0,aa,ab,za,ba,bb,bc,bd,be,bf,bg,ia'], 0],
         # Tag strip plus read group
         ['tags_rg1', { strip_tags => { fa => 1 }, read_groups => { grp2 => 1 }},
          ['-x', 'fa', '-r', 'grp2'], 0],


### PR DESCRIPTION
Both have long options now too.

NOTE: We may wish to consider making some functions from htslib public.  See the aux_type2size and skip_aux functions below.  These exist in htslib and are needed in samtools, but are duplicated here until we have a discussion on what public API we wish to expose (these or a derivative?).

Example uses:

  samtools view -x BD -x BI -x BQ in.bam
  samtools view -x{BD,BI,BQ} in.bam;               # equivalent via shell
  samtools view -x BD,BI,BQ in.bam;                # equivalent
  samtools view --tag-blacklist=BD,BI,BQ in.bam;   # equivalent

  samtools view --tag-whitelist BD,BI,BQ;          # opposite of above
