### PR TITLE
Changing the header HD line when sorting or collating

### DIFF
--- a/bamshuf.c
+++ b/bamshuf.c
@@ -110,6 +110,18 @@ static int bamshuf(const char *fn, int n_files, const char *pre, int clevel,
         fprintf(stderr, "Couldn't read header for '%s'\n", fn);
         goto fail;
     }
+
+    if (sam_hdr_change_HD(h, "SO", "unsorted") != 0) {
+        print_error("collate",
+                    "failed to change sort order header to 'unsorted'\n");
+        goto fail;
+    }
+    if (sam_hdr_change_HD(h, "GO", "query") != 0) {
+        print_error("collate",
+                    "failed to change group order header to 'query'\n");
+        goto fail;
+    }
+
     fnt = (char**)calloc(n_files, sizeof(char*));
     if (!fnt) goto mem_fail;
     fpt = (samFile**)calloc(n_files, sizeof(samFile*));

--- a/bamtk.c
+++ b/bamtk.c
@@ -31,7 +31,6 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include "htslib/hts.h"
 #include "samtools.h"
-#include "version.h"
 
 int bam_taf2baf(int argc, char *argv[]);
 int bam_mpileup(int argc, char *argv[]);
@@ -64,10 +63,6 @@ int main_addreplacerg(int argc, char *argv[]);
 int faidx_main(int argc, char *argv[]);
 int dict_main(int argc, char *argv[]);
 
-const char *samtools_version()
-{
-    return SAMTOOLS_VERSION;
-}
 
 static void usage(FILE *fp)
 {

--- a/sam_utils.c
+++ b/sam_utils.c
@@ -28,8 +28,10 @@ DEALINGS IN THE SOFTWARE.  */
 #include <stdarg.h>
 #include <string.h>
 #include <errno.h>
+#include <stdlib.h>
 
 #include "samtools.h"
+#include "version.h"
 
 static void vprint_error_core(const char *subcommand, const char *format, va_list args, const char *extra)
 {
@@ -57,4 +59,30 @@ void print_error_errno(const char *subcommand, const char *format, ...)
     va_start(args, format);
     vprint_error_core(subcommand, format, args, err? strerror(err) : NULL);
     va_end(args);
+}
+
+const char *samtools_version()
+{
+    return SAMTOOLS_VERSION;
+}
+
+const char *samtools_version_short()
+{
+    char *sv, *hyph, *v;
+    int len;
+
+    v = SAMTOOLS_VERSION;
+    hyph = strchr(v, '-');
+    if (!hyph)
+        return strdup(v);
+
+    len = hyph - v;
+    sv = (char *)malloc(len+1);
+    if (!sv)
+        return NULL;
+
+    strncpy(sv, v, len);
+    sv[len] = '\0';
+
+    return (const char*)sv;
 }

--- a/samtools.h
+++ b/samtools.h
@@ -26,6 +26,7 @@ DEALINGS IN THE SOFTWARE.  */
 #define SAMTOOLS_H
 
 const char *samtools_version(void);
+const char *samtools_version_short(void);
 
 #if defined __GNUC__ && __GNUC__ >= 2
 #define CHECK_PRINTF(fmt,args) __attribute__ ((format (printf, fmt, args)))

--- a/test/split/test_filter_header_rg.c
+++ b/test/split/test_filter_header_rg.c
@@ -40,10 +40,11 @@ void setup_test_1(bam_hdr_t** hdr_in)
 }
 
 bool check_test_1(const bam_hdr_t* hdr) {
-    const char *test1_res =
+    char test1_res[200];
+    snprintf(test1_res, 199,
     "@HD\tVN:1.4\n"
     "@SQ\tSN:blah\n"
-    "@PG\tID:samtools\tPN:samtools\tVN:x.y.test\tCL:test_filter_header_rg foo bar baz\n";
+    "@PG\tID:samtools\tPN:samtools\tVN:%s\tCL:test_filter_header_rg foo bar baz\n", samtools_version());
 
     if (strcmp(hdr->text, test1_res)) {
         return false;
@@ -63,11 +64,12 @@ void setup_test_2(bam_hdr_t** hdr_in)
 }
 
 bool check_test_2(const bam_hdr_t* hdr) {
-    const char *test2_res =
+    char test2_res[200];
+    snprintf(test2_res, 199,
     "@HD\tVN:1.4\n"
     "@SQ\tSN:blah\n"
     "@RG\tID:fish\n"
-    "@PG\tID:samtools\tPN:samtools\tVN:x.y.test\tCL:test_filter_header_rg foo bar baz\n";
+    "@PG\tID:samtools\tPN:samtools\tVN:%s\tCL:test_filter_header_rg foo bar baz\n", samtools_version());
 
     if (strcmp(hdr->text, test2_res)) {
         return false;
@@ -112,7 +114,7 @@ int main(int argc, char *argv[])
     bam_hdr_t* hdr1;
     const char* id_to_keep_1 = "1#2.3";
     setup_test_1(&hdr1);
-    if (verbose > 1) {
+    if (verbose > 0) {
         printf("hdr1\n");
         dump_hdr(hdr1);
     }
@@ -124,7 +126,7 @@ int main(int argc, char *argv[])
     fclose(stderr);
 
     if (verbose) printf("END RUN test 1\n");
-    if (verbose > 1) {
+    if (verbose > 0) {
         printf("hdr1\n");
         dump_hdr(hdr1);
     }
@@ -151,7 +153,7 @@ int main(int argc, char *argv[])
     bam_hdr_t* hdr2;
     const char* id_to_keep_2 = "fish";
     setup_test_2(&hdr2);
-    if (verbose > 1) {
+    if (verbose > 0) {
         printf("hdr2\n");
         dump_hdr(hdr2);
     }
@@ -163,7 +165,7 @@ int main(int argc, char *argv[])
     fclose(stderr);
 
     if (verbose) printf("END RUN test 2\n");
-    if (verbose > 1) {
+    if (verbose > 0) {
         printf("hdr2\n");
         dump_hdr(hdr2);
     }

--- a/test/test.c
+++ b/test/test.c
@@ -53,9 +53,3 @@ void dump_hdr(const bam_hdr_t* hdr)
     }
     printf("text: \"%s\"\n", hdr->text);
 }
-
-// For tests, just return a constant that can be embedded in expected output.
-const char *samtools_version(void)
-{
-    return "x.y.test";
-}


### PR DESCRIPTION
1. Uses the new **HD** line operations implemented in **[HTSlib](https://github.com/samtools/htslib/pull/650)** for sorting and collating.
2. Implements a new method for retrieving the **samtools** version as M.m (Major.minor).
2. Fixes some **samtools** test cases.
3. Fixes #757.