### PR TITLE
Place percent mapped bases output in the correct field

### DIFF
--- a/misc/plot-bamstats
+++ b/misc/plot-bamstats
@@ -1386,8 +1386,8 @@ sub create_html
             <tr><th>Bases</tr>
             <tr>
                 <td class="pad"><table>
-                <tr><td>total:       <td class="right"> $bases_total    <td class="right"> $bpercent_mapped</tr>
-                <tr><td>mapped:      <td class="right"> $bases_mapped   <td class="right"></tr>
+                <tr><td>total:       <td class="right"> $bases_total    <td class="right"></tr>
+                <tr><td>mapped:      <td class="right"> $bases_mapped   <td class="right"> $bpercent_mapped</tr>
                 <tr><td>error rate:      <td class="right"> $error_rate  <td class="right"></tr>
                 </table></tr>
         </table>


### PR DESCRIPTION
The simple plot-bamstats HTML output placed the percentage of mapped bases into an incorrect field.