### PR TITLE
Assorted samtools split bug fixes (note: change of behaviour for -u option)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,16 +217,16 @@ tmp_file.o: tmp_file.c config.h $(tmp_file_h) $(htslib_sam_h)
 # If using MSYS, avoid poor shell expansion via:
 #    MSYS2_ARG_CONV_EXCL="*" make check
 check test: samtools $(BGZIP) $(TEST_PROGRAMS)
+	test/split/test_count_rg
+	test/split/test_expand_format_string
+	test/split/test_filter_header_rg
+	test/split/test_parse_args
 	REF_PATH=: test/test.pl --exec bgzip=$(BGZIP) $${TEST_OPTS:-}
 	test/merge/test_bam_translate test/merge/test_bam_translate.tmp
 	test/merge/test_rtrans_build
 	test/merge/test_trans_tbl_init
 	cd test/mpileup && ./regression.sh mpileup.reg
 	cd test/mpileup && ./regression.sh depth.reg
-	test/split/test_count_rg
-	test/split/test_expand_format_string
-	test/split/test_filter_header_rg
-	test/split/test_parse_args
 
 
 test/merge/test_bam_translate: test/merge/test_bam_translate.o test/test.o libst.a $(HTSLIB)

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,15 @@
 Release a.b
 -----------
 
+* In samtools split, the '-u' option no longer accepts an extra file name
+  from which a replacement header was read.  The two file names were
+  separated using a colon, which caused problems on Windows and prevented
+  the use of URLs.  A new '-h' option has been added to allow the replacement
+  header file to be specified in its own option.
+
+* Fixed bug where samtools split would crash if it read a SAM header that
+  contained an @RG line with no ID tag. (#954, reported by @blue-bird1)
+
 Release 1.9 (18th July 2018)
 ----------------------------
 

--- a/bam_split.c
+++ b/bam_split.c
@@ -44,10 +44,10 @@ DEALINGS IN THE SOFTWARE.  */
 KHASH_MAP_INIT_STR(c2i, int)
 
 struct parsed_opts {
-    char* merged_input_name;
-    char* unaccounted_header_name;
-    char* unaccounted_name;
-    char* output_format_string;
+    const char *merged_input_name;
+    const char *unaccounted_header_name;
+    char *unaccounted_name;
+    const char *output_format_string;
     bool verbose;
     sam_global_args ga;
 };
@@ -117,8 +117,7 @@ static parsed_opts_t* parse_args(int argc, char** argv)
     while ((opt = getopt_long(argc, argv, optstring, lopts, NULL)) != -1) {
         switch (opt) {
         case 'f':
-            retval->output_format_string = strdup(optarg);
-            if (! retval->output_format_string ) { perror("cannot allocate output format string memory"); return NULL; }
+            retval->output_format_string = optarg;
             break;
         case 'v':
             retval->verbose = true;
@@ -128,8 +127,7 @@ static parsed_opts_t* parse_args(int argc, char** argv)
             if (! retval->unaccounted_name ) { perror("cannot allocate string memory"); return NULL; }
             if ((delim = strchr(retval->unaccounted_name, ':')) != NULL) {
                 *delim = '\0';
-                retval->unaccounted_header_name = strdup(delim+1);
-                if (! retval->unaccounted_header_name ) { perror("cannot allocate string memory"); return NULL; }
+                retval->unaccounted_header_name = delim+1;
             }
             break;
         default:
@@ -142,7 +140,7 @@ static parsed_opts_t* parse_args(int argc, char** argv)
         }
     }
 
-    if (retval->output_format_string == NULL) retval->output_format_string = strdup("%*_%#.%.");
+    if (retval->output_format_string == NULL) retval->output_format_string = "%*_%#.%.";
 
     argc -= optind;
     argv += optind;
@@ -154,8 +152,7 @@ static parsed_opts_t* parse_args(int argc, char** argv)
         return NULL;
     }
 
-    retval->merged_input_name = strdup(argv[0]);
-    if (! retval->merged_input_name ) { perror("cannot allocate string memory"); return NULL; }
+    retval->merged_input_name = argv[0];
 
     return retval;
 }
