### PR TITLE
Fixed the `-a` option for zero coverage positions

### DIFF
--- a/bam2depth.c
+++ b/bam2depth.c
@@ -213,7 +213,7 @@ int main_depth(int argc, char *argv[])
         if (bed && bed_overlap(bed, h->target_name[tid], pos, pos + 1) == 0) continue; // not in BED; skip
         if (all) {
             while (tid > last_tid) {
-                if (last_tid >= 0 && all > 1 && !reg) {
+                if (last_tid >= 0 && !reg) {
                     // Deal with remainder or entirety of last tid
                     while (++last_pos < h->target_len[last_tid]) {
                         if (bed && bed_overlap(bed, h->target_name[last_tid], last_pos, last_pos + 1) == 0)
@@ -226,6 +226,8 @@ int main_depth(int argc, char *argv[])
                 }
                 last_tid++;
                 last_pos = -1;
+                if (all < 2)
+                    break;
             }
 
             // Deal with missing portion of current tid


### PR DESCRIPTION
Fixes #374 after my [comment](https://github.com/samtools/samtools/issues/374#issuecomment-219427442).
The test in `test/mpileup/xx#depth1.sam` was unable to detect the bug because the two reads are on the same contig `xx`. Putting the second read to contig `xn` reveals the bug:
```
$ cat test/mpileup/xx#depth3.sam 
@HD	VN:1.4	SO:coordinate
@SQ	SN:xp	LN:20	AS:?	SP:?	UR:?	M5:bbf4de6d8497a119dda6e074521643dc
@SQ	SN:xx	LN:20	AS:?	SP:?	UR:?	M5:bbf4de6d8497a119dda6e074521643dc
@SQ	SN:xn	LN:20	AS:?	SP:?	UR:?	M5:bbf4de6d8497a119dda6e074521643dc
a1	16	xx	6	1	3M	*	0	0	*	*
b1	16	xn	13	1	3M	*	0	0	*	*
```
The current version returns:
```
$ ./samtools depth -a test/mpileup/xx#depth3.sam 
xx	1	0
xx	2	0
xx	3	0
xx	4	0
xx	5	0
xx	6	1
xx	7	1
xx	8	1
xn	1	0
xn	2	0
xn	3	0
xn	4	0
xn	5	0
xn	6	0
xn	7	0
xn	8	0
xn	9	0
xn	10	0
xn	11	0
xn	12	0
xn	13	1
xn	14	1
xn	15	1
xn	16	0
xn	17	0
xn	18	0
xn	19	0
xn	20	0
```
where contig `xx` is cut after it's last read in position 8. After the change I made in the code we have the correct output:
```
$ ./samtools depth -a test/mpileup/xx#depth3.sam 
xx	1	0
xx	2	0
xx	3	0
xx	4	0
xx	5	0
xx	6	1
xx	7	1
xx	8	1
xx	9	0
xx	10	0
xx	11	0
xx	12	0
xx	13	0
xx	14	0
xx	15	0
xx	16	0
xx	17	0
xx	18	0
xx	19	0
xx	20	0
xn	1	0
xn	2	0
xn	3	0
xn	4	0
xn	5	0
xn	6	0
xn	7	0
xn	8	0
xn	9	0
xn	10	0
xn	11	0
xn	12	0
xn	13	1
xn	14	1
xn	15	1
xn	16	0
xn	17	0
xn	18	0
xn	19	0
xn	20	0
```