### PR TITLE
Fixes and improvements for the multi-region iterator code

### DIFF
--- a/bedidx.c
+++ b/bedidx.c
@@ -186,7 +186,7 @@ int bed_overlap(const void *_h, const char *chr, int beg, int end)
  *  @param reg_hash    the region hash table with interval lists as values
  */
 
-static void bed_unify(void *reg_hash) {
+void bed_unify(void *reg_hash) {
 
     int i, j, new_n;
     reghash_t *h;

--- a/bedidx.h
+++ b/bedidx.h
@@ -16,5 +16,6 @@ int bed_overlap(const void *_h, const char *chr, int beg, int end);
 void *bed_hash_regions(void *reg_hash, char **regs, int first, int last, int *op);
 const char* bed_get(void *reg_hash, int index, int filter);
 hts_reglist_t *bed_reglist(void *reg_hash, int filter, int *count_regs);
+void bed_unify(void *_h);
 
 #endif

--- a/sam_view.c
+++ b/sam_view.c
@@ -472,22 +472,13 @@ int main_samview(int argc, char *argv[])
             settings.bed = bed_hash_regions(settings.bed, argv, optind+1, argc, &filter_op); //insert(1) or filter out(0) the regions from the command line in the same hash table as the bed file
             if (!filter_op)
                 filter_state = FILTERED;
+        } else {
+            bed_unify(settings.bed);
         }
 
         bam1_t *b = bam_init1();
         if (settings.bed == NULL) { // index is unavailable or no regions have been specified
-            while ((result = sam_read1(in, header, b)) >= 0) { // read one alignment from `in'
-                if (!process_aln(header, b, &settings)) {
-                    if (!is_count) { if (check_sam_write1(out, header, b, fn_out, &ret) < 0) break; }
-                    count++;
-                } else {
-                    if (un_out) { if (check_sam_write1(un_out, header, b, fn_un_out, &ret) < 0) break; }
-                }
-            }
-            if (result < -1) {
-                fprintf(stderr, "[main_samview] truncated file.\n");
-                ret = 1;
-            }
+            fprintf(stderr, "[main_samview] no regions or BED file have been provided. Aborting.\n");
         } else {
             hts_idx_t *idx = sam_index_load(in, fn_in); // load index
             if (idx != NULL) {


### PR DESCRIPTION
Improves the performance of the multi-region iterator by using
`bed_unify` on the region list, when regions are provided via
BED file only.
Fixes #819 (together with https://github.com/samtools/htslib/pull/684).