@@ -167,58 +164,65 @@ static char* expand_format_string(const char* format_string, const char* basenam
     const char* pointer = format_string;
     const char* next;
     while ((next = strchr(pointer, '%')) != NULL) {
-        kputsn(pointer, next-pointer, &str);
+        if (kputsn(pointer, next-pointer, &str) < 0) goto memfail;
         ++next;
         switch (*next) {
             case '%':
-                kputc('%', &str);
+                if (kputc('%', &str) < 0) goto memfail;
                 break;
             case '*':
-                kputs(basename, &str);
+                if (kputs(basename, &str) < 0) goto memfail;
                 break;
             case '#':
-                kputl(rg_idx, &str);
+                if (kputl(rg_idx, &str) < 0) goto memfail;
                 break;
             case '!':
-                kputs(rg_id, &str);
+                if (kputs(rg_id, &str) < 0) goto memfail;
                 break;
             case '.':
                 // Only really need to cope with sam, bam, cram
-                if (format->format != unknown_format)
-                    kputs(hts_format_file_extension(format), &str);
-                else
-                    kputs("bam", &str);
+                if (format->format != unknown_format) {
+                    if (kputs(hts_format_file_extension(format), &str) < 0)
+                        goto memfail;
+                } else {
+                    if (kputs("bam", &str) < 0) goto memfail;
+                }
                 break;
             case '\0':
-                // Error is: fprintf(stderr, "bad format string, trailing %%\n");
-                free(str.s);
-                return NULL;
+                print_error("split", "Trailing %% in filename format string");
+                goto fail;
             default:
                 // Error is: fprintf(stderr, "bad format string, unknown format specifier\n");
-                free(str.s);
-                return NULL;
+                print_error("split", "Unknown specifier %%%c in filename format string", *next);
+                goto fail;
         }
         pointer = next + 1;
     }
-    kputs(pointer, &str);
+    if (kputs(pointer, &str) < 0) goto memfail;
     return ks_release(&str);
+
+ memfail:
+    print_error_errno("split", "Couldn't build output filename");
+ fail:
+    free(str.s);
+    return NULL;
 }
 
 // Parse the header, count the number of RG tags and return a list of their names
 static bool count_RG(bam_hdr_t* hdr, size_t* count, char*** output_name)
 {
+    char **names = NULL;
+
     if (hdr->l_text < 3 ) {
         *count = 0;
         *output_name = NULL;
         return true;
     }
-    kstring_t input = { 0, 0, NULL };
-    kputsn(hdr->text, hdr->l_text, &input);
 
     //////////////////////////////////////////
     // First stage count number of @RG tags //
     //////////////////////////////////////////
-    char* pointer = ks_str(&input);
+    const char *pointer = hdr->text;
     size_t n_rg = 0;
     // Guard against rare case where @RG is first header line
     // This shouldn't happen but could where @HD is omitted
@@ -226,7 +230,7 @@ static bool count_RG(bam_hdr_t* hdr, size_t* count, char*** output_name)
         ++n_rg;
         pointer += 3;
     }
-    char* line;
+    const char *line;
     while ((line = strstr(pointer, "\n@RG")) != NULL) {
         ++n_rg;
         pointer = line + 1;
@@ -235,43 +239,55 @@ static bool count_RG(bam_hdr_t* hdr, size_t* count, char*** output_name)
     //////////////////////////////////
     // Second stage locate @RG ID's //
     //////////////////////////////////
-    char** names = (char**)calloc(sizeof(char*), n_rg);
-    size_t n_rg_id = 0;
-
     regex_t rg_finder;
-    if (regcomp(&rg_finder, "^@RG.*\tID:([!-)+-<>-~][ !-~]*)(\t.*$|$)", REG_EXTENDED|REG_NEWLINE) != 0) {
-        free(input.s);
-        free(names);
-        return false;
-    }
-    regmatch_t* matches = (regmatch_t*)calloc(sizeof(regmatch_t),2);
     int error;
-    char* begin = ks_str(&input);
+    memset(&rg_finder, 0, sizeof(rg_finder));
+    if ((error = regcomp(&rg_finder, "^@RG.*\tID:([!-)+-<>-~][ !-~]*)(\t.*$|$)", REG_EXTENDED|REG_NEWLINE)) != 0) {
+        goto regfail;
+    }
+    regmatch_t matches[2] = {{0, 0}, {0, 0}};
+    const char *begin = hdr->text;
+
+    names = calloc(n_rg, sizeof(names[0]));
+    if (!names) goto memfail;
+    size_t n_rg_id = 0;
 
     while ((error = regexec(&rg_finder, begin, 2, matches, 0)) == 0) {
         kstring_t str = { 0, 0, NULL };
-        kputsn(begin+matches[1].rm_so, matches[1].rm_eo-matches[1].rm_so, &str);
+        if (kputsn(begin+matches[1].rm_so, matches[1].rm_eo-matches[1].rm_so, &str) < 0)
+            goto memfail;
         assert(n_rg_id < n_rg);
         names[n_rg_id++] = ks_release(&str);
         begin += matches[0].rm_eo;
     }
 
-    if (error != REG_NOMATCH) {
-        // cleanup
-        regfree(&rg_finder);
-        free(matches);
-        free(names);
-        free(input.s);
-        return false;
-    }
-    free(matches);
+    if (error != REG_NOMATCH)
+        goto regfail;
 
     // return results
     *count = n_rg_id;
     *output_name = names;
     regfree(&rg_finder);
-    free(input.s);
     return true;
+
+ memfail:
+    print_error_errno("split", "Failed to get @RG IDs");
+    *count = 0;
+    *output_name = NULL;
+    regfree(&rg_finder);
+    free(names);
+    return false;
+
+ regfail: {
+        char msg[256];
+        regerror(error, &rg_finder, msg, sizeof(msg));
+        print_error("split", "Failed to parse @RG IDs : %s", msg);
+        *count = 0;
+        *output_name = NULL;
+        regfree(&rg_finder);
+        free(names);
+        return false;
+    }
 }
 
 // Filters a header of @RG lines where ID != id_keep
