### PR TITLE
Updates to use the new hts_parse_region functionality.

### DIFF
--- a/bam_aux.c
+++ b/bam_aux.c
@@ -61,21 +61,15 @@ int bam_aux_drop_other(bam1_t *b, uint8_t *s)
     return 0;
 }
 
+// Only here due to libbam.a being used by some applications.
 int bam_parse_region(bam_header_t *header, const char *str, int *ref_id, int *beg, int *end)
 {
-    const char *name_lim = hts_parse_reg(str, beg, end);
-    if (name_lim) {
-        char *name = malloc(name_lim - str + 1);
-        memcpy(name, str, name_lim - str);
-        name[name_lim - str] = '\0';
-        *ref_id = bam_name2id(header, name);
-        free(name);
-    }
-    else {
-        // not parsable as a region, but possibly a sequence named "foo:a"
-        *ref_id = bam_name2id(header, str);
-        *beg = 0; *end = INT_MAX;
-    }
-    if (*ref_id == -1) return -1;
-    return *beg <= *end? 0 : -1;
+    hts_pos_t beg64, end64;
+    int r;
+    r = sam_parse_region(header, str, ref_id, &beg64, &end64, 0) ? 0 : -1;
+    if (beg64 > INT_MAX || end64 > INT_MAX)
+        return -1;
+    *beg = beg64;
+    *end = end64;
+    return r;
 }

--- a/bam_tview_curses.c
+++ b/bam_tview_curses.c
@@ -162,19 +162,7 @@ static void tv_win_goto(curses_tview_t *tv, int *tid, hts_pos_t *pos) {
                     return;
                 }
             } else {
-                char *name_lim = (char *) hts_parse_reg64(str, &_beg, &_end);
-                if (name_lim) {
-                    char name_terminator = *name_lim;
-                    *name_lim = '\0';
-                    _tid = bam_name2id(base->header, str);
-                    *name_lim = name_terminator;
-                } else {
-                    // Unparsable region, but possibly a sequence named "foo:a"
-                    _tid = bam_name2id(base->header, str);
-                    _beg = 0;
-                }
-
-                if (_tid >= 0) {
+                if (sam_parse_region(base->header, str, &_tid, &_beg, &_end, 0) && _tid >= 0) {
                     *tid = _tid; *pos = _beg;
                     return;
                 }

--- a/bedidx.c
+++ b/bedidx.c
@@ -509,6 +509,11 @@ void *bed_hash_regions(void *reg_hash, char **regs, int first, int last, int *op
 
     for (i=first; i<last; i++) {
 
+        // Note, ideally we would call sam_parse_region here, but it's complicated by not
+        // having the sam header known and the likelihood of the bed file containing data for other
+        // references too which we currently just ignore.
+        //
+        // TO DO...
         q = hts_parse_reg(regs[i], &beg, &end);
         if (q) {
             if ((int)(q - regs[i] + 1) > 1024) {

--- a/sam_view.c
+++ b/sam_view.c
@@ -716,11 +716,7 @@ int main_samview(int argc, char *argv[])
                 int result;
                 hts_itr_t *iter = sam_itr_querys(idx, header, argv[i]); // parse a region in the format like `chr2:100-200'
                 if (iter == NULL) { // region invalid or reference name not found
-                    hts_pos_t beg, end;
-                    if (hts_parse_reg64(argv[i], &beg, &end))
-                        fprintf(stderr, "[main_samview] region \"%s\" specifies an unknown reference name. Continue anyway.\n", argv[i]);
-                    else
-                        fprintf(stderr, "[main_samview] region \"%s\" could not be parsed. Continue anyway.\n", argv[i]);
+                    fprintf(stderr, "[main_samview] region \"%s\" specifies an invalid region or unknown reference. Continue anyway.\n", argv[i]);
                     continue;
                 }
                 // fetch alignments


### PR DESCRIPTION
For consideration along side samtools/htslib#708

Note this does not entirely fix bed region parsing in bedidx.c, which is currently still using the old API.

To upgrade it to the new one isn't so hard, but it requires changing the bed hash table from strings to 'tid's.  This is doable, if a bit tedious, although it's a bit specific.  In this context "bed" is simply a euphemism for command line regions as the two get merged together into a single data structure before processing (`samtools view -M` mode).   Changing the internals of bed to be tid based instead is a bit of the tail wagging the dog, but perhaps it's beneficial as it adds a level of validity checking.  (Note we may need to silently ignore unknown references anyway for compatibility.)

The alternative is for the new API to have a way of returning the string component identified during chr:start-end parsing.  Hello hts_parsed_reg structure again!  This is then less change in the bed logic.
