### PR TITLE
Fix typo in samtools faidx/fqidx documentation

### DIFF
--- a/samtools.1
+++ b/samtools.1
@@ -989,7 +989,7 @@ Length of FASTA sequence line.
 [60]
 .TP
 .B -c, --continue
-Continue working if a non-existant region is requested.
+Continue working if a non-existent region is requested.
 .TP
 .BI "-r, --region-file " FILE
 Read regions from a file. Format is chr:from-to, one per line.
@@ -1067,7 +1067,7 @@ Length of FASTQ sequence line.
 [60]
 .TP
 .B -c, --continue
-Continue working if a non-existant region is requested.
+Continue working if a non-existent region is requested.
 .TP
 .BI "-r, --region-file " FILE
 Read regions from a file. Format is chr:from-to, one per line.


### PR DESCRIPTION
Fixes the spelling of 'existent' in the documentation.