### PR TITLE
Add tag to move sort -o option onto its own line.

### DIFF
--- a/doc/samtools-sort.1
+++ b/doc/samtools-sort.1
@@ -117,6 +117,7 @@ field) rather than by chromosomal coordinates.
 .BI "-t " TAG
 Sort first by the value in the alignment tag TAG, then by position or name (if
 also using \fB-n\fP).
+.TP
 .BI "-o " FILE
 Write the final sorted output to
 .IR FILE ,


### PR DESCRIPTION
Without the .TP tag it looked like -o was part of the -t option.

I noticed this on Debian testing with samtools version 1.7-2+b1, but I also checked the head 0cfa69903f6e126802309d52ce350d5661f12333 of the develop branch with ```groff -Tascii -man samtools-sort.1```

It really looks like the groff tag to put the -o option on its own line was left out.

Without the patch:
```
  -t TAG     Sort first by the value in the alignment tag  TAG,
             then  by  position or name (if also using -n).  -o
             FILE Write the final sorted output to FILE, rather
             than to standard output.
```

After patch:

```
  -t TAG     Sort first by the value in the alignment tag  TAG,  then  by
             position or name (if also using -n).

  -o FILE    Write  the final sorted output to FILE, rather than to stan-
             dard output.
```