### PR TITLE
Some new error handling in faidx.

### DIFF
--- a/samtools.1
+++ b/samtools.1
@@ -3,7 +3,7 @@
 .SH NAME
 samtools \- Utilities for the Sequence Alignment/Map (SAM) format
 .\"
-.\" Copyright (C) 2008-2011, 2013-2017 Genome Research Ltd.
+.\" Copyright (C) 2008-2011, 2013-2018 Genome Research Ltd.
 .\" Portions copyright (C) 2010, 2011 Broad Institute.
 .\"
 .\" Author: Heng Li <lh3@sanger.ac.uk>
@@ -948,6 +948,23 @@ The sequences in the input file should all have different names.
 If they do not, indexing will emit a warning about duplicate sequences and
 retrieval will only produce subsequences from the first sequence with the
 duplicated name.
+
+.B Options
+.RS
+.TP 8
+.BI "-o, --output " FILE
+Write FASTA to file rather than to stdout.
+.TP
+.BI "-n, --length " INT
+Length of FASTA sequence line.
+[60]
+.TP
+.B -c, --continue
+Continue working if a non-existant region is requested.
+.TP
+.B -h, --help
+Print help message and exit.
+.RE
 
 .TP \"-------- tview
 .B tview

--- a/test/test.pl
+++ b/test/test.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 #
-#    Copyright (C) 2013-2017 Genome Research Ltd.
+#    Copyright (C) 2013-2018 Genome Research Ltd.
 #
 #    Author: Petr Danecek <pd3@sanger.ac.uk>
 #
@@ -526,6 +526,13 @@ sub test_faidx
     cmd("cat $$opts{tmp}/faidx.fa | $$opts{bgzip} -ci -I $$opts{tmp}/faidx.fa.gz.gzi > $$opts{tmp}/faidx.fa.gz");
     cmd("$$opts{bin}/samtools faidx $$opts{tmp}/faidx.fa.gz");
     cmd("$$opts{bin}/samtools faidx --length 5 --output $$opts{tmp}/output_faidx.fa $$opts{tmp}/faidx.fa 1:1-104 && test -f $$opts{tmp}/output_faidx.fa");
+    
+    # test continuing after an error
+    cmd("$$opts{bin}/samtools faidx --output $$opts{tmp}/output_faidx.fa --continue $$opts{tmp}/faidx.fa 100 EEE FFF");
+    
+    # test for reporting retrieval errors, Zero results and truncated
+    cmd("$$opts{bin}/samtools faidx $$opts{tmp}/faidx.fa 1:10000000-10000005 > $$opts{tmp}/output_faidx.fa 2>&1 && grep Zero $$opts{tmp}/output_faidx.fa");
+    cmd("$$opts{bin}/samtools faidx $$opts{tmp}/faidx.fa 1:99998-100099 > $$opts{tmp}/output_faidx.fa 2>&1 && grep Truncated $$opts{tmp}/output_faidx.fa");
 
     for my $reg ('3:11-13','2:998-1003','1:100-104','1:99998-100007')
     {


### PR DESCRIPTION
Added extra error messages when retrieving empty or shortened sequences from FASTA.  Added the option to continue running after querying a non-existent sequence.  Also updated the man page and usage for this program.  Closes (#513) and (#673).