### PR TITLE
Add optional QNAME column to mpileup text output

### DIFF
--- a/samtools.1
+++ b/samtools.1
@@ -1284,6 +1284,9 @@ Output base positions on reads.
 .B -s, --output-MQ
 Output mapping quality.
 .TP
+.B --output-QNAME
+Output an extra column containing comma-separated read names.
+.TP
 .B -a
 Output all positions, including those with zero depth.
 .TP


### PR DESCRIPTION
We recently had a need to answer questions like “find all the reads with a T at genomic position NNN”. Thinking `mpileup` text output had an option to show read names, a quick 'n' dirty script parsing mpileup output sprang to mind — but it turns out `mpileup` doesn't do that.

There may be a better approach to answering such questions, but this is a simple one…