### PR TITLE
Remove redundant ks_mergesort() call in bam_sort.c

### DIFF
--- a/bam_sort.c
+++ b/bam_sort.c
@@ -2184,7 +2184,6 @@ int bam_sort_core_ext(int is_by_qname, char* sort_by_tag, const char *fn, const 
 
     // write the final output
     if (n_files == 0 && num_in_mem < 2) { // a single block
-        ks_mergesort(sort, k, buf, 0);
         if (write_buffer(fnout, modeout, k, buf, header, n_threads, out_fmt) != 0) {
             print_error_errno("sort", "failed to create \"%s\"", fnout);
             goto err;


### PR DESCRIPTION
There is already sorted block after condition:
```
// Sort last records
if (k > 0) {
        ...
        num_in_mem = sort_blocks(n_files, k, buf, prefix, header, n_threads, in_mem);
        ...
}
```
Thus, there is no need to sort single block again in:
```
if (n_files == 0 && num_in_mem < 2) { // a single block
        ks_mergesort(sort, k, buf, 0);
        ...
}
```