### PR TITLE
Remove gcc build on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ matrix:
       env: CFLAGS="-std=gnu99 -O0"
     - os: osx
       compiler: clang
-    - os: osx
-      compiler: gcc
 
 env:
   global:


### PR DESCRIPTION
It's just using clang anyway:
https://travis-ci.org/samtools/samtools/jobs/107289030#L37