### PR TITLE
Fix --version when building from a Git repository

### DIFF
--- a/bamtk.c
+++ b/bamtk.c
@@ -31,6 +31,7 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include "htslib/hts.h"
 #include "samtools.h"
+#include "version.h"
 
 int bam_taf2baf(int argc, char *argv[]);
 int bam_mpileup(int argc, char *argv[]);
@@ -63,6 +64,10 @@ int main_addreplacerg(int argc, char *argv[]);
 int faidx_main(int argc, char *argv[]);
 int dict_main(int argc, char *argv[]);
 
+const char *samtools_version()
+{
+    return SAMTOOLS_VERSION;
+}
 
 static void usage(FILE *fp)
 {

--- a/sam_utils.c
+++ b/sam_utils.c
@@ -28,10 +28,8 @@ DEALINGS IN THE SOFTWARE.  */
 #include <stdarg.h>
 #include <string.h>
 #include <errno.h>
-#include <stdlib.h>
 
 #include "samtools.h"
-#include "version.h"
 
 static void vprint_error_core(const char *subcommand, const char *format, va_list args, const char *extra)
 {
@@ -59,30 +57,4 @@ void print_error_errno(const char *subcommand, const char *format, ...)
     va_start(args, format);
     vprint_error_core(subcommand, format, args, err? strerror(err) : NULL);
     va_end(args);
-}
-
-const char *samtools_version()
-{
-    return SAMTOOLS_VERSION;
-}
-
-const char *samtools_version_short()
-{
-    char *sv, *hyph, *v;
-    int len;
-
-    v = SAMTOOLS_VERSION;
-    hyph = strchr(v, '-');
-    if (!hyph)
-        return strdup(v);
-
-    len = hyph - v;
-    sv = (char *)malloc(len+1);
-    if (!sv)
-        return NULL;
-
-    strncpy(sv, v, len);
-    sv[len] = '\0';
-
-    return (const char*)sv;
 }

--- a/samtools.h
+++ b/samtools.h
@@ -26,7 +26,6 @@ DEALINGS IN THE SOFTWARE.  */
 #define SAMTOOLS_H
 
 const char *samtools_version(void);
-const char *samtools_version_short(void);
 
 #if defined __GNUC__ && __GNUC__ >= 2
 #define CHECK_PRINTF(fmt,args) __attribute__ ((format (printf, fmt, args)))

--- a/test/split/test_filter_header_rg.c
+++ b/test/split/test_filter_header_rg.c
@@ -40,11 +40,10 @@ void setup_test_1(bam_hdr_t** hdr_in)
 }
 
 bool check_test_1(const bam_hdr_t* hdr) {
-    char test1_res[200];
-    snprintf(test1_res, 199,
+    const char *test1_res =
     "@HD\tVN:1.4\n"
     "@SQ\tSN:blah\n"
-    "@PG\tID:samtools\tPN:samtools\tVN:%s\tCL:test_filter_header_rg foo bar baz\n", samtools_version());
+    "@PG\tID:samtools\tPN:samtools\tVN:x.y.test\tCL:test_filter_header_rg foo bar baz\n";
 
     if (strcmp(hdr->text, test1_res)) {
         return false;
@@ -64,12 +63,11 @@ void setup_test_2(bam_hdr_t** hdr_in)
 }
 
 bool check_test_2(const bam_hdr_t* hdr) {
-    char test2_res[200];
-    snprintf(test2_res, 199,
+    const char *test2_res =
     "@HD\tVN:1.4\n"
     "@SQ\tSN:blah\n"
     "@RG\tID:fish\n"
-    "@PG\tID:samtools\tPN:samtools\tVN:%s\tCL:test_filter_header_rg foo bar baz\n", samtools_version());
+    "@PG\tID:samtools\tPN:samtools\tVN:x.y.test\tCL:test_filter_header_rg foo bar baz\n";
 
     if (strcmp(hdr->text, test2_res)) {
         return false;
@@ -114,7 +112,7 @@ int main(int argc, char *argv[])
     bam_hdr_t* hdr1;
     const char* id_to_keep_1 = "1#2.3";
     setup_test_1(&hdr1);
-    if (verbose > 0) {
+    if (verbose > 1) {
         printf("hdr1\n");
         dump_hdr(hdr1);
     }
@@ -126,7 +124,7 @@ int main(int argc, char *argv[])
     fclose(stderr);
 
     if (verbose) printf("END RUN test 1\n");
-    if (verbose > 0) {
+    if (verbose > 1) {
         printf("hdr1\n");
         dump_hdr(hdr1);
     }
@@ -153,7 +151,7 @@ int main(int argc, char *argv[])
     bam_hdr_t* hdr2;
     const char* id_to_keep_2 = "fish";
     setup_test_2(&hdr2);
-    if (verbose > 0) {
+    if (verbose > 1) {
         printf("hdr2\n");
         dump_hdr(hdr2);
     }
@@ -165,7 +163,7 @@ int main(int argc, char *argv[])
     fclose(stderr);
 
     if (verbose) printf("END RUN test 2\n");
-    if (verbose > 0) {
+    if (verbose > 1) {
         printf("hdr2\n");
         dump_hdr(hdr2);
     }

--- a/test/test.c
+++ b/test/test.c
@@ -53,3 +53,9 @@ void dump_hdr(const bam_hdr_t* hdr)
     }
     printf("text: \"%s\"\n", hdr->text);
 }
+
+// For tests, just return a constant that can be embedded in expected output.
+const char *samtools_version(void)
+{
+    return "x.y.test";
+}


### PR DESCRIPTION
Samtools's version infrastructure has been broken since January:

```
$ make
make: Nothing to be done for `all'.
$ git pull
Already up to date.
$ git describe --dirty --always
1.8-20-g4ff8062                           <--
$ make
make: Nothing to be done for `all'.
$ ./samtools --version
samtools 1.7-5-g2bd9d6b-dirty             <--
Using htslib 1.8-13-g19a66ce-dirty
Copyright (C) 2018 Genome Research Ltd.
```

This is caused by 3ecdcc4760ae76bbdedaa40ae0d4c0bff26a5b20, which changed _bam_sort.c_ and _bamshuf.c_ to use HTSlib's `sam_hdr_change_HD()`, but also included some unrelated code that appears to be local test code and/or incomplete.

Reverting those changes — which are not mentioned in the commit's log message — fixes the versioning and makes `samtools --version` report the right thing when built from a busy samtools Git checkout.