### PR TITLE
Memory leaks & buffer 1-beyond-end reads in corner cases.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,11 @@ language: c
 
 matrix:
   include:
+    # An optimised build with address, leak and undefined behavior checking
     - os: linux
       compiler: clang
+      sudo: required
+      env: CFLAGS="-fsanitize=address" LDFLAGS="-fsanitize=address"
     - os: linux
       compiler: gcc
     # An unoptimised C99 build, for detecting non-static inline functions
@@ -39,4 +42,4 @@ before_script:
   # Logic for choosing which to use is in the .travis/clone script.
   - .travis/clone "git://github.com/$(dirname $TRAVIS_REPO_SLUG)/htslib.git" "$HTSDIR" "$TRAVIS_BRANCH"
 
-script: make -e && make -e test
+script: autoreconf -i && (./configure || (cat config.log; /bin/false)) && make -e && make -e test

--- a/bam2depth.c
+++ b/bam2depth.c
@@ -255,7 +255,8 @@ int main_depth(int argc, char *argv[])
             for (j = 0; j < n_plp[i]; ++j) {
                 const bam_pileup1_t *p = plp[i] + j; // DON'T modfity plp[][] unless you really know
                 if (p->is_del || p->is_refskip) ++m; // having dels or refskips at tid:pos
-                else if (bam_get_qual(p->b)[p->qpos] < baseQ) ++m; // low base quality
+                else if (p->qpos < p->b->core.l_qseq &&
+                         bam_get_qual(p->b)[p->qpos] < baseQ) ++m; // low base quality
             }
             printf("\t%d", n_plp[i] - m); // this the depth to output
         }

--- a/bam_addrprg.c
+++ b/bam_addrprg.c
@@ -71,6 +71,7 @@ static void cleanup_opts(parsed_opts_t* opts)
     free(opts->rg_id);
     free(opts->output_name);
     free(opts->input_name);
+    free(opts->rg_line);
     if (opts->p.pool) hts_tpool_destroy(opts->p.pool);
     sam_global_args_free(&opts->ga);
     free(opts);
@@ -316,6 +317,7 @@ static bool parse_args(int argc, char** argv, parsed_opts_t** opts)
             cleanup_opts(retval);
             return false;
         }
+        free(retval->rg_line);
         retval->rg_line = tmp;
     }
     retval->input_name = strdup(argv[optind+0]);