@@ -279,39 +295,39 @@ static bool count_RG(bam_hdr_t* hdr, size_t* count, char*** output_name)
 static bool filter_header_rg(bam_hdr_t* hdr, const char* id_keep, const char *arg_list)
 {
     kstring_t str = {0, 0, NULL};
-
+    size_t len_id_keep = strlen(id_keep);
+    SAM_hdr *sh = NULL;
     regex_t rg_finder;
+    int error;
+    memset(&rg_finder, 0, sizeof(rg_finder));
 
-    if (regcomp(&rg_finder, "^@RG.*\tID:([!-)+-<>-~][ !-~]*)(\t.*$|$)", REG_EXTENDED|REG_NEWLINE) != 0) {
-        return false;
+    if ((error = regcomp(&rg_finder, "^@RG.*\tID:([!-)+-<>-~][ !-~]*)(\t.*$|$)", REG_EXTENDED|REG_NEWLINE)) != 0) {
+        goto regfail;
     }
 
     // regex vars
     char* header = hdr->text;
-    regmatch_t* matches = (regmatch_t*)calloc(sizeof(regmatch_t),2);
-    kstring_t found_id = { 0, 0, NULL };
-    int error;
+    regmatch_t matches[2] = {{0, 0}, {0, 0}};
+
+    // We're removing lines so new header must be shorter than old
+    if (ks_resize(&str, hdr->l_text + 1) < 0)
+        goto memfail;
 
     while ((error = regexec(&rg_finder, header, 2, matches, 0)) == 0) {
         kputsn(header, matches[0].rm_so, &str); // copy header up until the found RG line
 
-        found_id.l = 0;
-        kputsn(header+matches[1].rm_so, matches[1].rm_eo-matches[1].rm_so, &found_id); // extract ID
-        // if it matches keep keep it, else we can just ignore it
-        if (strcmp(ks_str(&found_id), id_keep) == 0) {
+        // if ID matches keep keep it, else we can just ignore it
+        if (matches[1].rm_eo-matches[1].rm_so == len_id_keep &&
+            memcmp(header+matches[1].rm_so, id_keep, len_id_keep) == 0) {
             kputsn(header+matches[0].rm_so, (matches[0].rm_eo+1)-matches[0].rm_so, &str);
         }
         // move pointer forward
         header += matches[0].rm_eo+1;
     }
     // cleanup
-    free(found_id.s);
-    free(matches);
-    regfree(&rg_finder);
     // Did we leave loop because of an error?
-    if (error != REG_NOMATCH) {
-        return false;
-    }
+    if (error != REG_NOMATCH)
+        goto regfail;
 
     // Write remainder of string
     kputs(header, &str);
@@ -322,22 +338,43 @@ static bool filter_header_rg(bam_hdr_t* hdr, const char* id_keep, const char *ar
     hdr->text = ks_release(&str);
 
     // Add the PG line
-    SAM_hdr *sh = sam_hdr_parse_(hdr->text, hdr->l_text);
+    sh = sam_hdr_parse_(hdr->text, hdr->l_text);
+    if (!sh) {
+        print_error("split", "Couldn't parse SAM header");
+        goto fail;
+    }
     if (sam_hdr_add_PG(sh, "samtools",
                            "VN", samtools_version(),
                            arg_list ? "CL": NULL,
                            arg_list ? arg_list : NULL,
                            NULL) != 0)
-        return -1;
+        goto fail;
 
     free(hdr->text);
-    hdr->text = strdup(sam_hdr_str(sh));
+    char *new_text = strdup(sam_hdr_str(sh));
+    if (!new_text)
+        goto memfail;
     hdr->l_text = sam_hdr_length(sh);
-    if (!hdr->text)
-        return false;
+    hdr->text = new_text;
     sam_hdr_free(sh);
+    regfree(&rg_finder);
 
     return true;
+
+ regfail: {
+        char msg[256];
+        regerror(error, &rg_finder, msg, sizeof(msg));
+        print_error("split", "Failed to parse @RG IDs : %s", msg);
+        goto fail;
+    }
+
+ memfail:
+    print_error_errno("split", "Couldn't make new SAM header");
+ fail:
+    regfree(&rg_finder);
+    free(ks_release(&str));
+    if (sh) sam_hdr_free(sh);
+    return false;
 }
 
 // Set the initial state
@@ -352,6 +389,7 @@ static state_t* init(parsed_opts_t* opts, const char *arg_list)
     if (opts->ga.nthreads > 0) {
         if (!(retval->p.pool = hts_tpool_init(opts->ga.nthreads))) {
             fprintf(stderr, "Error creating thread pool\n");
+            cleanup_state(retval, false);
             return NULL;
         }
     }
@@ -359,7 +397,7 @@ static state_t* init(parsed_opts_t* opts, const char *arg_list)
     retval->merged_input_file = sam_open_format(opts->merged_input_name, "rb", &opts->ga.in);
     if (!retval->merged_input_file) {
         print_error_errno("split", "Could not open \"%s\"", opts->merged_input_name);
-        free(retval);
+        cleanup_state(retval, false);
         return NULL;
     }
     if (retval->p.pool)
@@ -377,12 +415,14 @@ static state_t* init(parsed_opts_t* opts, const char *arg_list)
             if (!hdr_load) {
                 print_error_errno("split", "Could not open unaccounted header file \"%s\"", opts->unaccounted_header_name);
                 cleanup_state(retval, false);
+                sam_close(hdr_load);
                 return NULL;
             }
             retval->unaccounted_header = sam_hdr_read(hdr_load);
             if (retval->unaccounted_header == NULL) {
                 print_error("split", "Could not read header from \"%s\"", opts->unaccounted_header_name);
                 cleanup_state(retval, false);
+                sam_close(hdr_load);
                 return NULL;
             }
             sam_close(hdr_load);
@@ -434,7 +474,6 @@ static state_t* init(parsed_opts_t* opts, const char *arg_list)
                                                &opts->ga.out);
 
         if ( output_filename == NULL ) {
-            print_error("split", "Error expanding output filename format string");
             cleanup_state(retval, false);
             free(input_base_name);
             return NULL;
@@ -454,6 +493,12 @@ static state_t* init(parsed_opts_t* opts, const char *arg_list)
         // Record index in hash
         int ret;
         khiter_t iter = kh_put_c2i(retval->rg_hash, retval->rg_id[i], &ret);
+        if (ret < 0) {
+            print_error_errno("split", "Couldn't add @RG ID to look-up table");
+            cleanup_state(retval, false);
+            free(input_base_name);
+            return NULL;
+        }
         kh_val(retval->rg_hash,iter) = i;
 
         // Set and edit header
@@ -595,10 +640,7 @@ static int cleanup_state(state_t* status, bool check_close)
 static void cleanup_opts(parsed_opts_t* opts)
 {
     if (!opts) return;
-    free(opts->merged_input_name);
-    free(opts->unaccounted_header_name);
     free(opts->unaccounted_name);
-    free(opts->output_format_string);
     sam_global_args_free(&opts->ga);
     free(opts);
 }

--- a/doc/samtools-split.1
+++ b/doc/samtools-split.1
@@ -61,8 +61,13 @@ records without an RG tag.
 .BI "-u " FILE1
 .RI "Put reads with no RG tag or an unrecognised RG tag into " FILE1
 .TP
-.BI "-u " FILE1 ":" FILE2
-.RI "As above, but assigns an RG tag as given in the header of " FILE2
+.BI "-h " FILE2
+.RI "Use the header from " FILE2 " when writing the file given in the " -u
+option.
+This header completely replaces the one from the input file.
+It must be compatible with the input file header, which means it must
+have the same number of references listed in the @SQ lines and the
+references must be in the same order and have the same lengths.
 .TP
 .BI "-f " STRING
 Output filename format string (see below)

--- a/test/split/split.expected.grp1.sam
+++ b/test/split/split.expected.grp1.sam
@@ -1,0 +1,41 @@
+@HD	VN:1.4	SO:coordinate
+@RG	ID:grp1	DS:Group 1	LB:Library 1	SM:Sample
+@PG	ID:prog1	PN:emacs	CL:emacs	VN:23.1.1
+@CO	The MIT License
+@CO	
+@CO	Copyright (c) 2014 Genome Research Ltd.
+@CO	
+@CO	Permission is hereby granted, free of charge, to any person obtaining a copy
+@CO	of this software and associated documentation files (the "Software"), to deal
+@CO	in the Software without restriction, including without limitation the rights
+@CO	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+@CO	copies of the Software, and to permit persons to whom the Software is
+@CO	furnished to do so, subject to the following conditions:
+@CO	
+@CO	The above copyright notice and this permission notice shall be included in
+@CO	all copies or substantial portions of the Software.
+@CO	
+@CO	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+@CO	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+@CO	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+@CO	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+@CO	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+@CO	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+@CO	THE SOFTWARE.
+@SQ	SN:ref1	LN:56	M5:08c04d512d4797d9ba2a156c1daba468
+@SQ	SN:ref2	LN:60	M5:7c35feac7036c1cdef3bee0cc4b21437
+@SQ	SN:ref3_unused	LN:70	M5:5fdd18c2c6ecac4838996d029bf395b5
+ref1_grp1_p001	99	ref1	1	0	10M	=	25	34	CGAGCTCGGT	!!!!!!!!!!	RG:Z:grp1	BC:Z:ACGT	H0:i:1	aa:A:!	ab:A:~	fa:f:3.14159	za:Z:Hello world!	ha:H:DEADBEEF	ba:B:c,-128,0,127	bb:B:C,0,127,255	bc:B:s,-32768,0,32767	bd:B:S,0,32768,65535	be:B:i,-2147483648,0,2147483647	bf:B:I,0,2147483648,4294967295	bg:B:f,2.71828,6.626e-34,2.9979e+09	NM:i:0	MD:Z:10
+ref1_grp1_p002	99	ref1	5	2	10M	=	29	34	CTCGGTACCC	##########	RG:Z:grp1	BC:Z:AATTCCGG	H0:i:1	aa:A:a	ab:A:z	fa:f:4.3597e-18	za:Z:Another string	ha:H:2000AD	NM:i:0	MD:Z:10
+ref1_grp1_p003	99	ref1	9	4	10M	=	33	34	GTACCCGGGG	%%%%%%%%%%	fa:f:1.66e-27	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp1_p004	99	ref1	13	6	10M	=	37	34	CCGGGGATCC	''''''''''	fa:f:1.38e-23	za:Z:xRG:Z:grp2	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp1_p005	99	ref1	17	8	10M	=	41	34	GGATCCTCTA	))))))))))	RG:Z:grp1	ia:i:40000	NM:i:0	MD:Z:10
+ref1_grp1_p006	99	ref1	21	10	10M	=	45	34	CCTCTAGAGT	++++++++++	RG:Z:grp1	ia:i:255	NM:i:0	MD:Z:10
+ref1_grp1_p001	147	ref1	25	12	10M	=	1	-34	TAGAGTCGAC	----------	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp1_p002	147	ref1	29	14	10M	=	5	-34	GTCGACCTGC	//////////	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp1_p003	147	ref1	33	16	10M	=	9	-34	ACCTGCAGGC	1111111111	RG:Z:grp1	NM:i:0	MD:Z:10
+ref12_grp1_p001	97	ref1	36	50	10M	ref2	2	0	TGCAGGCATG	AAAAAAAAAA	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp1_p004	147	ref1	37	18	10M	=	13	-34	GCAGGCATGC	3333333333	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp1_p005	147	ref1	41	20	10M	=	17	-34	GCATGCAAGC	5555555555	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp1_p006	147	ref1	45	22	10M	=	21	-34	GCAAGCTTGA	7777777777	RG:Z:grp1	NM:i:0	MD:Z:10
+ref12_grp1_p001	145	ref2	2	50	10M	ref1	36	0	TTCTATAGTG	BBBBBBBBBB	RG:Z:grp1	NM:i:0	MD:Z:10

--- a/test/split/split.expected.grp2.sam
+++ b/test/split/split.expected.grp2.sam
@@ -1,0 +1,41 @@
+@HD	VN:1.4	SO:coordinate
+@RG	ID:grp2	DS:Group 2	LB:Library 2	SM:Sample
+@PG	ID:prog1	PN:emacs	CL:emacs	VN:23.1.1
+@CO	The MIT License
+@CO	
+@CO	Copyright (c) 2014 Genome Research Ltd.
+@CO	
+@CO	Permission is hereby granted, free of charge, to any person obtaining a copy
+@CO	of this software and associated documentation files (the "Software"), to deal
+@CO	in the Software without restriction, including without limitation the rights
+@CO	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+@CO	copies of the Software, and to permit persons to whom the Software is
+@CO	furnished to do so, subject to the following conditions:
+@CO	
+@CO	The above copyright notice and this permission notice shall be included in
+@CO	all copies or substantial portions of the Software.
+@CO	
+@CO	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+@CO	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+@CO	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+@CO	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+@CO	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+@CO	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+@CO	THE SOFTWARE.
+@SQ	SN:ref1	LN:56	M5:08c04d512d4797d9ba2a156c1daba468
+@SQ	SN:ref2	LN:60	M5:7c35feac7036c1cdef3bee0cc4b21437
+@SQ	SN:ref3_unused	LN:70	M5:5fdd18c2c6ecac4838996d029bf395b5
+ref1_grp2_p001	99	ref1	3	1	10M	=	27	34	AGCTCGGTAC	""""""""""	RG:Z:grp2	BC:Z:TGCA	H0:i:1	aa:A:A	ab:A:Z	fa:f:6.67e-11	za:Z:!"$%^&*()	ha:H:CAFE	NM:i:0	MD:Z:10
+ref1_grp2_p002	99	ref1	7	3	10M	=	31	34	CGGTACCCGG	$$$$$$$$$$	fa:f:6.022e+23	RG:Z:grp2	NM:i:0	MD:Z:10
+ref1_grp2_p003	99	ref1	11	5	10M	=	35	34	ACCCGGGGAT	&&&&&&&&&&	RG:Z:grp2	ia:i:4294967295	NM:i:0	MD:Z:10
+ref1_grp2_p004	99	ref1	15	7	10M	=	39	34	GGGGATCCTC	((((((((((	RG:Z:grp2	ia:i:-2147483648	NM:i:0	MD:Z:10
+ref1_grp2_p005	99	ref1	19	9	10M	=	43	34	ATCCTCTAGA	**********	RG:Z:grp2	ia:i:-1000	NM:i:0	MD:Z:10
+ref1_grp2_p006	99	ref1	23	11	10M	=	47	34	TCTAGAGTCG	,,,,,,,,,,	RG:Z:grp2	ia:i:-1	NM:i:0	MD:Z:10
+ref1_grp2_p001	147	ref1	27	13	10M	=	3	-34	GAGTCGACCT	..........	RG:Z:grp2	NM:i:0	MD:Z:10
+ref1_grp2_p002	147	ref1	31	15	10M	=	7	-34	CGACCTGCAG	0000000000	RG:Z:grp2	NM:i:0	MD:Z:10
+ref1_grp2_p003	147	ref1	35	17	10M	=	11	-34	CTGCAGGCAT	2222222222	RG:Z:grp2	NM:i:0	MD:Z:10
+ref1_grp2_p004	147	ref1	39	19	10M	=	15	-34	AGGCATGCAA	4444444444	RG:Z:grp2	NM:i:0	MD:Z:10
+ref1_grp2_p005	147	ref1	43	21	10M	=	19	-34	ATGCAAGCTT	6666666666	RG:Z:grp2	NM:i:0	MD:Z:10
+ref12_grp2_p001	97	ref1	46	50	10M	ref2	12	0	CAAGCTTGAG	AAAAAAAAAA	RG:Z:grp2	NM:i:0	MD:Z:10
+ref1_grp2_p006	147	ref1	47	23	10M	=	23	-34	AAGCTTGAGT	8888888888	RG:Z:grp2	NM:i:0	MD:Z:10
+ref12_grp2_p001	145	ref2	12	50	10M	ref1	46	0	TCACCTAAAT	BBBBBBBBBB	RG:Z:grp2	NM:i:0	MD:Z:10

--- a/test/split/split.expected.unk.sam
+++ b/test/split/split.expected.unk.sam
@@ -1,0 +1,34 @@
+@HD	VN:1.4	SO:coordinate
+@RG	ID:grp1	DS:Group 1	LB:Library 1	SM:Sample
+@RG	ID:grp2	DS:Group 2	LB:Library 2	SM:Sample
+@PG	ID:prog1	PN:emacs	CL:emacs	VN:23.1.1
+@CO	The MIT License
+@CO	
+@CO	Copyright (c) 2014 Genome Research Ltd.
+@CO	
+@CO	Permission is hereby granted, free of charge, to any person obtaining a copy
+@CO	of this software and associated documentation files (the "Software"), to deal
+@CO	in the Software without restriction, including without limitation the rights
+@CO	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+@CO	copies of the Software, and to permit persons to whom the Software is
+@CO	furnished to do so, subject to the following conditions:
+@CO	
+@CO	The above copyright notice and this permission notice shall be included in
+@CO	all copies or substantial portions of the Software.
+@CO	
+@CO	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+@CO	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+@CO	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+@CO	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+@CO	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+@CO	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+@CO	THE SOFTWARE.
+@SQ	SN:ref1	LN:56	M5:08c04d512d4797d9ba2a156c1daba468
+@SQ	SN:ref2	LN:60	M5:7c35feac7036c1cdef3bee0cc4b21437
+@SQ	SN:ref3_unused	LN:70	M5:5fdd18c2c6ecac4838996d029bf395b5
+ref2_grp3_p001	83	ref2	1	99	15M	=	31	45	ATTCTATAGTGTCAC	~~~~~~~~~~~~~~~	NM:i:0	MD:Z:15
+ref2_grp3_p002	147	ref2	16	99	15M	=	46	45	CTAAATAGCTTGGCG	}}}}}}}}}}}}}}}	NM:i:0	MD:Z:15
+ref2_grp3_p001	163	ref2	31	99	15M	=	1	-45	CTGTTTCCTGTGTGA	|||||||||||||||	NM:i:13	MD:Z:0T0A0A1C0A0T0G0G0T0C0A1A0G0
+ref2_grp3_p002	99	ref2	46	99	15M	=	16	-45	CTGTTTCCTGTGTGA	{{{{{{{{{{{{{{{	NM:i:0	MD:Z:15
+unaligned_grp3_p001	77	*	0	0	*	*	0	0	CACTCGTTCATGACG	0123456789abcde
+unaligned_grp3_p001	141	*	0	0	*	*	0	0	GAAAGTGAGGAGGTG	edcba9876543210

--- a/test/split/split.sam
+++ b/test/split/split.sam
@@ -1,0 +1,62 @@
+@HD	VN:1.4	SO:coordinate
+@RG	ID:grp1	DS:Group 1	LB:Library 1	SM:Sample
+@RG	ID:grp2	DS:Group 2	LB:Library 2	SM:Sample
+@PG	ID:prog1	PN:emacs	CL:emacs	VN:23.1.1
+@CO	The MIT License
+@CO	
+@CO	Copyright (c) 2014 Genome Research Ltd.
+@CO	
+@CO	Permission is hereby granted, free of charge, to any person obtaining a copy
+@CO	of this software and associated documentation files (the "Software"), to deal
+@CO	in the Software without restriction, including without limitation the rights
+@CO	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+@CO	copies of the Software, and to permit persons to whom the Software is
+@CO	furnished to do so, subject to the following conditions:
+@CO	
+@CO	The above copyright notice and this permission notice shall be included in
+@CO	all copies or substantial portions of the Software.
+@CO	
+@CO	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+@CO	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+@CO	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+@CO	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+@CO	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+@CO	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+@CO	THE SOFTWARE.
+@SQ	SN:ref1	LN:56	M5:08c04d512d4797d9ba2a156c1daba468
+@SQ	SN:ref2	LN:60	M5:7c35feac7036c1cdef3bee0cc4b21437
+@SQ	SN:ref3_unused	LN:70	M5:5fdd18c2c6ecac4838996d029bf395b5
+ref1_grp1_p001	99	ref1	1	0	10M	=	25	34	CGAGCTCGGT	!!!!!!!!!!	RG:Z:grp1	BC:Z:ACGT	H0:i:1	aa:A:!	ab:A:~	fa:f:3.14159	za:Z:Hello world!	ha:H:DEADBEEF	ba:B:c,-128,0,127	bb:B:C,0,127,255	bc:B:s,-32768,0,32767	bd:B:S,0,32768,65535	be:B:i,-2147483648,0,2147483647	bf:B:I,0,2147483648,4294967295	bg:B:f,2.71828,6.626e-34,2.9979e+09	NM:i:0	MD:Z:10
+ref1_grp2_p001	99	ref1	3	1	10M	=	27	34	AGCTCGGTAC	""""""""""	RG:Z:grp2	BC:Z:TGCA	H0:i:1	aa:A:A	ab:A:Z	fa:f:6.67e-11	za:Z:!"$%^&*()	ha:H:CAFE	NM:i:0	MD:Z:10
+ref1_grp1_p002	99	ref1	5	2	10M	=	29	34	CTCGGTACCC	##########	RG:Z:grp1	BC:Z:AATTCCGG	H0:i:1	aa:A:a	ab:A:z	fa:f:4.3597e-18	za:Z:Another string	ha:H:2000AD	NM:i:0	MD:Z:10
+ref1_grp2_p002	99	ref1	7	3	10M	=	31	34	CGGTACCCGG	$$$$$$$$$$	fa:f:6.022e+23	RG:Z:grp2	NM:i:0	MD:Z:10
+ref1_grp1_p003	99	ref1	9	4	10M	=	33	34	GTACCCGGGG	%%%%%%%%%%	fa:f:1.66e-27	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp2_p003	99	ref1	11	5	10M	=	35	34	ACCCGGGGAT	&&&&&&&&&&	RG:Z:grp2	ia:i:4294967295	NM:i:0	MD:Z:10
+ref1_grp1_p004	99	ref1	13	6	10M	=	37	34	CCGGGGATCC	''''''''''	fa:f:1.38e-23	za:Z:xRG:Z:grp2	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp2_p004	99	ref1	15	7	10M	=	39	34	GGGGATCCTC	((((((((((	RG:Z:grp2	ia:i:-2147483648	NM:i:0	MD:Z:10
+ref1_grp1_p005	99	ref1	17	8	10M	=	41	34	GGATCCTCTA	))))))))))	RG:Z:grp1	ia:i:40000	NM:i:0	MD:Z:10
+ref1_grp2_p005	99	ref1	19	9	10M	=	43	34	ATCCTCTAGA	**********	RG:Z:grp2	ia:i:-1000	NM:i:0	MD:Z:10
+ref1_grp1_p006	99	ref1	21	10	10M	=	45	34	CCTCTAGAGT	++++++++++	RG:Z:grp1	ia:i:255	NM:i:0	MD:Z:10
+ref1_grp2_p006	99	ref1	23	11	10M	=	47	34	TCTAGAGTCG	,,,,,,,,,,	RG:Z:grp2	ia:i:-1	NM:i:0	MD:Z:10
+ref1_grp1_p001	147	ref1	25	12	10M	=	1	-34	TAGAGTCGAC	----------	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp2_p001	147	ref1	27	13	10M	=	3	-34	GAGTCGACCT	..........	RG:Z:grp2	NM:i:0	MD:Z:10
+ref1_grp1_p002	147	ref1	29	14	10M	=	5	-34	GTCGACCTGC	//////////	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp2_p002	147	ref1	31	15	10M	=	7	-34	CGACCTGCAG	0000000000	RG:Z:grp2	NM:i:0	MD:Z:10
+ref1_grp1_p003	147	ref1	33	16	10M	=	9	-34	ACCTGCAGGC	1111111111	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp2_p003	147	ref1	35	17	10M	=	11	-34	CTGCAGGCAT	2222222222	RG:Z:grp2	NM:i:0	MD:Z:10
+ref12_grp1_p001	97	ref1	36	50	10M	ref2	2	0	TGCAGGCATG	AAAAAAAAAA	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp1_p004	147	ref1	37	18	10M	=	13	-34	GCAGGCATGC	3333333333	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp2_p004	147	ref1	39	19	10M	=	15	-34	AGGCATGCAA	4444444444	RG:Z:grp2	NM:i:0	MD:Z:10
+ref1_grp1_p005	147	ref1	41	20	10M	=	17	-34	GCATGCAAGC	5555555555	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp2_p005	147	ref1	43	21	10M	=	19	-34	ATGCAAGCTT	6666666666	RG:Z:grp2	NM:i:0	MD:Z:10
+ref1_grp1_p006	147	ref1	45	22	10M	=	21	-34	GCAAGCTTGA	7777777777	RG:Z:grp1	NM:i:0	MD:Z:10
+ref12_grp2_p001	97	ref1	46	50	10M	ref2	12	0	CAAGCTTGAG	AAAAAAAAAA	RG:Z:grp2	NM:i:0	MD:Z:10
+ref1_grp2_p006	147	ref1	47	23	10M	=	23	-34	AAGCTTGAGT	8888888888	RG:Z:grp2	NM:i:0	MD:Z:10
+ref2_grp3_p001	83	ref2	1	99	15M	=	31	45	ATTCTATAGTGTCAC	~~~~~~~~~~~~~~~	NM:i:0	MD:Z:15
+ref12_grp1_p001	145	ref2	2	50	10M	ref1	36	0	TTCTATAGTG	BBBBBBBBBB	RG:Z:grp1	NM:i:0	MD:Z:10
+ref12_grp2_p001	145	ref2	12	50	10M	ref1	46	0	TCACCTAAAT	BBBBBBBBBB	RG:Z:grp2	NM:i:0	MD:Z:10
+ref2_grp3_p002	147	ref2	16	99	15M	=	46	45	CTAAATAGCTTGGCG	}}}}}}}}}}}}}}}	NM:i:0	MD:Z:15
+ref2_grp3_p001	163	ref2	31	99	15M	=	1	-45	CTGTTTCCTGTGTGA	|||||||||||||||	NM:i:13	MD:Z:0T0A0A1C0A0T0G0G0T0C0A1A0G0
+ref2_grp3_p002	99	ref2	46	99	15M	=	16	-45	CTGTTTCCTGTGTGA	{{{{{{{{{{{{{{{	NM:i:0	MD:Z:15
+unaligned_grp3_p001	77	*	0	0	*	*	0	0	CACTCGTTCATGACG	0123456789abcde
+unaligned_grp3_p001	141	*	0	0	*	*	0	0	GAAAGTGAGGAGGTG	edcba9876543210

--- a/test/test.pl
+++ b/test/test.pl
@@ -66,7 +66,8 @@ test_addrprg($opts, threads=>2);
 test_markdup($opts);
 test_markdup($opts, threads=>2);
 test_bedcov($opts);
-
+test_split($opts);
+test_split($opts, threads=>2);
 
 print "\nNumber of tests:\n";
 printf "    total            .. %d\n", $$opts{nok}+$$opts{nfailed}+$$opts{nxfail}+$$opts{nxpass};
@@ -210,6 +211,7 @@ sub cmd
 #       want_fail=> consider passed() if cmd() returns non-zero
 #       out_map => map output filenames to their expected result file (can be used alongside out)
 #       hskip => number of header lines to ignore during diff
+#       ignore_pg_header => remove @PG header lines
 sub test_cmd
 {
     my ($opts,%args) = @_;
@@ -269,6 +271,11 @@ sub test_cmd
         close($fh);
     }
     elsif ( !$$opts{redo_outputs} ) { failed($opts,%args,msg=>$test,reason=>"$$opts{path}/$args{out}: $!"); return; }
+
+    if ($args{ignore_pg_header}) {
+	$out =~ s/(^|\n)\@PG\t[^\n]*\n/$1/sg;
+	$exp =~ s/(^|\n)\@PG\t[^\n]*\n/$1/sg;
+    }
 
     if ( $exp ne $out )
     {
@@ -352,6 +359,11 @@ sub test_cmd
                 close($fh);
             }
             elsif ( !$$opts{redo_outputs} ) { failed($opts,%args,msg=>$test,reason=>"$$opts{path}/$out_actual: $!"); return; }
+
+	    if ($args{ignore_pg_header}) {
+		$out =~ s/(^|\n)\@PG\t[^\n]*\n/$1/sg;
+		$exp =~ s/(^|\n)\@PG\t[^\n]*\n/$1/sg;
+	    }
 
             if ( $exp ne $out )
             {
@@ -2885,3 +2897,19 @@ sub test_bedcov
     test_cmd($opts,out=>'bedcov/bedcov_j.expected',cmd=>"$$opts{bin}/samtools bedcov -j $$opts{path}/bedcov/bedcov.bed $$opts{path}/bedcov/bedcov.bam");
 }
 
+sub test_split
+{
+    my ($opts, %args) = @_;
+
+    my $threads = exists($args{threads}) ? " -@ $args{threads}" : "";
+
+    test_cmd($opts,
+	     out=>"dat/empty.expected",
+	     out_map => {
+		 'split/split.tmp.grp1.sam' => 'split/split.expected.grp1.sam',
+		 'split/split.tmp.grp2.sam' => 'split/split.expected.grp2.sam',
+		 'split/split.tmp.unk.sam' => 'split/split.expected.unk.sam',
+	     },
+	     ignore_pg_header => 1,
+	     cmd => "$$opts{bin}/samtools split $threads --output-fmt sam -u $$opts{path}/split/split.tmp.unk.sam -f $$opts{path}/split/split.tmp.\%!.\%. $$opts{path}/split/split.sam");
+}


### PR DESCRIPTION
Fixes invalid memory accesses in bam_split (Fixes #954).

Fixes use after free in cleanup_state()

Adds some missing error checks, improves error reporting and clean up after errors.

Changes how `unaccounted_header_name` is passed into samtools split.  Previously this involved passing two files in the `-u` option separated by a colon, which did not work well on Windows.  This PR makes `-u` take a single file and adds a new `-h` option for the second one.

Adds a simple function test for `samtools split` (before it just had unit tests on some of the internals).