### PR TITLE
Fix bug caused by difference between BAM and SAM API

### DIFF
--- a/sam_view.c
+++ b/sam_view.c
@@ -928,7 +928,7 @@ static bool bam2fq_mainloop_singletontrack(bam2fq_state_t *state)
 
     bool valid = true;
     while (true) {
-        at_eof = sam_read1(state->fp, state->h, b);
+        at_eof = sam_read1(state->fp, state->h, b) < 0;
 
         if (!at_eof && filter_it_out(b, state)) continue;
         if (!at_eof) ++n_reads;


### PR DESCRIPTION
BAM returns different values to SAM and there was a silly mistake in the code that checked that value. (Fixes #532)