### PR TITLE
Added documentation for samtools stats sections.

### DIFF
--- a/doc/samtools-stats.1
+++ b/doc/samtools-stats.1
@@ -58,8 +58,8 @@ detailed descriptions.
 
 .TS
 lb l .
-CHK     checksum
-SN      summary numbers
+CHK     Checksum
+SN      Summary numbers
 FFQ     First fragment qualities
 LFQ     Last fragment qualities
 GCF     GC content of first fragments
@@ -67,20 +67,20 @@ GCL     GC content of last fragments
 GCC     ACGT content per cycle
 FBC     ACGT content per cycle for first fragments only
 LBC     ACGT content per cycle for last fragments only
-BCC1    ACGT content per cycle for BC barcode
-CRC1    ACGT content per cycle for CR barcode
-OXC1    ACGT content per cycle for OX barcode
-RXC1    ACGT content per cycle for RX barcode
-QTQ1    Quality distribution for BC barcode
-CYQ1    Quality distribution for CR barcode
-BZQ1    Quality distribution for OX barcode
-QXQ1    Quality distribution for RX barcode
+BCC     ACGT content per cycle for BC barcode
+CRC     ACGT content per cycle for CR barcode
+OXC     ACGT content per cycle for OX barcode
+RXC     ACGT content per cycle for RX barcode
+QTQ     Quality distribution for BC barcode
+CYQ     Quality distribution for CR barcode
+BZQ     Quality distribution for OX barcode
+QXQ     Quality distribution for RX barcode
 IS      Insert sizes
 RL      Read lengths
 FRL     Read lengths for first fragments only
 LRL     Read lengths for last fragments only
 ID      Indel size distribution
-IC      indels per cycle
+IC      Indels per cycle
 COV     Coverage (depth) distribution
 GCD     GC-depth
 .TE
@@ -94,9 +94,153 @@ and quality values.  The checksums are computed per alignment record
 and summed, meaning the checksum does not change if the input file has
 the sort-order changed.
 
-The SN section contains a series of counts, in a similar style to
-.BR "samtools stats" ,
+The SN section contains a series of counts, percentages, and averages, in a similar style to
+.BR "samtools flagstat" ,
 but more comprehensive.
+
+.RS
+.B raw total sequences
+- total number of reads in a file. Same number reported by 
+.BR "samtools view -c".
+
+.B filtered sequences
+- number of discarded reads when using -f or -F option.
+
+.B sequences
+- number of processed reads.
+
+.B is sorted
+- flag indicating whether the file is coordinate sorted (1) or not (0).
+
+.B 1st fragments
+- number of reads with flag 0x40 (64) set.
+
+.B last fragments
+- number of reads with flag 0x80 (128) set.
+
+.B reads mapped
+- number of reads, paired or single, that are mapped (flag 0x4 or 0x8 not set).
+
+.B reads mapped and paired
+- number of mapped paired reads (flag 0x1 is set and flags 0x4 and 0x8 are not set).
+
+.B reads unmapped
+- number of unmapped reads (flag 0x4 is set).
+
+.B reads properly paired
+- number of mapped paired reads with flag 0x2 set.
+
+.B paired
+- number of paired reads, mapped or unmapped, that are neither secondary nor supplementary (flag 0x1 is set and flags 0x100 (256) and 0x800 (2048) are not set).
+
+.B reads duplicated
+- number of duplicate reads (flag 0x400 (1024) is set).
+
+.B reads MQ0
+- number of mapped reads with mapping quality 0.
+
+.B reads QC failed
+- number of reads that failed the quality checks (flag 0x200 (512) is set).
+
+.B non-primary alignments
+- number of secondary reads (flag 0x100 (256) set).
+
+.B total length
+- number of processed bases from reads that are neither secondary nor supplementary (flags 0x100 (256) and 0x800 (2048) are not set).
+
+.B total first fragment length
+- number of processed bases that belong to
+.B 1st fragments.
+
+.B total last fragment length
+- number of processed bases that belong to
+.B last fragments.
+
+.B bases mapped
+- number of processed bases that belong to
+.B reads mapped.
+
+.B bases mapped (cigar)
+- number of mapped bases filtered by the CIGAR string corresponding to the read they belong to. Only alignment matches(M), inserts(I), sequence matches(=) and sequence mismatches(X) are counted.
+
+.B bases trimmed
+- number of bases trimmed by bwa, that belong to non secondary and non supplementary reads. Enabled by -q option.
+
+.B bases duplicated
+- number of bases that belong to
+.B reads duplicated.
+
+.B mismatches
+- number of mismatched bases, as reported by the NM tag associated wit a read, if present.
+
+.B error rate
+- ratio between
+.B mismatches
+and
+.B bases mapped (cigar).
+
+.B average length
+- ratio between
+.B total length
+and
+.B sequences.
+
+.B average first fragment length
+- ratio between
+.B total first fragment length
+and
+.B 1st fragments.
+
+.B average last fragment length
+- ratio between
+.B total last fragment length
+and
+.B last fragments.
+
+.B maximum length
+- length of the longest read (includes hard-clipped bases).
+
+.B maximum first fragment length
+- length of the longest read with flag 0x40 (64) set (includes hard-clipped bases).
+
+.B maximum last fragment length
+- length of the longest read with flag 0x80 (128) set (includes hard-clipped bases).
+
+.B average quality
+- ratio between the sum of base qualities and
+.B total length.
+
+.B insert size average
+- the average absolute template length for paired and mapped reads.
+
+.B insert size standard deviation
+- standard deviation for the average template length distribution.
+
+.B inward oriented pairs
+- number of paired reads with flag 0x40 (64) set and flag 0x10 (16) not set or with flag 0x80 (128) set and flag 0x10 (16) set.
+
+.B outward oriented pairs
+- number of paired reads with flag 0x40 (64) set and flag 0x10 (16) set or with flag 0x80 (128) set and flag 0x10 (16) not set.
+
+.B pairs with other orientation
+- number of paired reads that don't fall in any of the above two categories.
+
+.B pairs on different chromosomes
+- number of pairs where one read is on one chromosome and the pair read is on a different chromosome.
+
+.B percentage of properly paired reads
+- percentage of
+.B reads properly paired
+out of
+.B sequences.
+
+.B bases inside the target
+- number of bases inside the target region(s) (when a target file is specified with -t option).
+
+.B percentage of target genome with coverage > VAL
+- percentage of target bases with a coverage larger than VAL. By default, VAL is 0, but a custom value can be supplied by the user with -g option.
+.RE
+
 
 The FFQ and LFQ sections report the quality distribution per
 first/last fragment and per cycle number.  They have one row per cycle
