### PR TITLE
Make travis use owner/htslib or samtools/htslib HEAD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,12 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then HOMEBREW_NO_AUTO_UPDATE=1 brew install xz || ( brew update && brew install xz ); fi
 
 before_script:
-  # Clone samtools/htslib (or another repository, as specified by a Travis CI
-  # repository $HTSREPO setting) and check out a corresponding branch with the
-  # same name, if any, or otherwise the default branch.
-  - .travis/clone ${HTSREPO:-git://github.com/samtools/htslib.git} $HTSDIR $TRAVIS_BRANCH
+  # Clone htslib, trying the same branch name in the owners' copy of htslib.
+  # If this exists then the user is likely making a joint PR to htslib and
+  # samtools and we want to validate this PR works in the context of their
+  # htslib.  If not, then we need to test this PR against the upstream
+  # develop htslib as this is what we'll be linking against once merged.
+  # Logic for choosing which to use is in the .travis/clone script.
+  - .travis/clone "git://github.com/$(dirname $TRAVIS_REPO_SLUG)/htslib.git" "$HTSDIR" "$TRAVIS_BRANCH"
 
 script: make -e && make -e test

--- a/.travis/clone
+++ b/.travis/clone
@@ -2,13 +2,16 @@
 # Usage: .travis/clone REPOSITORY [DIR] [BRANCH]
 #
 # Creates a shallow clone, checking out the specified branch.  If BRANCH is
-# omitted or if there is no branch with that name, checks out origin/HEAD.
+# omitted or if there is no branch with that name, checks out origin/HEAD
+# from the samtools/htslib repository.
 
 repository=$1
 localdir=$2
 branch=$3
 
-[ -n "$branch" ] && ref=$(git ls-remote --heads $repository $branch)
+ref=''
+[ -n "$branch" ] && ref=$(git ls-remote --heads "$repository" "$branch" 2>/dev/null)
+[ -z "$ref" ] && repository='git://github.com/samtools/htslib.git'
 
 set -x
-git clone --depth=1 ${ref:+--branch=$branch} $repository $localdir
+git clone --depth=50 ${ref:+--branch="$branch"} "$repository" "$localdir"

--- a/version.sh
+++ b/version.sh
@@ -7,7 +7,7 @@ VERSION=1.7
 if [ -e .git ]
 then
     # If we ever get to 10.x this will need to be more liberal
-    VERSION=`git describe --match '[0-9].[0-9]*' --dirty`
+    VERSION=`git describe --match '[0-9].[0-9]*' --dirty --always`
 fi
 
 echo $VERSION


### PR DESCRIPTION
Alternate to #794, following review comments.

You can still inspect the logs to find out which repository was cloned.

Clone depth is increased to make race conditions where merges are done before travis finishes very unlikely.  The difference in clone time is very small, less than the normal variability we see.

Fixed `version.sh` so it still gives a non-empty answer if the clone doesn't pick up a version tag.  Note that for clones from forked repositories, the version returned may not be the latest as it depends on which tags are present in the fork.