### PR TITLE
Modifies faidx to work on FASTQ

### DIFF
--- a/bamtk.c
+++ b/bamtk.c
@@ -63,6 +63,7 @@ int main_quickcheck(int argc, char *argv[]);
 int main_addreplacerg(int argc, char *argv[]);
 int faidx_main(int argc, char *argv[]);
 int dict_main(int argc, char *argv[]);
+int fqidx_main(int argc, char *argv[]);
 
 const char *samtools_version()
 {
@@ -84,6 +85,7 @@ static void usage(FILE *fp)
 "  -- Indexing\n"
 "     dict           create a sequence dictionary file\n"
 "     faidx          index/extract FASTA\n"
+"     fqidx          index/extract FASTQ\n"
 "     index          index alignment\n"
 "\n"
 "  -- Editing\n"
@@ -166,6 +168,7 @@ int main(int argc, char *argv[])
     else if (strcmp(argv[1], "index") == 0)     ret = bam_index(argc-1, argv+1);
     else if (strcmp(argv[1], "idxstats") == 0)  ret = bam_idxstats(argc-1, argv+1);
     else if (strcmp(argv[1], "faidx") == 0)     ret = faidx_main(argc-1, argv+1);
+    else if (strcmp(argv[1], "fqidx") == 0)     ret = fqidx_main(argc-1, argv+1);
     else if (strcmp(argv[1], "dict") == 0)      ret = dict_main(argc-1, argv+1);
     else if (strcmp(argv[1], "fixmate") == 0)   ret = bam_mating(argc-1, argv+1);
     else if (strcmp(argv[1], "rmdup") == 0)     ret = bam_rmdup(argc-1, argv+1);

--- a/samtools.1
+++ b/samtools.1
@@ -65,6 +65,8 @@ samtools merge out.bam in1.bam in2.bam in3.bam
 .PP
 samtools faidx ref.fasta
 .PP
+samtools fqidx ref.fastq
+.PP
 samtools tview aln.sorted.bam ref.fasta
 .PP
 samtools split merged.bam
@@ -958,6 +960,10 @@ If they do not, indexing will emit a warning about duplicate sequences and
 retrieval will only produce subsequences from the first sequence with the
 duplicated name.
 
+FASTQ files can be read and indexed by this command.  Without using
+.B --fastq
+any extracted subsequence will be in FASTA format.
+
 .B Options
 .RS
 .TP 8
@@ -966,6 +972,56 @@ Write FASTA to file rather than to stdout.
 .TP
 .BI "-n, --length " INT
 Length of FASTA sequence line.
+[60]
+.TP
+.B -c, --continue
+Continue working if a non-existant region is requested.
+.TP
+.BI "-r, --region-file " FILE
+Read regions from a file. Format is chr:from-to, one per line.
+.TP
+.B -f, --fastq
+Read FASTQ files and output extracted sequences in FASTQ format.  Same as using samtools fqidx.
+.TP
+.B -h, --help
+Print help message and exit.
+.RE
+
+.TP \"-------- fqidx
+.B fqidx
+samtools fqidx <ref.fastq> [region1 [...]]
+
+Index reference sequence in the FASTQ format or extract subsequence from
+indexed reference sequence. If no region is specified,
+.B fqidx
+will index the file and create
+.I <ref.fastq>.fai
+on the disk. If regions are specified, the subsequences will be
+retrieved and printed to stdout in the FASTQ format.
+
+The input file can be compressed in the
+.B BGZF
+format.
+
+The sequences in the input file should all have different names.
+If they do not, indexing will emit a warning about duplicate sequences and
+retrieval will only produce subsequences from the first sequence with the
+duplicated name.
+
+.B samtools fqidx
+should only be used on fastq files with a small number of entries.
+Trying to use it on a file containing millions of short sequencing reads
+will produce an index that is almost as big as the original file, and
+searches using the index will be very slow and use a lot of memory.
+
+.B Options
+.RS
+.TP 8
+.BI "-o, --output " FILE
+Write FASTQ to file rather than to stdout.
+.TP
+.BI "-n, --length " INT
+Length of FASTQ sequence line.
 [60]
 .TP
 .B -c, --continue


### PR DESCRIPTION
Adds an option to faidx to work on FASTQ.
Adds the command samtools fqidx which works on FASTQ files in a similar way that samtools faidx works on FASTA.
Replaces and closes #805.