### PR TITLE
Fixed bam_get_library() crash.

### DIFF
--- a/bam.c
+++ b/bam.c
@@ -105,6 +105,9 @@ const char *bam_get_library(bam_header_t *h, const bam1_t *b)
             last = *cp++;
         }
 
+        if (!ID || !LB)
+            continue;
+
         // Check it's the correct ID
         if (strncmp(rg, ID, strlen(rg)) != 0 || ID[strlen(rg)] != '\t')
             continue;

--- a/sam_view.c
+++ b/sam_view.c
@@ -98,7 +98,7 @@ static int process_aln(const bam_hdr_t *h, bam1_t *b, samview_settings_t* settin
     }
     if (settings->library) {
         const char *p = bam_get_library((bam_hdr_t*)h, b);
-        if (p && strcmp(p, settings->library) != 0) return 1;
+        if (!p || strcmp(p, settings->library) != 0) return 1;
     }
     if (settings->remove_aux_len) {
         size_t i;

--- a/test/dat/view.001.sam
+++ b/test/dat/view.001.sam
@@ -1,7 +1,7 @@
 @HD	VN:1.4	SO:coordinate
 @RG	ID:grp1	DS:Group 1	LB:Library 1	SM:Sample
 @RG	ID:grp2	DS:Group 2	LB:Library 2	SM:Sample
-@RG	ID:grp3	DS:Group 3	LB:Library 3	SM:Sample
+@RG	ID:grp3	DS:Group 3	SM:Sample
 @PG	ID:prog1	PN:emacs	CL:emacs	VN:23.1.1
 @CO	The MIT License
 @CO	

--- a/test/test.pl
+++ b/test/test.pl
@@ -1668,6 +1668,7 @@ sub test_view
          ['-r', 'grp2', '-R', $fogn], 0],
         # Libraries
         ['lib2', { libraries => { 'Library 2' => 1 }}, ['-l', 'Library 2'], 0],
+        ['lib3', { libraries => { 'Library 3' => 1 }}, ['-l', 'Library 3'], 0],
         # Mapping qualities
         ['mq50',  { min_map_qual => 50 },  ['-q', 50], 0],
         ['mq99',  { min_map_qual => 99 },  ['-q', 99], 0],


### PR DESCRIPTION
This was triggerable from samtools rmdup or samtools view -l when an
@RG header was present without an LB: record.

I also fixed the samtools view -l logic.  The man page states that it
only shows reads in that library, while the implementation was to only
show reads in that library or those where it could not determine the
library.

Fixes #538