### PR TITLE
Enforce a minimum memory requirement for samtools sort

### DIFF
--- a/samtools.1
+++ b/samtools.1
@@ -404,6 +404,9 @@ or with a
 .BR K ", " M ", or " G
 suffix.
 [768 MiB]
+.IP
+To prevent sort from creating a huge number of temporary files, it enforces a
+minimum value of 1M for this setting.
 .TP
 .B -n
 Sort by read names (i.e., the


### PR DESCRIPTION
Prevent accidents where sort creates one temporary file per input read
by refusing to run unless the -m parameter is set to at least 1 MiB.
If it doesn't run, it prints an error message explaining in detail why
not.

Includes a note in the man page describing the limit.

Fixes #547.