@@ -117,16 +261,20 @@ are cycle number (integer), and percentage counts for A, C, G, T, N
 and other (typically containing ambiguity codes) normalised against
 the total counts of A, C, G and T only (excluding N and other).
 
-BCC1, CRC1, OXC1 and RXC1 are the barcode equivalent of GCC, showing
+BCC, CRC, OXC and RXC are the barcode equivalent of GCC, showing
 nucleotide content for the barcode tags BC, CR, OX and RX respectively.
-Their quality values distributions are in the QTQ1, CYQ1, BZQ1 and
-QXQ1 sections, corresponding to the BC/QT, CR/CY, OX/BZ and RX/QX SAM
+Their quality values distributions are in the QTQ, CYQ, BZQ and
+QXQ sections, corresponding to the BC/QT, CR/CY, OX/BZ and RX/QX SAM
 format sequence/quality tags.  These quality value distributions
-follow the same format used in the FFQ and LFQ sections.
-Note if a separator is present in the SAM tag (usually a hyphen) to
-indicate dual indexing, then sections ending in "2" will also be
-reported to show the second tag statistics (e.g. both BCC1 and
-BCC2 are present).
+follow the same format used in the FFQ and LFQ sections. All these
+section names are followed by a number (1 or 2), indicating that the
+stats figures below them correspond to the first or second barcode (in
+the case of dual indexing). Thus, these sections will appear as BCC1,
+CRC1, OXC1 and RXC1, accompanied by their quality correspondents QTQ1,
+CYQ1, BZQ1 and QXQ1. If a separator is present in the barcode sequence
+(usually a hyphen), indicating dual indexing, then sections ending in
+"2" will also be reported to show the second tag statistics (e.g. both
+BCC1 and BCC2 are present).
 
 IS reports insert size distributions with one row per size, reported
 in the first column, with subsequent columns for the frequency of

--- a/doc/samtools-stats.1
+++ b/doc/samtools-stats.1
@@ -53,6 +53,125 @@ samtools stats
 samtools stats collects statistics from BAM files and outputs in a text format.
 The output can be visualized graphically using plot-bamstats.
 
