### PR TITLE
Widen tview "goto position" text entry box

### DIFF
--- a/bam_tview.h
+++ b/bam_tview.h
@@ -77,7 +77,7 @@ char bam_aux_getCSi(bam1_t *b, int i);
 char bam_aux_getCQi(bam1_t *b, int i);
 
 #define TV_MIN_ALNROW 2
-#define TV_MAX_GOTO  40
+#define TV_MAX_GOTO  48
 #define TV_LOW_MAPQ  10
 
 #define TV_COLOR_MAPQ   0


### PR DESCRIPTION
Ensure that positions on contigs named by UUIDs can be entered, i.e., that there is space to enter "36_char_uuid:2147483647". (It can't be arbitrarily wide as it still needs to fit on a terminal as narrow as 80 columns.)

See <https://www.biostars.org/p/344564/>.