### PR TITLE
Don't output BAM to stdout if the user askes for in-place reheader.

### DIFF
--- a/bam_reheader.c
+++ b/bam_reheader.c
@@ -496,12 +496,20 @@ int main_reheader(int argc, char *argv[])
         return 1;
     }
     if (hts_get_format(in)->format == bam) {
-        r = bam_reheader(in->fp.bgzf, h, fileno(stdout), arg_list, add_PG);
-    } else {
+        if (inplace) {
+            print_error("reheader", "cannot reheader BAM '%s' in-place", argv[optind+1]);
+            r = -1;
+        } else {
+            r = bam_reheader(in->fp.bgzf, h, fileno(stdout), arg_list, add_PG);
+        }
+    } else if (hts_get_format(in)->format == cram) {
         if (inplace)
             r = cram_reheader_inplace(in->fp.cram, h, arg_list, add_PG);
         else
             r = cram_reheader(in->fp.cram, h, arg_list, add_PG);
+    } else {
+        print_error("reheader", "input file '%s' must be BAM or CRAM", argv[optind+1]);
+        r = -1;
     }
 
     if (sam_close(in) != 0)


### PR DESCRIPTION
This isn't possible in BAM format, so error instead.
We also now detect SAM files and fail on those too as this code doesn't support SAM either.

Fixes #618