### PR TITLE
Improve collate interface and add tests

### DIFF
--- a/bamshuf.c
+++ b/bamshuf.c
@@ -30,6 +30,11 @@ DEALINGS IN THE SOFTWARE.  */
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <errno.h>
+#ifdef _WIN32
+#  define WIN32_LEAN_AND_MEAN
+#  include <windows.h>
+#endif
 #include "htslib/sam.h"
 #include "htslib/hts.h"
 #include "htslib/ksort.h"
@@ -78,12 +83,12 @@ static inline int elem_lt(elem_t x, elem_t y)
 KSORT_INIT(bamshuf, elem_t, elem_lt)
 
 static int bamshuf(const char *fn, int n_files, const char *pre, int clevel,
-                   int is_stdout, sam_global_args *ga)
+                   int is_stdout, const char *output_file, sam_global_args *ga)
 {
     samFile *fp, *fpw = NULL, **fpt = NULL;
     char **fnt = NULL, modew[8];
     bam1_t *b = NULL;
-    int i, l, r;
+    int i, counter, l, r;
     bam_hdr_t *h = NULL;
     int64_t j, max_cnt = 0, *cnt = NULL;
     elem_t *a = NULL;
@@ -131,15 +136,18 @@ static int bamshuf(const char *fn, int n_files, const char *pre, int clevel,
 
     l = strlen(pre);
 
-    for (i = 0; i < n_files; ++i) {
-        fnt[i] = (char*)calloc(l + 10, 1);
+    for (i = counter = 0; i < n_files; ++i) {
+        fnt[i] = (char*)calloc(l + 20, 1);
         if (!fnt[i]) goto mem_fail;
-        sprintf(fnt[i], "%s.%.4d.bam", pre, i);
-        fpt[i] = sam_open(fnt[i], "wb1");
+        do {
+            sprintf(fnt[i], "%s.%04d.bam", pre, counter++);
+            fpt[i] = sam_open(fnt[i], "wxb1");
+        } while (!fpt[i] && errno == EEXIST);
         if (fpt[i] == NULL) {
             print_error_errno("collate", "Cannot open intermediate file \"%s\"", fnt[i]);
             goto fail;
         }
+        if (p.pool) hts_set_opt(fpt[i], HTS_OPT_THREAD_POOL, &p);
         if (sam_hdr_write(fpt[i], h) < 0) {
             print_error_errno("collate", "Couldn't write header to intermediate file \"%s\"", fnt[i]);
             goto fail;
@@ -180,7 +188,7 @@ static int bamshuf(const char *fn, int n_files, const char *pre, int clevel,
     fp = NULL;
     // merge
     sprintf(modew, "wb%d", (clevel >= 0 && clevel <= 9)? clevel : DEF_CLEVEL);
-    if (!is_stdout) { // output to a file
+    if (!is_stdout && !output_file) { // output to a file (name based on prefix)
         char *fnw = (char*)calloc(l + 5, 1);
         if (!fnw) goto mem_fail;
         if (ga->out.format == unknown_format)
@@ -189,6 +197,13 @@ static int bamshuf(const char *fn, int n_files, const char *pre, int clevel,
             sprintf(fnw, "%s.%s", pre,  hts_format_file_extension(&ga->out));
         fpw = sam_open_format(fnw, modew, &ga->out);
         free(fnw);
+    } else if (output_file) { // output to a given file
+        modew[0] = 'w'; modew[1] = '\0';
+        sam_open_mode(modew + 1, output_file, NULL);
+        j = strlen(modew);
+        snprintf(modew + j, sizeof(modew) - j, "%d",
+                 (clevel >= 0 && clevel <= 9)? clevel : DEF_CLEVEL);
+        fpw = sam_open_format(output_file, modew, &ga->out);
     } else fpw = sam_open_format("-", modew, &ga->out); // output to stdout
     if (fpw == NULL) {
         if (is_stdout) print_error_errno("collate", "Cannot open standard output");
@@ -281,42 +296,87 @@ static int bamshuf(const char *fn, int n_files, const char *pre, int clevel,
 
 static int usage(FILE *fp, int n_files) {
     fprintf(fp,
-            "Usage:   samtools collate [-Ou] [-n nFiles] [-l cLevel] <in.bam> <out.prefix>\n\n"
+            "Usage: samtools collate [-Ou] [-o <name>] [-n nFiles] [-l cLevel] <in.bam> [<prefix>]\n\n"
             "Options:\n"
             "      -O       output to stdout\n"
+            "      -o       output file name (use prefix if not set)\n"
             "      -u       uncompressed BAM output\n"
             "      -l INT   compression level [%d]\n" // DEF_CLEVEL
             "      -n INT   number of temporary files [%d]\n", // n_files
             DEF_CLEVEL, n_files);
 
     sam_global_opt_help(fp, "-....@");
+    fprintf(fp,
+            "  <prefix> is required unless the -o or -O options are used.\n");
 
     return 1;
+}
+
+char * generate_prefix() {
+    char *prefix;
+    unsigned int pid = getpid();
+#ifdef _WIN32
+#  define PREFIX_LEN (MAX_PATH + 16)
+    DWORD ret;
+    prefix = calloc(PREFIX_LEN, sizeof(*prefix));
+    if (!prefix) {
+        perror("collate");
+        return NULL;
+    }
+    ret = GetTempPathA(MAX_PATH, prefix);
+    if (ret > MAX_PATH || ret == 0) {
+        fprintf(stderr,
+                "[E::collate] Couldn't get path for temporary files.\n");
+        free(prefix);
+        return NULL;
+    }
+    snprintf(prefix + ret, PREFIX_LEN - ret, "\\%x", pid);
+    return prefix;
+#else
+#  define PREFIX_LEN 64
+    prefix = malloc(PREFIX_LEN);
+    if (!prefix) {
+        perror("collate");
+        return NULL;
+    }
+    snprintf(prefix, PREFIX_LEN, "/tmp/collate%x", pid);
+    return prefix;
+#endif
 }
 
 int main_bamshuf(int argc, char *argv[])
 {
     int c, n_files = 64, clevel = DEF_CLEVEL, is_stdout = 0, is_un = 0;
+    const char *output_file = NULL, *prefix = NULL;
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
     static const struct option lopts[] = {
         SAM_OPT_GLOBAL_OPTIONS('-', 0, 0, 0, 0, '@'),
         { NULL, 0, NULL, 0 }
     };
 
-    while ((c = getopt_long(argc, argv, "n:l:uO@:", lopts, NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "n:l:uOo:@:", lopts, NULL)) >= 0) {
         switch (c) {
         case 'n': n_files = atoi(optarg); break;
         case 'l': clevel = atoi(optarg); break;
         case 'u': is_un = 1; break;
         case 'O': is_stdout = 1; break;
+        case 'o': output_file = optarg; break;
         default:  if (parse_sam_global_opt(c, optarg, lopts, &ga) == 0) break;
                   /* else fall-through */
         case '?': return usage(stderr, n_files);
         }
     }
     if (is_un) clevel = 0;
-    if (optind + 2 > argc)
+    if (argc >= optind + 2) prefix = argv[optind+1];
+    if (!(prefix || is_stdout || output_file))
         return usage(stderr, n_files);
+    if (is_stdout && output_file) {
+        fprintf(stderr, "collate: -o and -O options cannot be used together.\n");
+        return usage(stderr, n_files);
+    }
+    if (!prefix) prefix = generate_prefix();
+    if (!prefix) return EXIT_FAILURE;
 
-    return bamshuf(argv[optind], n_files, argv[optind+1], clevel, is_stdout, &ga);
+    return bamshuf(argv[optind], n_files, prefix, clevel, is_stdout,
+                   output_file, &ga);
 }

--- a/samtools.1
+++ b/samtools.1
@@ -85,7 +85,7 @@ samtools fasta input.bam > output.fasta
 .PP
 samtools addreplacerg -r 'ID:fish' -r 'LB:1334' -r 'SM:alpha' -o output.bam input.bam
 .PP
-samtools collate aln.sorted.bam aln.name_collated.bam
+samtools collate -o aln.name_collated.bam aln.sorted.bam
 .PP
 samtools depad input.bam
 .PP
@@ -1566,7 +1566,7 @@ ignore the left part of the tag until the separator, then use the second part
 .B collate
 samtools collate
 .RI [ options ]
-.IR in.sam | in.bam | in.cram " [" out.prefix "]"
+.IR in.sam | in.bam | in.cram " [" <prefix> "]"
 
 Shuffles and groups reads together by their names.
 A faster alternative to a full query name sort,
@@ -1577,11 +1577,23 @@ but doesn't make any guarantees about the order of read names between groups.
 The output from this command should be suitable for any operation that
 requires all reads from the same template to be grouped together.
 
+If present, <prefix> is used to name the temporary files that collate
+uses when sorting the data.  If neither the '-O' nor '-o' options are used,
+<prefix> must be present and collate will use it to make an output file name
+by appending a suffix depending on the format written (.bam by default).
+
+If either the -O or -o option is used, <prefix> is optional.  If <prefix>
+is absent, collate will write the temporary files to a system-dependent
+location (/tmp on UNIX).
+
 .B Options:
 .RS
 .TP 8
 .B -O
-Output to stdout rather than to files starting with out.prefix
+Output to stdout.  This option cannot be used with '-o'.
+.TP
+.B -o FILE
+Write output to FILE.  This option cannot be used with '-O'.
 .TP
 .B -u
 Write uncompressed BAM output

--- a/test/collate/collate.expected.sam
+++ b/test/collate/collate.expected.sam
@@ -1,0 +1,24 @@
+@HD	VN:1.4	SO:unsorted	GO:query
+@SQ	SN:insert	LN:599
+@SQ	SN:ref1	LN:45
+@SQ	SN:ref2	LN:40
+@SQ	SN:ref3	LN:4
+@PG	ID:llama
+@RG	ID:fish	PG:llama
+@RG	ID:cow	PU:13_&^&&*(:332	PG:donkey
+@RG	PU:*9u8jkjjkjd:	ID:colt
+@PG	ID:bull	PP:donkey
+@PG	ID:donkey
+@CO	Do you know?
+r006	0	ref1	9	30	1S2I6M1P1I1P1I4M2I	*	0	0	AAAAGATAAGGGATAAA	*	XA:Z:abc	XB:i:-10	RG:Z:colt	PG:Z:donkey	AS:i:20	FI:f:4.5
+r006	16	ref1	29	30	6H5M	*	0	0	TAGGC	*	RG:Z:colt	PG:Z:donkey	FI:i:3
+x8	0	ref2	2	30	21M	*	0	0	GGTTTTATAAAACAAATAATT	?????????????????????	RG:Z:cow	PG:Z:bull	AS:i:10	FI:f:1.5
+x10	0	ref2	10	30	25M	*	0	0	CAAATAATTAAGTCTACAGAGCAAC	?????????????????????????	RG:Z:cow	PG:Z:bull	AS:i:0	FI:A:b
+x7	0	ref2	1	30	20M	*	0	0	AGGTTTTATAAAACAAATAA	*	RG:Z:cow	PG:Z:bull	AS:i:50	FI:i:2
+x11	0	ref2	12	30	24M	*	0	0	AATAATTAAGTCTACAGAGCAACT	????????????????????????	RG:Z:cow	PG:Z:bull	FI:Z:a
+r005	83	ref1	37	30	9M	=	7	-39	CAGCGCCAT	*	RG:Z:colt	PG:Z:donkey	AS:i:100	FI:f:2.5
+r005	163	ref1	7	30	8M4I4M1D3M	=	37	39	TTAGATAAAGAGGATACTG	*	XX:B:S,12561,2,20,112	YY:i:100	RG:Z:colt	PG:Z:donkey	AS:i:10	FI:i:5
+r007	0	ref1	9	30	5H6M	*	0	0	AGCTAA	*	RG:Z:colt	PG:Z:donkey	AS:i:1	FI:i:4
+r007	0	ref1	16	30	6M14N1I5M	*	0	0	ATAGCTCTCAGC	*	RG:Z:colt	PG:Z:donkey	AS:i:-5	FI:f:3.5
+x12	0	ref2	14	30	23M	*	0	0	TAATTAAGTCTACAGAGCAACTA	???????????????????????	RG:Z:cow	PG:Z:bull	AS:i:65100
+x9	0	ref2	6	30	9M4I13M	*	0	0	TTATAAAACAAATAATTAAGTCTACA	??????????????????????????	RG:Z:cow	PG:Z:bull	AS:i:20	FI:i:1

--- a/test/test.pl
+++ b/test/test.pl
@@ -51,6 +51,8 @@ test_merge($opts);
 test_merge($opts, threads=>2);
 test_sort($opts);
 test_sort($opts, threads=>2);
+test_collate($opts);
+test_collate($opts, threads=>2);
 test_fixmate($opts);
 test_fixmate($opts, threads=>2);
 test_calmd($opts);
@@ -2488,6 +2490,35 @@ sub test_sort
 
     # Tag sort (FI)
     test_cmd($opts, out=>"sort/tag.fi.sort.expected.sam", cmd=>"$$opts{bin}/samtools sort${threads} -t FI $$opts{path}/dat/test_input_1_d.sam -O SAM -o -");
+}
+
+sub test_collate
+{
+    my ($opts, %args) = @_;
+
+    my $threads = exists($args{threads}) ? " -@ $args{threads}" : "";
+
+    # Output to stdout
+    test_cmd($opts, out=>"collate/collate.expected.sam",
+	     cmd=>"$$opts{bin}/samtools collate${threads} --output-fmt=sam -O $$opts{path}/dat/test_input_1_d.sam");
+
+    # Output to file
+    test_cmd($opts, out=>"dat/empty.expected",
+	     out_map=>{"collate/collate1.tmp.sam"
+			    =>"collate/collate.expected.sam"},
+	     cmd=>"$$opts{bin}/samtools collate${threads} -o $$opts{path}/collate/collate1.tmp.sam  $$opts{path}/dat/test_input_1_d.sam");
+
+    # Output to file, given tmp file prefix
+    test_cmd($opts, out=>"dat/empty.expected",
+	     out_map=>{"collate/collate2.tmp.sam"
+			   =>"collate/collate.expected.sam"},
+	     cmd=>"$$opts{bin}/samtools collate${threads} -o $$opts{path}/collate/collate2.tmp.sam  $$opts{path}/dat/test_input_1_d.sam $$opts{path}/collate/collate2.tmp");
+
+    # Legacy usage with output file name based on prefix
+    test_cmd($opts, out=>"dat/empty.expected",
+	     out_map=>{"collate/collate3.tmp.sam"
+			   =>"collate/collate.expected.sam"},
+	     cmd=>"$$opts{bin}/samtools collate${threads} --output-fmt=sam $$opts{path}/dat/test_input_1_d.sam $$opts{path}/collate/collate3.tmp");
 }
 
 sub test_fixmate


### PR DESCRIPTION
Fixes #780 by improving collate's user interface:

- It's now possible to specify an output file name using -o, instead of deriving it from the prefix used for temporary files.
- The prefix becomes optional if -o or -O (to stdout) is used.  If not specified, temporary files will be written to /tmp (or the Windows equivalent).
- Updates the manual page.

Adds collate tests, which were previously missing.

Adds temporary files to the thread pool when writing.  This considerably improves the speed when running in multi-threaded mode.