### PR TITLE
Mpileup depth limit settings

### DIFF
--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -115,7 +115,8 @@ static inline void pileup_seq(FILE *fp, const bam_pileup1_t *p, int pos, int ref
 #define MPLP_SMART_OVERLAPS (1<<12)
 #define MPLP_PRINT_QNAME (1<<13)
 
-#define MPLP_MAX_DEPTH 250
+#define MPLP_MAX_DEPTH 8000
+#define MPLP_MAX_INDEL_DEPTH 250
 
 void *bed_read(const char *fn);
 void bed_destroy(void *_h);
@@ -422,6 +423,7 @@ static int mpileup(mplp_conf_t *conf, int n, char **fn)
     if (conf->flag & MPLP_BCF)
     {
         const char *mode;
+
         if ( conf->flag & MPLP_VCF )
             mode = (conf->flag&MPLP_NO_COMP)? "wu" : "wz";   // uncompressed VCF or compressed VCF
         else
@@ -561,7 +563,7 @@ static int mpileup(mplp_conf_t *conf, int n, char **fn)
         fprintf(stderr, "[%s] Max depth set to maximum value (%d)\n", __func__, INT_MAX);
     } else {
         max_depth = conf->max_depth;
-        if ( max_depth * sm->n > 1<<20 )
+        if ( max_depth * n > 1<<20 )
             fprintf(stderr, "[%s] Combined max depth is above 1M. Potential memory hog!\n", __func__);
     }
     max_indel_depth = conf->max_indel_depth * sm->n;
@@ -963,7 +965,8 @@ int bam_mpileup(int argc, char *argv[])
     memset(&mplp, 0, sizeof(mplp_conf_t));
     mplp.min_baseQ = 13;
     mplp.capQ_thres = 0;
-    mplp.max_depth = MPLP_MAX_DEPTH; mplp.max_indel_depth = MPLP_MAX_DEPTH;
+    mplp.max_depth = MPLP_MAX_DEPTH;
+    mplp.max_indel_depth = MPLP_MAX_INDEL_DEPTH;
     mplp.openQ = 40; mplp.extQ = 20; mplp.tandemQ = 100;
     mplp.min_frac = 0.002; mplp.min_support = 1;
     mplp.flag = MPLP_NO_ORPHAN | MPLP_REALN | MPLP_SMART_OVERLAPS;

--- a/samtools.1
+++ b/samtools.1
@@ -1289,13 +1289,14 @@ functionality; if enabled, the recommended value for BWA is 50. [0]
 .BI -d,\ --max-depth \ INT
 At a position, read maximally
 .I INT
-reads per input file. Note that samtools has a minimum value of
-.I 8000/n
-where
-.I n
-is the number of input files given to mpileup.  This means the default
-is highly likely to be increased.  Once above the cross-sample minimum of
-8000 the -d parameter will have an effect. [250]
+reads per input file. Setting this limit reduces the amount of memory and
+time needed to process regions with very high coverage.  Passing zero for this
+option sets it to the highest possible value, effectively removing the depth
+limit. [8000]
+
+Note that up to release 1.8, samtools would enforce a minimum value for
+this option.  This no longer happens and the limit is set exactly as
+specified.
 .TP
 .B -E, --redo-BAQ
 Recalculate BAQ on the fly, ignore existing BQ tags

--- a/test/dat/mpileup.err.1
+++ b/test/dat/mpileup.err.1
@@ -1,2 +1,1 @@
 [mpileup] 3 samples in 3 input files
-<mpileup> Set max per-file depth to 2666


### PR DESCRIPTION
Add the possibility of increasing the depth limit to the maximum integer value
by passing the **-d** option with the value 0.
Reduce the depth lower limit to the default (250).
Fixes #858 
Fixes #851 