+A summary of output sections is listed below, followed by more
+detailed descriptions.
+
+.TS
+lb l .
+CHK     checksum
+SN      summary numbers
+FFQ     First fragment qualities
+LFQ     Last fragment qualities
+GCF     GC content of first fragments
+GCL     GC content of last fragments
+GCC     ACGT content per cycle
+FBC     ACGT content per cycle for first fragments only
+LBC     ACGT content per cycle for last fragments only
+BCC1    ACGT content per cycle for BC barcode
+CRC1    ACGT content per cycle for CR barcode
+OXC1    ACGT content per cycle for OX barcode
+RXC1    ACGT content per cycle for RX barcode
+QTQ1    Quality distribution for BC barcode
+CYQ1    Quality distribution for CR barcode
+BZQ1    Quality distribution for OX barcode
+QXQ1    Quality distribution for RX barcode
+IS      Insert sizes
+RL      Read lengths
+FRL     Read lengths for first fragments only
+LRL     Read lengths for last fragments only
+ID      Indel size distribution
+IC      indels per cycle
+COV     Coverage (depth) distribution
+GCD     GC-depth
+.TE
+
+Not all sections will be reported as some depend on the data being
+coordinate sorted while others are only present when specific barcode
+tags are in use.
+
+The CHK row contains distinct CRC32 checksums of read names, sequences
+and quality values.  The checksums are computed per alignment record
+and summed, meaning the checksum does not change if the input file has
+the sort-order changed.
+
+The SN section contains a series of counts, in a similar style to
+.BR "samtools stats" ,
+but more comprehensive.
+
+The FFQ and LFQ sections report the quality distribution per
+first/last fragment and per cycle number.  They have one row per cycle
+(reported as the first column after the FFQ/LFQ key) with remaining
+columns being the observed integer counts per quality value, starting
+at quality 0 in the left-most row and ending at the largest observed
+quality.  Thus each row forms its own quality distribution and any
+cycle specific quality artefacts can be observed.
+
+GCF and GCL report the total GC content of each fragment, separated
+into first and last fragments.  The columns show the GC percentile
+(between 0 and 100) and an integer count of fragments at that
+percentile.
+
+GCC, FBC and LBC report the nucleotide content per cycle either combined
+(GCC) or split into first (FBC) and last (LBC) fragments.  The columns
+are cycle number (integer), and percentage counts for A, C, G, T, N
+and other (typically containing ambiguity codes) normalised against
+the total counts of A, C, G and T only (excluding N and other).
+
+BCC1, CRC1, OXC1 and RXC1 are the barcode equivalent of GCC, showing
+nucleotide content for the barcode tags BC, CR, OX and RX respectively.
+Their quality values distributions are in the QTQ1, CYQ1, BZQ1 and
+QXQ1 sections, corresponding to the BC/QT, CR/CY, OX/BZ and RX/QX SAM
+format sequence/quality tags.  These quality value distributions
+follow the same format used in the FFQ and LFQ sections.
+Note if a separator is present in the SAM tag (usually a hyphen) to
+indicate dual indexing, then sections ending in "2" will also be
+reported to show the second tag statistics (e.g. both BCC1 and
+BCC2 are present).
+
+IS reports insert size distributions with one row per size, reported
+in the first column, with subsequent columns for the frequency of
+total pairs, inward oriented pairs, outward orient pairs and other
+orientation pairs.  The \fB-i\fR option specifies the maximum insert
+size reported.
+
+RL reports the distribution for all read lengths, with one row per
+observed length (up to the maximum specified by the \fB-l\fR option).
+Columns are read length and frequency.  FRL and LRL contains the same
+information separated into first and last fragments.
+
+ID reports the distribution of indel sizes, with one row per observed
+size. The columns are size, frequency of insertions at that size and
+frequency of deletions at that size.
+
+IC reports the frequency of indels occurring per cycle, broken down by
+both insertion / deletion and by first / last read.  Note for
+multi-base indels this only counts the first base location.  Columns
+are cycle, number of insertions in first fragments, number of
+insertions in last fragments, number of deletions in first fragments,
+and number of deletions in last fragments.
+
+COV reports a distribution of the alignment depth per covered
+reference site.  For example an average depth of 50 would ideally
+result in a normal distribution centred on 50, but the presence of
+repeats or copy-number variation may reveal multiple peaks at
+approximate multiples of 50.  The first column is an inclusive
+coverage range in the form of \fB[\fImin\fB-\fImax\fB]\fR.  The next
+columns are a repeat of the \fImax\fRimum portion of the depth range
+(now as a single integer) and the frequency that depth range was
+observed.  The minimum, maximum and range step size are controlled by
+the \fB-c\fR option.  Depths above and below the minimum and maximum
+are reported with ranges \fB[<\fImin\fB]\fR and \fB[\fImax\fB<]\fR.
+
+GCD reports the GC content of the reference data aligned against per
+alignment record, with one row per observed GC percentage reported as
+the first column and sorted on this column.  The second column is a
+total sequence percentile, as a running total (ending at 100%).  The
+first and second columns may be used to produce a simple distribution
+of GC content.  Subsequent columns list the coverage depth at 10th,
+25th, 50th, 75th and 90th GC percentiles for this specific GC
+percentage, revealing any GC bias in mapping.  These columns are
+averaged depths, so are floating point with no maximum value.
+
 .SH OPTIONS
 .TP 8
 .BI "-c, --coverage " MIN , MAX , STEP


### PR DESCRIPTION
(Mostly) fixes #890.  It doesn't specifically cover all the SN keys, but these are mostly counts so it's not possible to give any expected values here.