### PR TITLE
Alter the path to version.h.

### DIFF
--- a/misc/maq2sam.c
+++ b/misc/maq2sam.c
@@ -1,6 +1,6 @@
 /*  maq2sam.c -- convert MAQ output to SAM.
 
-    Copyright (C) 2008, 2009 Genome Research Ltd.
+    Copyright (C) 2008, 2009, 2018 Genome Research Ltd.
 
     Author: Heng Li <lh3@sanger.ac.uk>
 
@@ -30,7 +30,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <inttypes.h>
 #include <stdlib.h>
 #include <assert.h>
-#include "version.h"
+#include "../version.h"
 
 //#define MAQ_LONGREADS
 

--- a/misc/wgsim.c
+++ b/misc/wgsim.c
@@ -1,6 +1,6 @@
 /* The MIT License
 
-   Copyright (c) 2008 Genome Research Ltd (GRL).
+   Copyright (c) 2008, 2018 Genome Research Ltd (GRL).
                  2011 Heng Li <lh3@live.co.uk>
 
    Permission is hereby granted, free of charge, to any person obtaining
@@ -39,7 +39,7 @@
 #include <ctype.h>
 #include <string.h>
 #include <zlib.h>
-#include "version.h"
+#include "../version.h"
 #include "htslib/kseq.h"
 #include "htslib/hts_os.h"
 KSEQ_INIT(gzFile, gzread)


### PR DESCRIPTION
This prevents the compiler from picking up *htslib's* `version.h` when **C_INCLUDE_PATH=:** (or similar).

From #817: 
Simplest way to reproduce the error:

    tar xvfj samtools-1.8.tar.bz2
    cd samtools-1.8
    ./configure
    C_INCLUDE_PATH=: make

The `:` in the **C_INCLUDE_PATH** is in effect adding `-I.` to the end of the gcc list of include paths while removing the original `-I.` from the start.
So
`gcc -g -O2 -DMAQ_LONGREADS -I. -Ihtslib-1.8 -I./lz4  -c -o misc/maq2sam-long.o misc/maq2sam.c`
becomes
`gcc -g -O2 -DMAQ_LONGREADS -Ihtslib-1.8 -I./lz4 -I.  -c -o misc/maq2sam-long.o misc/maq2sam.c`

Though there is no apparent change in the command line, internally *gcc* removes any duplicate paths that are also in  **C_INCLUDE_PATH**.  This makes *gcc* find the *htslib* `version.h` before the *samtools* `version.h` so the build fails with a missing  **SAMTOOLS_VERSION**.

The *gcc* and *clang* compilers both exhibit this behaviour.

Fixes #817.
