### PR TITLE
Fix incorrect macro definition on Windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -129,7 +129,7 @@ case $host_alias in
     # This also sets __USE_MINGW_ANSI_STDIO which in turn makes PRId64,
     # %lld and %z printf formats work.  It also enforces the snprintf to
     # be C99 compliant so it returns the correct values (in kstring.c).
-    CPPFLAGS="$CPPCFLAGS -D_POSIX_C_SOURCE=600"
+    CPPFLAGS="$CPPCFLAGS -D_XOPEN_SOURCE=600"
     ;;
 esac
 


### PR DESCRIPTION
_POSIX_C_SOURCE should have been _XOPEN_SOURCE.
The value given to _POSIX_C_SOURCE caused the strdup() and M_PI definitions to disappear.

Not sure quite how Appveyor failed to spot this, but I think it may be because it builds with htslib in a subdirectory of samtools.  It failed for me when they were in side-by-side directories.