### PR TITLE
Switched the comma in line 1187 to `and`

### DIFF
--- a/misc/plot-bamstats
+++ b/misc/plot-bamstats
@@ -1183,7 +1183,7 @@ sub merge_bamcheck
         open($fh,'>',"$$opts{prefix}merge.bchk") or error("$$opts{prefix}merge.bchk: $!\n");
     }
 
-    print $fh "# This file was produced by plot-bamstats and the command line was:\n#   $$opts{args}\n#\n";
+    print $fh "# This file was produced by plot-bamstats and can be plotted using plot-bamstats\n# The command line was $$opts{args}\n";
 
     for my $sec (@{$$opts{sections}})
     {
@@ -1400,6 +1400,3 @@ sub create_html
 
     close($fh);
 }
-
-
-

--- a/misc/plot-bamstats
+++ b/misc/plot-bamstats
@@ -1183,7 +1183,7 @@ sub merge_bamcheck
         open($fh,'>',"$$opts{prefix}merge.bchk") or error("$$opts{prefix}merge.bchk: $!\n");
     }
 
-    print $fh "# This file was produced by plot-bamstats, the command line was:\n#   $$opts{args}\n#\n";
+    print $fh "# This file was produced by plot-bamstats and the command line was:\n#   $$opts{args}\n#\n";
 
     for my $sec (@{$$opts{sections}})
     {


### PR DESCRIPTION
In line 1187, the comma after `plot-bamstats` was being captured by the sanity check on Line 338. By switching the comma to `and`, this allows for the regex in the sanity check to still pass.