--- a/bam_markdup.c
+++ b/bam_markdup.c
@@ -477,7 +477,7 @@ static int add_duplicate(khash_t(duplicates) *d_hash, bam1_t *dupe) {
    step.  This is because the duplicate can occur before the primary read.*/
 
 static int bam_mark_duplicates(samFile *in, samFile *out, char *prefix, int remove_dups, int32_t max_length, int do_stats, int supp, int tag) {
-    bam_hdr_t *header;
+    bam_hdr_t *header = NULL;
     khiter_t k;
     khash_t(reads) *pair_hash        = kh_init(reads);
     khash_t(reads) *single_hash      = kh_init(reads);
@@ -507,13 +507,13 @@ static int bam_mark_duplicates(samFile *in, samFile *out, char *prefix, int remo
        // (e.g. must ignore in a @CO comment line later in header)
        if ((p != 0) && (p < q)) {
            fprintf(stderr, "[markdup] error: queryname sorted, must be sorted by coordinate.\n");
-           return 1;
+           goto fail;
        }
     }
 
     if (sam_hdr_write(out, header) < 0) {
         fprintf(stderr, "[markdup] error writing header.\n");
-        return 1;
+        goto fail;
     }
 
     // used for coordinate order checks
@@ -526,13 +526,13 @@ static int bam_mark_duplicates(samFile *in, samFile *out, char *prefix, int remo
     if (supp) {
         if (tmp_file_open_write(&temp, prefix, 1)) {
             fprintf(stderr, "[markdup] error: unable to open tmp file %s.\n", prefix);
-            return 1;
+            goto fail;
         }
     }
 
     if ((in_read->b = bam_init1()) == NULL) {
         fprintf(stderr, "[markdup] error: unable to allocate memory for alignment.\n");
-        return 1;
+        goto fail;
     }
 
     reading = writing = excluded = single_dup = duplicate = examined = pair = single = 0;
@@ -543,8 +543,7 @@ static int bam_mark_duplicates(samFile *in, samFile *out, char *prefix, int remo
         if (in_read->b->core.tid >= 0) { // -1 for unmapped reads
             if (in_read->b->core.tid < prev_tid ||
                ((in_read->b->core.tid == prev_tid) && (in_read->b->core.pos < prev_coord))) {
-                fprintf(stderr, "[markdup] error: bad coordinate order.\n");
-                return 1;
+                goto fail;
             }
         }
 
@@ -569,7 +568,7 @@ static int bam_mark_duplicates(samFile *in, samFile *out, char *prefix, int remo
 
                 if (make_pair_key(&pair_key, in_read->b)) {
                     fprintf(stderr, "[markdup] error: unable to assign pair hash key.\n");
-                    return 1;
+                    goto fail;
                 }
 
                 make_single_key(&single_key, in_read->b);
@@ -602,21 +601,20 @@ static int bam_mark_duplicates(samFile *in, samFile *out, char *prefix, int remo
                         if (tag) {
                             if (bam_aux_append(dup, "do", 'Z', strlen(bam_get_qname(bp->p)) + 1, (uint8_t*)bam_get_qname(bp->p))) {
                                 fprintf(stderr, "[markdup] error: unable to append 'do' tag.\n");
-                                return 1;
+                                goto fail;
                             }
                         }
 
                         if (supp) {
                             if (bam_aux_get(dup, "SA") || (dup->core.flag & BAM_FMUNMAP)) {
-                                if (add_duplicate(dup_hash, dup)) {
-                                    return 1;
-                                }
+                                if (add_duplicate(dup_hash, dup))
+                                    goto fail;
                             }
                         }
                     }
                 } else {
                     fprintf(stderr, "[markdup] error: single hashing failure.\n");
-                    return 1;
+                    goto fail;
                 }
 
                 // now do the pair
@@ -635,14 +633,14 @@ static int bam_mark_duplicates(samFile *in, samFile *out, char *prefix, int remo
 
                     if ((mate_tmp = get_mate_score(bp->p)) == -1) {
                         fprintf(stderr, "[markdup] error: no ms score tag. Please run samtools fixmate on file first.\n");
-                        return 1;
+                        goto fail;
                     } else {
                         old_score = calc_score(bp->p) + mate_tmp;
                     }
 
                     if ((mate_tmp = get_mate_score(in_read->b)) == -1) {
                         fprintf(stderr, "[markdup] error: no ms score tag. Please run samtools fixmate on file first.\n");
-                        return 1;
+                        goto fail;
                     } else {
                         new_score = calc_score(in_read->b) + mate_tmp;
                     }
@@ -670,23 +668,22 @@ static int bam_mark_duplicates(samFile *in, samFile *out, char *prefix, int remo
                     if (tag) {
                         if (bam_aux_append(dup, "do", 'Z', strlen(bam_get_qname(bp->p)) + 1, (uint8_t*)bam_get_qname(bp->p))) {
                             fprintf(stderr, "[markdup] error: unable to append 'do' tag.\n");
-                            return 1;
+                            goto fail;
                         }
 
                     }
 
                     if (supp) {
                         if (bam_aux_get(dup, "SA") || (dup->core.flag & BAM_FMUNMAP)) {
-                            if (add_duplicate(dup_hash, dup)) {
-                                return 1;
-                            }
+                            if (add_duplicate(dup_hash, dup))
+                                goto fail;
                         }
                     }
 
                     duplicate++;
                 } else {
                     fprintf(stderr, "[markdup] error: pair hashing failure.\n");
-                    return 1;
+                    goto fail;
                 }
             } else { // do the single (or effectively single) reads
                 int ret;
@@ -713,15 +710,14 @@ static int bam_mark_duplicates(samFile *in, samFile *out, char *prefix, int remo
                         if (tag) {
                             if (bam_aux_append(in_read->b, "do", 'Z', strlen(bam_get_qname(bp->p)) + 1, (uint8_t*)bam_get_qname(bp->p))) {
                                 fprintf(stderr, "[markdup] error: unable to append 'do' tag.\n");
-                                return 1;
+                                goto fail;
                             }
                         }
 
                         if (supp) {
                             if (bam_aux_get(in_read->b, "SA") || (in_read->b->core.flag & BAM_FMUNMAP)) {
-                                if (add_duplicate(dup_hash, in_read->b)) {
-                                    return 1;
-                                }
+                                if (add_duplicate(dup_hash, in_read->b))
+                                    goto fail;
                             }
                         }
 
@@ -747,15 +743,14 @@ static int bam_mark_duplicates(samFile *in, samFile *out, char *prefix, int remo
                         if (tag) {
                             if (bam_aux_append(dup, "do", 'Z', strlen(bam_get_qname(bp->p)) + 1, (uint8_t*)bam_get_qname(bp->p))) {
                                 fprintf(stderr, "[markdup] error: unable to append 'do' tag.\n");
-                                return 1;
+                                goto fail;
                             }
                         }
 
                         if (supp) {
                             if (bam_aux_get(dup, "SA") || (dup->core.flag & BAM_FMUNMAP)) {
-                                if (add_duplicate(dup_hash, dup)) {
-                                    return 1;
-                                }
+                                if (add_duplicate(dup_hash, dup))
+                                    goto fail;
                             }
                         }
                     }
@@ -763,7 +758,7 @@ static int bam_mark_duplicates(samFile *in, samFile *out, char *prefix, int remo
                     single_dup++;
                 } else {
                     fprintf(stderr, "[markdup] error: single hashing failure.\n");
-                    return 1;
+                    goto fail;
                 }
             }
         } else {
@@ -786,12 +781,12 @@ static int bam_mark_duplicates(samFile *in, samFile *out, char *prefix, int remo
                 if (supp) {
                     if (tmp_file_write(&temp, in_read->b)) {
                         fprintf(stderr, "[markdup] error: writing temp output failed.\n");
-                        return 1;
+                        goto fail;
                     }
                 } else {
                     if (sam_write1(out, header, in_read->b) < 0) {
                         fprintf(stderr, "[markdup] error: writing output failed.\n");
-                        return 1;
+                        goto fail;
                     }
                 }
 
@@ -819,13 +814,13 @@ static int bam_mark_duplicates(samFile *in, samFile *out, char *prefix, int remo
 
         if ((in_read->b = bam_init1()) == NULL) {
             fprintf(stderr, "[markdup] error: unable to allocate memory for alignment.\n");
-            return 1;
+            goto fail;
         }
     }
 
     if (ret < -1) {
         fprintf(stderr, "[markdup] error: truncated input file.\n");
-        return 1;
+        goto fail;
     }
 
     // write out the end of the list
@@ -838,12 +833,12 @@ static int bam_mark_duplicates(samFile *in, samFile *out, char *prefix, int remo
                 if (supp) {
                     if (tmp_file_write(&temp, in_read->b)) {
                         fprintf(stderr, "[markdup] error: writing temp output failed.\n");
-                        return 1;
+                        goto fail;
                     }
                 } else {
                     if (sam_write1(out, header, in_read->b) < 0) {
                         fprintf(stderr, "[markdup] error: writing output failed.\n");
-                        return 1;
+                        goto fail;
                     }
                 }
 
@@ -861,14 +856,13 @@ static int bam_mark_duplicates(samFile *in, samFile *out, char *prefix, int remo
 
         if (tmp_file_end_write(&temp)) {
             fprintf(stderr, "[markdup] error: unable to end tmp writing.\n");
-            return 1;
+            goto fail;
         }
 
         // read data from temp file and mark duplicate supplementary alignments
 
-        if (tmp_file_begin_read(&temp, NULL)) {
-            return 1;
-        }
+        if (tmp_file_begin_read(&temp, NULL))
+            goto fail;
 
         b = bam_init1();
 
@@ -885,24 +879,26 @@ static int bam_mark_duplicates(samFile *in, samFile *out, char *prefix, int remo
             if (!remove_dups || !(b->core.flag & BAM_FDUP)) {
                 if (sam_write1(out, header, b) < 0) {
                     fprintf(stderr, "[markdup] error: writing final output failed.\n");
-                    return 1;
+                    goto fail;
                 }
             }
         }
 
         if (ret == -1) {
             fprintf(stderr, "[markdup] error: failed to read tmp file.\n");
-            return 1;
+            goto fail;
         }
 
         for (k = kh_begin(dup_hash); k != kh_end(dup_hash); ++k) {
             if (kh_exist(dup_hash, k)) {
                 free((char *)kh_key(dup_hash, k));
+                kh_key(dup_hash, k) = NULL;
             }
         }
 
         tmp_file_destroy(&temp, b, 0);
         kh_destroy(duplicates, dup_hash);
+        dup_hash = NULL;
         bam_destroy1(b);
     }
 
@@ -915,12 +911,33 @@ static int bam_mark_duplicates(samFile *in, samFile *out, char *prefix, int remo
                                 duplicate, single_dup, single_dup + duplicate);
     }
 
+    if (dup_hash) {
+        kh_destroy(duplicates, dup_hash);
+    }
     kh_destroy(reads, pair_hash);
     kh_destroy(reads, single_hash);
     kl_destroy(read_queue, read_buffer);
     bam_hdr_destroy(header);
 
     return 0;
+
+ fail:
+    for (rq = kl_begin(read_buffer); rq != kl_end(read_buffer); rq = kl_next(rq))
+        bam_destroy1(kl_val(rq).b);
+    kl_destroy(read_queue, read_buffer);
+
+    for (k = kh_begin(dup_hash); k != kh_end(dup_hash); ++k) {
+        if (kh_exist(dup_hash, k)) {
+            free((char *)kh_key(dup_hash, k));
+        }
+    }
+    kh_destroy(duplicates, dup_hash);
+
+    kh_destroy(reads, pair_hash);
+    kh_destroy(reads, single_hash);
+    bam_hdr_destroy(header);
+    return 1;
+
 }
 
 

--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -686,7 +686,9 @@ static int mpileup(mplp_conf_t *conf, int n, char **fn)
                         putc('\t', pileup_fp);
                         for (j = 0; j < n_plp[i]; ++j) {
                             const bam_pileup1_t *p = plp[i] + j;
-                            int c = bam_get_qual(p->b)[p->qpos];
+                            int c = p->qpos < p->b->core.l_qseq
+                                ? bam_get_qual(p->b)[p->qpos]
+                                : 0;
                             if ( c < conf->min_baseQ ) continue;
                             c = plp[i][j].b->core.qual + 33;
                             if (c > 126) c = 126;
@@ -701,7 +703,9 @@ static int mpileup(mplp_conf_t *conf, int n, char **fn)
                         putc('\t', pileup_fp);
                         for (j = 0; j < n_plp[i]; ++j) {
                             const bam_pileup1_t *p = plp[i] + j;
-                            int c = bam_get_qual(p->b)[p->qpos];
+                            int c = p->qpos < p->b->core.l_qseq
+                                ? bam_get_qual(p->b)[p->qpos]
+                                : 0;
                             if ( c < conf->min_baseQ ) continue;
 
                             if (n > 0) putc(',', pileup_fp);
@@ -716,7 +720,9 @@ static int mpileup(mplp_conf_t *conf, int n, char **fn)
                         putc('\t', pileup_fp);
                         for (j = 0; j < n_plp[i]; ++j) {
                             const bam_pileup1_t *p = &plp[i][j];
-                            int c = bam_get_qual(p->b)[p->qpos];
+                            int c = p->qpos < p->b->core.l_qseq
+                                ? bam_get_qual(p->b)[p->qpos]
+                                : 0;
                             if ( c < conf->min_baseQ ) continue;
 
                             if (n > 0) putc(',', pileup_fp);

--- a/bam_reheader.c
+++ b/bam_reheader.c
@@ -49,16 +49,18 @@ int bam_reheader(BGZF *in, bam_hdr_t *h, int fd,
     ssize_t len;
     uint8_t *buf = NULL;
     SAM_hdr *sh = NULL;
+    bam_hdr_t *tmp;
     if (in->is_write) return -1;
     buf = malloc(BUF_SIZE);
     if (!buf) {
         fprintf(stderr, "Out of memory\n");
         return -1;
     }
-    if (bam_hdr_read(in) == NULL) {
+    if ((tmp = bam_hdr_read(in)) == NULL) {
         fprintf(stderr, "Couldn't read header\n");
         goto fail;
     }
+    bam_hdr_destroy(tmp);
     fp = bgzf_fdopen(fd, "w");
     if (!fp) {
         print_error_errno("reheader", "Couldn't open output file");

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -1545,9 +1545,9 @@ int bam_merge(int argc, char *argv[])
         switch (c) {
         case 'r': flag |= MERGE_RG; break;
         case 'f': flag |= MERGE_FORCE; break;
-        case 'h': fn_headers = strdup(optarg); break;
+        case 'h': fn_headers = optarg; break;
         case 'n': is_by_qname = 1; break;
-        case 't': sort_tag = strdup(optarg); break;
+        case 't': sort_tag = optarg; break;
         case '1': flag |= MERGE_LEVEL1; level = 1; break;
         case 'u': flag |= MERGE_UNCOMP; level = 0; break;
         case 'R': reg = strdup(optarg); break;
@@ -1622,7 +1622,6 @@ end:
     }
     free(fn);
     free(reg);
-    free(fn_headers);
     sam_global_args_free(&ga);
     return ret;
 }
@@ -2361,7 +2360,7 @@ int bam_sort(int argc, char *argv[])
         switch (c) {
         case 'o': fnout = optarg; o_seen = 1; break;
         case 'n': is_by_qname = 1; break;
-        case 't': sort_tag = strdup(optarg); break;
+        case 't': sort_tag = optarg; break;
         case 'm': {
                 char *q;
                 max_mem = strtol(optarg, &q, 0);

--- a/dict.c
+++ b/dict.c
@@ -98,6 +98,7 @@ static void write_dict(const char *fn, args_t *args)
     hts_md5_destroy(md5);
 
     if (args->output_fname) fclose(out);
+    gzclose(fp);
 }
 
 static int dict_usage(void)

--- a/test/merge/test_bam_translate.c
+++ b/test/merge/test_bam_translate.c
@@ -146,7 +146,7 @@ void setup_test_2(bam1_t** b_in, trans_tbl_t* tbl) {
     tbl->tid_trans[3] = 8;
     int in_there = 0;
     khiter_t iter = kh_put(c2c, tbl->rg_trans, strdup("hello"), &in_there);
-    kh_value(tbl->rg_trans, iter) = strdup("goodbye");
+    kh_value(tbl->rg_trans, iter) = "goodbye";
 
     b->core.tid = 0;
     b->core.pos = 1334;
@@ -186,7 +186,7 @@ void setup_test_3(bam1_t** b_in, trans_tbl_t* tbl) {
     tbl->tid_trans[3] = 8;
     int in_there = 0;
     khiter_t iter = kh_put(c2c, tbl->pg_trans, strdup("hello"), &in_there);
-    kh_value(tbl->pg_trans,iter) = strdup("goodbye");
+    kh_value(tbl->pg_trans,iter) = "goodbye";
 
 
     b->core.tid = 0;
@@ -302,9 +302,9 @@ void setup_test_6(bam1_t** b_in, trans_tbl_t* tbl) {
     tbl->tid_trans[3] = 8;
     int in_there = 0;
     khiter_t iter_rg = kh_put(c2c, tbl->rg_trans, strdup("hello"), &in_there);
-    kh_value(tbl->rg_trans, iter_rg) = strdup("goodbye");
+    kh_value(tbl->rg_trans, iter_rg) = "goodbye";
     khiter_t iter_pg = kh_put(c2c, tbl->pg_trans, strdup("quail"), &in_there);
-    kh_value(tbl->pg_trans, iter_pg) = strdup("bird");
+    kh_value(tbl->pg_trans, iter_pg) = "bird";
 
 
     b->core.tid = 0;


### PR DESCRIPTION
This enables the test harness to pass when we use `-fsanitize=address` (which also does basic memory leak checking).  In turn, this permits us to enable it in travis, thus spotting more problems in pull requests.

I also changed it to use `./configure` too as without it it was building htslib without sanitise and samtools with it.  (This is probably a bug in our Makefile.)  We should consider an equivalent htslib travis mod too.

Note the sudo: required bit is because clang uses a second monitoring process and this cannot work when run from a container.  We only enable sudo for the one build though.