### PR TITLE
Add gcc-7 case as a conditional job.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,18 @@ matrix:
       env:
         - CC=gcc-8
         - AR=gcc-ar-8
+    - os: linux
+      compiler: gcc-7
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-7
+      env:
+        - CC=gcc-7
+        - AR=gcc-ar-7
+      if: type = cron OR env(CI_SECONDARY) = 1
     # An unoptimised C99 build, for detecting non-static inline functions
     - os: linux
       compiler: gcc-8


### PR DESCRIPTION
> https://github.com/samtools/samtools/issues/951#issuecomment-430708002
> Ubuntu 18.04 LTS (Bionic Beaver) is using GCC 7.3.

This pull-request is experimental proposal.

I am understanding reducing total running time for the pull-request or pushing to a branch is quite important.
In other words, we want to check supported environment such as above GCC 7.3.

This pull-request is to add conditional job (= something like "secondary" important job).
In a case of a pull-request or pushing to a branch, the running test case are same with current one.
This new job is only run if Travis is run as cron mode or `CI_SECONDARY` is set as `1` from Travis's setting page.

This solves our needs, does not it?

Here is the result of my repository. I did set `CI_SECONDARY`: `1` on my repository's setting page.
https://travis-ci.org/junaruga/samtools/builds/442844526
You can see total 6 jobs (test cases) including the new gcc-7 job.

But you will see 5 jobs in this pull-request's CI test.

I would recommend you to start cron job for necessary branches from Travis setting page, if this pull-request is adapted.
