### PR TITLE
Amend info regarding bedcov subcommand

### DIFF
--- a/bam2depth.c
+++ b/bam2depth.c
@@ -80,10 +80,10 @@ static int usage() {
     fprintf(stderr, "   -a -a (or -aa)      output absolutely all positions, including unused ref. sequences\n");
     fprintf(stderr, "   -b <bed>            list of positions or regions\n");
     fprintf(stderr, "   -f <list>           list of input BAM filenames, one per line [null]\n");
-    fprintf(stderr, "   -l <int>            read length threshold (ignore reads shorter than <int>)\n");
+    fprintf(stderr, "   -l <int>            read length threshold (ignore reads shorter than <int>) [0]\n");
     fprintf(stderr, "   -d/-m <int>         maximum coverage depth [8000]\n");  // the htslib's default
-    fprintf(stderr, "   -q <int>            base quality threshold\n");
-    fprintf(stderr, "   -Q <int>            mapping quality threshold\n");
+    fprintf(stderr, "   -q <int>            base quality threshold [0]\n");
+    fprintf(stderr, "   -Q <int>            mapping quality threshold [0]\n");
     fprintf(stderr, "   -r <chr:from-to>    region\n");
 
     sam_global_opt_help(stderr, "-.--.");

--- a/bedcov.c
+++ b/bedcov.c
@@ -89,7 +89,8 @@ int main_bedcov(int argc, char *argv[])
     }
     if (usage || optind + 2 > argc) {
         fprintf(stderr, "Usage: samtools bedcov [options] <in.bed> <in1.bam> [...]\n\n");
-        fprintf(stderr, "  -Q INT       Only count bases of at least INT quality [0]\n");
+        fprintf(stderr, "Options:\n");
+        fprintf(stderr, "   -Q <int>            mapping quality threshold [0]\n");
         sam_global_opt_help(stderr, "-.--.");
         return 1;
     }

--- a/samtools.1
+++ b/samtools.1
@@ -695,9 +695,17 @@ Suppress outputting IS rows where there are no insertions.
 .TP \"-------- bedcov
 .B bedcov
 samtools bedcov
+.RI [ options ]
 .IR region.bed " " in1.sam | in1.bam | in1.cram "[...]"
 
 Reports read depth per genomic region, as specified in the supplied BED file.
+
+.B Options:
+.RS
+.TP
+.BI "-Q " INT
+.RI "Only count reads with mapping quality greater than " INT
+.RE
 
 .TP \"-------- depth
 .B depth


### PR DESCRIPTION
Correct help message from command to note the -Q INT optional filter
works on mapping quality (not base quality). Report help messages
from depth and bedcov more consistently. Add -Q option to bedcov
entry in man page.

Resolves #580