### PR TITLE
add an option -H to samtools depth to print a file header

### DIFF
--- a/bam2depth.c
+++ b/bam2depth.c
@@ -147,9 +147,9 @@ int main_depth(int argc, char *argv[])
         return usage();
 
     /* output file provided by user */
-    if( output_file != NULL && strcmp(output_file,"-")!=0 ) {
+    if (output_file != NULL && strcmp(output_file,"-")!=0) {
         file_out = fopen( output_file, "w" );
-        if( file_out == NULL) {
+        if (file_out == NULL) {
             print_error_errno("depth", "Cannot open \"%s\" for writing.", output_file);
             return EXIT_FAILURE;
         }
@@ -213,12 +213,12 @@ int main_depth(int argc, char *argv[])
             }
         }
     }
-    if( print_header ) {
+    if (print_header) {
         fputs("#CHROM\tPOS", file_out);
         for (i = 0; i < n; ++i) {
             fputc('\t', file_out);
             fputs(argv[optind+i], file_out);
-            }  
+            }
         fputc('\n', file_out);
         }
     h = data[0]->hdr; // easy access to the header of the 1st BAM
@@ -317,7 +317,7 @@ int main_depth(int argc, char *argv[])
 depth_end:
     fflush(file_out);
     fclose(file_out);
-    
+
     for (i = 0; i < n && data[i]; ++i) {
         bam_hdr_destroy(data[i]->hdr);
         if (data[i]->fp) sam_close(data[i]->fp);

--- a/bam2depth.c
+++ b/bam2depth.c
@@ -150,7 +150,7 @@ int main_depth(int argc, char *argv[])
     if( output_file != NULL && strcmp(output_file,"-")!=0 ) {
         file_out = fopen( output_file, "w" );
         if( file_out == NULL) {
-            print_error_errno("depth", "Cannot open \"%s\" for writing\n", output_file);
+            print_error_errno("depth", "Cannot open \"%s\" for writing.", output_file);
             return EXIT_FAILURE;
         }
     }
@@ -168,7 +168,7 @@ int main_depth(int argc, char *argv[])
         n = argc - optind; // the number of BAMs on the command line
     data = calloc(n, sizeof(aux_t*)); // data[i] for the i-th input
     reg_tid = 0; beg = 0; end = INT_MAX;  // set the default region
-    if( print_header ) fputs("#CHROM\tPOS", file_out);
+
     for (i = 0; i < n; ++i) {
         int rf;
         data[i] = calloc(1, sizeof(aux_t));
@@ -177,10 +177,6 @@ int main_depth(int argc, char *argv[])
             print_error_errno("depth", "Could not open \"%s\"", argv[optind+i]);
             status = EXIT_FAILURE;
             goto depth_end;
-        }
-        if( print_header ) {
-            fputc('\t', file_out);
-            fputs(argv[optind+i], file_out);
         }
         rf = SAM_FLAG | SAM_RNAME | SAM_POS | SAM_MAPQ | SAM_CIGAR | SAM_SEQ;
         if (baseQ) rf |= SAM_QUAL;
@@ -217,8 +213,14 @@ int main_depth(int argc, char *argv[])
             }
         }
     }
-    if( print_header ) fputc('\n', file_out);
-
+    if( print_header ) {
+        fputs("#CHROM\tPOS", file_out);
+        for (i = 0; i < n; ++i) {
+            fputc('\t', file_out);
+            fputs(argv[optind+i], file_out);
+            }  
+        fputc('\n', file_out);
+        }
     h = data[0]->hdr; // easy access to the header of the 1st BAM
     if (reg) {
         beg = data[0]->iter->beg; // and to the parsed region coordinates

--- a/bam2depth.c
+++ b/bam2depth.c
@@ -79,15 +79,15 @@ static int usage() {
     fprintf(stderr, "   -a                  output all positions (including zero depth)\n");
     fprintf(stderr, "   -a -a (or -aa)      output absolutely all positions, including unused ref. sequences\n");
     fprintf(stderr, "   -b <bed>            list of positions or regions\n");
-    fprintf(stderr, "   -H                  print a file header\n");
     fprintf(stderr, "   -f <list>           list of input BAM filenames, one per line [null]\n");
+    fprintf(stderr, "   -H                  print a file header\n");
     fprintf(stderr, "   -l <int>            read length threshold (ignore reads shorter than <int>) [0]\n");
     fprintf(stderr, "   -d/-m <int>         maximum coverage depth [8000]. If 0, depth is set to the maximum\n"
                     "                       integer value, effectively removing any depth limit.\n");  // the htslib's default
+    fprintf(stderr, "   -o FILE             where to write output to [stdout]\n");
     fprintf(stderr, "   -q <int>            base quality threshold [0]\n");
     fprintf(stderr, "   -Q <int>            mapping quality threshold [0]\n");
     fprintf(stderr, "   -r <chr:from-to>    region\n");
-    fprintf(stderr, "   -o FILE             where to write output to [stdout]\n");
 
     sam_global_opt_help(stderr, "-.--.-");
 
@@ -113,9 +113,9 @@ int main_depth(int argc, char *argv[])
     bam_mplp_t mplp;
     int last_pos = -1, last_tid = -1, ret;
     int print_header = 0;
-    char* output_file = NULL;
-    FILE* file_out = stdout;
-    
+    char *output_file = NULL;
+    FILE *file_out = stdout;
+
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
     static const struct option lopts[] = {
         SAM_OPT_GLOBAL_OPTIONS('-', 0, '-', '-', 0, '-'),


### PR DESCRIPTION
This PR adds a new option `-H` to samtools depth to print a header.

with filenames

```
$ ./samtools depth -H ~/src/jvarkit-git/src/test/resources/S*.bam | head -n 3 
#CHROM	POS	/home/lindenb/src/jvarkit-git/src/test/resources/S1.bam	/home/lindenb/src/jvarkit-git/src/test/resources/S2.bam	/home/lindenb/src/jvarkit-git/src/test/resources/S3.bam	/home/lindenb/src/jvarkit-git/src/test/resources/S4.bam	/home/lindenb/src/jvarkit-git/src/test/resources/S5.bam
RF01	1	1	0	0	0	0
RF01	2	1	0	0	0	0
```
with stdin

```
$ cat ~/src/jvarkit-git/src/test/resources/S1.bam | ./samtools depth -H - | head
#CHROM	POS	-
RF01	1	1
RF01	2	1
RF01	3	1
RF01	4	1
RF01	5	1
RF01	6	1
RF01	7	1
RF01	8	2
RF01	9	2
```

