### PR TITLE
index: update error message for failure to index

### DIFF
--- a/bam_index.c
+++ b/bam_index.c
@@ -94,7 +94,7 @@ int bam_index(int argc, char *argv[])
         break;
 
     default:
-        print_error("index", "\"%s\" is corrupted or unsorted", argv[optind]);
+        print_error_errno("index", "failed to create index for \"%s\"", argv[optind]);
         break;
     }
 


### PR DESCRIPTION
After samtools/htslib#470, which fixes the underlying issue #241,
we update the error message upon failure to index. See
https://github.com/samtools/samtools/issues/241#issuecomment-279783955

Closes #241