### PR TITLE
Improved documentation of how mpileup -d/-L work.

### DIFF
--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -787,7 +787,7 @@ static void print_usage(FILE *fp, const mplp_conf_t *mplp)
 "  -b, --bam-list FILE     list of input BAM filenames, one per line\n"
 "  -B, --no-BAQ            disable BAQ (per-Base Alignment Quality)\n"
 "  -C, --adjust-MQ INT     adjust mapping quality; recommended:50, disable:0 [0]\n"
-"  -d, --max-depth INT     max per-BAM depth; avoids excessive memory usage [%d]\n", mplp->max_depth);
+"  -d, --max-depth INT     max per-file depth; avoids excessive memory usage [%d]\n", mplp->max_depth);
     fprintf(fp,
 "  -E, --redo-BAQ          recalculate BAQ on the fly, ignore existing BQs\n"
 "  -f, --fasta-ref FILE    faidx indexed reference sequence file\n"
@@ -828,7 +828,7 @@ static void print_usage(FILE *fp, const mplp_conf_t *mplp)
 "  -h, --tandem-qual INT   coefficient for homopolymer errors [%d]\n", mplp->tandemQ);
     fprintf(fp,
 "  -I, --skip-indels       do not perform indel calling\n"
-"  -L, --max-idepth INT    maximum per-sample depth for INDEL calling [%d]\n", mplp->max_indel_depth);
+"  -L, --max-idepth INT    maximum per-file depth for INDEL calling [%d]\n", mplp->max_indel_depth);
     fprintf(fp,
 "  -m, --min-ireads INT    minimum number gapped reads for indel candidates [%d]\n", mplp->min_support);
     fprintf(fp,

--- a/samtools.1
+++ b/samtools.1
@@ -1076,7 +1076,7 @@ where
 .I n
 is the number of input files given to mpileup.  This means the default
 is highly likely to be increased.  Once above the cross-sample minimum of
-8000 the -d parameters will have an affect. [250]
+8000 the -d parameter will have an affect. [250]
 .TP
 .B -E, --redo-BAQ
 Recalculate BAQ on the fly, ignore existing BQ tags

--- a/samtools.1
+++ b/samtools.1
@@ -1070,7 +1070,13 @@ functionality; if enabled, the recommended value for BWA is 50. [0]
 .BI -d,\ --max-depth \ INT
 At a position, read maximally
 .I INT
-reads per input BAM. [250]
+reads per input file. Note that samtools has a minimum value of
+.I 8000/n
+where
+.I n
+is the number of input files given to mpileup.  This means the default
+is highly likely to be increased.  Once above the cross-sample minimum of
+8000 the -d parameters will have an affect. [250]
 .TP
 .B -E, --redo-BAQ
 Recalculate BAQ on the fly, ignore existing BQ tags
@@ -1235,7 +1241,7 @@ is modeled as
 Do not perform INDEL calling
 .TP
 .BI -L,\ --max-idepth \ INT
-Skip INDEL calling if the average per-sample depth is above
+Skip INDEL calling if the average per-input-file depth is above
 .IR INT .
 [250]
 .TP


### PR DESCRIPTION
They're still quirky, but at least it's documented quirks!

Fixes #29 in as far as the bizarreness is documented.