### PR TITLE
Improve fasta/q documentation and fix flushing bug

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -101,6 +101,9 @@ Release a.b
    - blast2sam.pl now reports perfect match hits (no indels or mismatches).
      (#873, thanks to Nils Homer)
 
+   - Fixed bug in fasta and fastq subcommands where stdout would not be flushed
+     correctly if the -0 option was used.
+
 Release 1.8 (3rd April 2018)
 ----------------------------
 

--- a/samtools.1
+++ b/samtools.1
@@ -793,7 +793,7 @@ samtools bedcov
 .IR region.bed " " in1.sam | in1.bam | in1.cram "[...]"
 
 Reports the total read base count (i.e. the sum of per base read depths)
-for each genomic region specified in the supplied BED file. The regions 
+for each genomic region specified in the supplied BED file. The regions
 are output as they appear in the BED file and are 0-based.
 Counts for each alignment file supplied are reported in separate columns.
 
@@ -1841,7 +1841,7 @@ samtools cat [-b list] [-h header.sam] [-o out.bam] <in1.bam> <in2.bam> [ ... ]
 Concatenate BAMs or CRAMs. Although this works on either BAM or CRAM,
 all input files must be the same format as each other. The sequence
 dictionary of each input file must be identical, although this command
-does not check this. This command uses a similar trick to 
+does not check this. This command uses a similar trick to
 .B reheader
 which enables fast BAM concatenation.
 

--- a/samtools.1
+++ b/samtools.1
@@ -1516,15 +1516,69 @@ samtools fasta
 .I in.bam
 
 Converts a BAM or CRAM into either FASTQ or FASTA format depending on the
-command invoked. The FASTQ files will be automatically compressed if the 
-filenames have a .gz or .bgzf extention.
+command invoked. The files will be automatically compressed if the
+file names have a .gz or .bgzf extension.
+
+The input to this program must be collated by name.
+Use
+.B samtools collate
+or
+.B samtools sort -n
+to ensure this.
+
+For each different QNAME, the input records are categorised according to
+the state of the READ1 and READ2 flag bits.
+The three categories used are:
+
+1 : Only READ1 is set.
+
+2 : Only READ2 is set.
+
+0 : Either both READ1 and READ2 are set; or neither is set.
+
+The exact meaning of these categories depends on the sequencing technology
+used.
+It is expected that ordinary single and paired-end sequencing reads will be
+in categories 1 and 2 (in the case of paired-end reads, one read of the pair
+will be in category 1, the other in category 2).
+Category 0 is essentially a \*(lqcatch-all\*(rq for reads that do not
+fit into a simple paired-end sequencing model.
+
+For each category only one sequence will be written for a given QNAME.
+If more than one record is available for a given QNAME and category,
+the first in input file order that has quality values will be used.
+If none of the candidate records has quality values, then the first in
+input file order will be used instead.
+
+Sequences will be written to standard output unless one of the
+.BR -1 , -2 ", or " -0
+options is used, in which case sequences for that category will be written to
+the specified file.
+
+If a singleton file is specified using the
+.B -s
+option then only paired sequences will be output for categories 1 and 2;
+paired meaning that for a given QNAME there are sequences for both
+category 1
+.B and
+2.
+If there is a sequence for only one of categories 1 or 2 then it will be
+diverted into the specified singletons file.
+This can be used to prepare fastq files for programs that cannot handle
+a mixture of paired and singleton reads.
+
+The
+.B -s
+option only affects category 1 and 2 records.
+The output for category 0 will be the same irrespective of the use of this
+option.
 
 .B OPTIONS:
 .RS
 .TP 8
 .B -n
 By default, either '/1' or '/2' is added to the end of read names
-where the corresponding BAM_READ1 or BAM_READ2 flag is set.
+where the corresponding READ1 or READ2 FLAG bit is set.
 Using
 .B -n
 causes read names to be left as they are.
@@ -1538,23 +1592,32 @@ Use quality values from OQ tags in preference to standard quality string
 if available.
 .TP 8
 .B -s FILE
-Write singleton reads in FASTQ format to FILE instead of outputting them.
+Write singleton reads to FILE.
 .TP 8
 .B -t
 Copy RG, BC and QT tags to the FASTQ header line, if they exist.
 .TP 8
 .B -T TAGLIST
-Specify a comma-separated list of tags to copy to the FASTQ header line, if they exist.
+Specify a comma-separated list of tags to copy to the FASTQ header line, if
+they exist.
 .TP 8
 .B -1 FILE
-Write reads with the BAM_READ1 flag set to FILE instead of outputting them.
+Write reads with the READ1 FLAG set (and READ2 not set) to FILE instead of
+outputting them.
+If the
+.B -s
+option is used, only paired reads will be written to this file.
 .TP 8
 .B -2 FILE
-Write reads with the BAM_READ2 flag set to FILE instead of outputting them.
+Write reads with the READ2 FLAG set (and READ1 not set) to FILE instead of
+outputting them.
+If the
+.B -s
+option is used, only paired reads will be written to this file.
 .TP 8
 .B -0 FILE
-Write reads with both or neither of the BAM_READ1 and BAM_READ2 flags set
-to FILE instead of outputting them.
+Write reads where the READ1 and READ2 FLAG bits set are either both set
+or both unset to FILE instead of outputting them.
 .TP 8
 .BI "-f " INT
 Only output alignments with all bits set in
@@ -1615,6 +1678,53 @@ mean 'read until the separator or end of tag', for example:
 .B n*i*
 ignore the left part of the tag until the separator, then use the second part
 .RE
+
+.B EXAMPLES
+
+Output paired reads to separate files, discarding singletons, supplementary
+and secondary reads.
+The resulting files can be used with, for example, the
+.B bwa
+aligner.
+.EX 4
+samtools fastq -1 paired1.fq -2 paired2.fq -0 /dev/null -s /dev/null -n -F 0x900 in.bam
+.EE
+
+Output paired and singleton reads in a single file, discarding supplementary
+and secondary reads.
+To get all of the reads in a single file, it is necessary to redirect the
+output of samtools fastq.
+The output file is suitable for use with
+.B bwa mem -p
+which understands interleaved files containing a mixture of paired and
+singleton reads.
+.EX 4
+samtools fastq -0 /dev/null -F 0x900 in.bam > all_reads.fq
+.EE
+
+Output paired reads in a single file, discarding supplementary and
+secondary reads.
+Save any singletons in a separate file.
+Append /1 and /2 to read names.
+This format is suitable for use by
+.B NextGenMap
+when using its
+.BR -p " and " -q " options."
+With this aligner, paired reads must be mapped separately to the singletons.
+.EX 4
+samtools fastq -0 /dev/null -s single.fq -N -F 0x900 in.bam > paired.fq
+.EE
+
+.B BUGS
+
+.IP o 2
+The way of specifying output files is far to complicated and easy to get wrong.
+
+.IP o 2
+The default value for the -F option should really be 0x900 so that secondary
+and supplementary reads are automatically excluded.
+The existing default of 0 is retained for reasons of compatibility.
+
 .RE
 
 .TP \"-------- collate


### PR DESCRIPTION
Try to make what the fasta and fastq output options do clearer in both the online help and the manual page.

Fix a bug where stdout was not flushed when the -0 output option was used (found when testing out the examples).

Fixes #885 (samtools fasta (samtools fastq) does not extract paired reads)