### PR TITLE
memory optimization for better sorting performance

### DIFF
--- a/bam_sort.c
+++ b/bam_sort.c
@@ -1741,7 +1741,7 @@ int bam_sort_core_ext(int is_by_qname, const char *fn, const char *prefix,
     size_t max_k, k, max_mem;
     bam_hdr_t *header = NULL;
     samFile *fp;
-    bam1_t b = {0}, **buf;
+    bam1_t b, **buf;
     uint8_t *bam_mem, *bam_mem_offset;
 
     if (n_threads < 2) n_threads = 1;

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -1741,7 +1741,7 @@ int bam_sort_core_ext(int is_by_qname, const char *fn, const char *prefix,
     size_t max_k, k, max_mem;
     bam_hdr_t *header = NULL;
     samFile *fp;
-    bam1_t b, **buf;
+    bam1_t b = {.m_data = 0}, **buf;
     uint8_t *bam_mem, *bam_mem_offset;
 
     if (n_threads < 2) n_threads = 1;

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -1738,11 +1738,11 @@ int bam_sort_core_ext(int is_by_qname, const char *fn, const char *prefix,
                       const htsFormat *in_fmt, const htsFormat *out_fmt)
 {
     int ret = -1, i, n_files = 0;
-    size_t max_k, k, max_mem;
+    size_t max_k, k, max_mem, bam_mem_offset;
     bam_hdr_t *header = NULL;
     samFile *fp;
-    bam1_t b = {.m_data = 0}, **buf;
-    uint8_t *bam_mem, *bam_mem_offset;
+    bam1_t *b = bam_init1(), **buf;
+    uint8_t *bam_mem;
 
     if (n_threads < 2) n_threads = 1;
     g_is_by_qname = is_by_qname;
@@ -1766,17 +1766,17 @@ int bam_sort_core_ext(int is_by_qname, const char *fn, const char *prefix,
 
     }
     // write sub files
-    for (k = 0, max_k = 0, bam_mem_offset = bam_mem; true; ++k) {
-        if ((ret = sam_read1(fp, header, &b)) < 0) break;
+    for (k = 0, max_k = 0, bam_mem_offset = 0; true; ++k) {
+        if ((ret = sam_read1(fp, header, b)) < 0) break;
         // if the BAM record could cause the memory limit to be exceeded
-        if ((uintptr_t)bam_mem_offset + sizeof(b) + b.l_data > (uintptr_t)bam_mem + max_mem - 1) {
+        if (bam_mem_offset + sizeof(*b) + b->l_data > (uintptr_t)bam_mem + max_mem - 1) {
             n_files = sort_blocks(n_files, k, buf, prefix, header, n_threads);
             if (n_files < 0) {
                 ret = -1;
                 goto err;
             }
             k = 0;
-            bam_mem_offset = bam_mem;
+            bam_mem_offset = 0;
         }
         if (k == max_k) {
             max_k = max_k? max_k<<1 : 0x10000;
@@ -1786,12 +1786,12 @@ int bam_sort_core_ext(int is_by_qname, const char *fn, const char *prefix,
                 goto err;
             }
         }
-        buf[k] = (bam1_t *)bam_mem_offset;
-        *buf[k] = b;
+        buf[k] = (bam1_t *)(bam_mem + bam_mem_offset);
+        *buf[k] = *b;
         buf[k]->data = (uint8_t *)((char *)buf[k] + sizeof(bam1_t));
-        memcpy(buf[k]->data, b.data, b.l_data);
+        memcpy(buf[k]->data, b->data, b->l_data);
         // store next BAM record in next 8-byte-aligned address after current BAM record
-        bam_mem_offset = (uint8_t *)(((uintptr_t)bam_mem_offset + sizeof(b) + b.l_data + 8 - 1) & ~((uintptr_t)(8 - 1)));
+        bam_mem_offset = (bam_mem_offset + sizeof(*b) + b->l_data + 8 - 1) & ~((size_t)(8 - 1));
     }
     if (ret != -1) {
         print_error("sort", "truncated file. Aborting");
@@ -1838,6 +1838,7 @@ int bam_sort_core_ext(int is_by_qname, const char *fn, const char *prefix,
 
  err:
     // free
+    bam_destroy1(b);
     free(buf);
     bam_hdr_destroy(header);
     sam_close(fp);


### PR DESCRIPTION
This proposed change improves sorting performance by storing BAM records in a contiguous memory region that is allocated/deallocated with a single malloc() and freed with a single free(), eliminating overhead associated with many small memory allocations/deallocations. This resulted in a 20-25% reduction in wall time when sorting ~127 million BAM records entirely in memory on two different benchmark systems (both with 64GB memory).

As a prerequisite, this requires the addition of a flexible array member to the bam1_t struct described in https://github.com/samtools/htslib/pull/393

The underlying buffer is both allocated and freed within bam_sort_core_ext(), and the existing bam1_t "data" member is made to point to the flexible array member for backwards compatibility with subroutines invoked from bam_sort_core_ext(). For backwards compatibility with other code, (e.g., bam_read1() in htslib), the bam1_t "data" member is made to point to the flexible array member. So that a realloc() on the bam1_t data member doesn't occur in the htslib bam_read1(), the "m_data" member is set to INT_MAX.

This change may make memory usage a bit more predictable (potentially resolving https://github.com/samtools/samtools/issues/494). It shouldn't cause an increase in the actual memory used by the process over the existing approach, since the extra physical memory won't be used until the corresponding memory pages are touched. To make the memory limit more precise, a guesstimate of the maximum size of the buf[] array could be subtracted from the size of the allocated bam_array. This also largely obviates the need for a previous patch I submitted (https://github.com/samtools/samtools/pull/507), which avoided costly memory deallocation (e.g., hundreds of millions of calls to free() for the data set I had benchmarked with) by simply exiting without freeing the memory, letting the OS reclaim it at the end of execution.
