### PR TITLE
Feat/support passing index files

### DIFF
--- a/bam2depth.c
+++ b/bam2depth.c
@@ -79,7 +79,7 @@ static int usage() {
     fprintf(stderr, "   -a                  output all positions (including zero depth)\n");
     fprintf(stderr, "   -a -a (or -aa)      output absolutely all positions, including unused ref. sequences\n");
     fprintf(stderr, "   -b <bed>            list of positions or regions\n");
-    fprintf(stderr, "   -D                  use customized index files\n");
+    fprintf(stderr, "   -X                  use customized index files\n");
     fprintf(stderr, "   -f <list>           list of input BAM filenames, one per line [null]\n");
     fprintf(stderr, "   -H                  print a file header\n");
     fprintf(stderr, "   -l <int>            read length threshold (ignore reads shorter than <int>) [0]\n");
@@ -124,7 +124,7 @@ int main_depth(int argc, char *argv[])
     };
 
     // parse the command line
-    while ((n = getopt_long(argc, argv, "r:b:Dq:Q:l:f:am:d:Ho:", lopts, NULL)) >= 0) {
+    while ((n = getopt_long(argc, argv, "r:b:Xq:Q:l:f:am:d:Ho:", lopts, NULL)) >= 0) {
         switch (n) {
             case 'l': min_len = atoi(optarg); break; // minimum query length
             case 'r': reg = strdup(optarg); break;   // parsing a region requires a BAM header
@@ -132,7 +132,7 @@ int main_depth(int argc, char *argv[])
                 bed = bed_read(optarg); // BED or position list file can be parsed now
                 if (!bed) { print_error_errno("depth", "Could not read file \"%s\"", optarg); return 1; }
                 break;
-            case 'D': has_index_file = 1; break;
+            case 'X': has_index_file = 1; break;
             case 'q': baseQ = atoi(optarg); break;   // base quality threshold
             case 'Q': mapQ = atoi(optarg); break;    // mapping quality threshold
             case 'f': file_list = optarg; break;
@@ -162,7 +162,7 @@ int main_depth(int argc, char *argv[])
     if (file_list)
     {
         if (has_index_file) {
-            fprintf(stderr,"Error: The -f option cannot be combined with -D\n");
+            fprintf(stderr,"Error: The -f option cannot be combined with -X\n");
             return 1;
         }
         if ( read_file_list(file_list,&nfiles,&fn) ) return 1;

--- a/bam2depth.c
+++ b/bam2depth.c
@@ -74,7 +74,7 @@ int read_file_list(const char *file_list,int *n,char **argv[]);
 
 static int usage() {
     fprintf(stderr, "\n");
-    fprintf(stderr, "Usage: samtools depth [options] in1.bam [in2.bam [...]] [index1 index2 ...]\n");
+    fprintf(stderr, "Usage: samtools depth [options] in1.bam [in2.bam [...]]\n");
     fprintf(stderr, "Options:\n");
     fprintf(stderr, "   -a                  output all positions (including zero depth)\n");
     fprintf(stderr, "   -a -a (or -aa)      output absolutely all positions, including unused ref. sequences\n");

--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -916,7 +916,7 @@ static void print_usage(FILE *fp, const mplp_conf_t *mplp)
 
     fprintf(fp,
 "\n"
-"Usage: samtools mpileup [options] in1.bam [in2.bam [...]] [index1 index2 ...]\n"
+"Usage: samtools mpileup [options] in1.bam [in2.bam [...]]\n"
 "\n"
 "Input options:\n"
 "  -6, --illumina1.3+      quality is in the Illumina-1.3+ encoding\n"

--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -942,7 +942,7 @@ static void print_usage(FILE *fp, const mplp_conf_t *mplp)
 "                                            [%s]\n", tmp_filter);
     fprintf(fp,
 "  -x, --ignore-overlaps   disable read-pair overlap detection\n"
-"  -D, --customized-index  use customized index files\n" // -D flag for index filename
+"  -X, --customized-index  use customized index files\n" // -X flag for index filename
 "\n"
 "Output options:\n"
 "  -o, --output FILE       write output to FILE [standard output]\n"
@@ -1041,11 +1041,11 @@ int bam_mpileup(int argc, char *argv[])
         {"per-sample-mF", no_argument, NULL, 'p'},
         {"per-sample-mf", no_argument, NULL, 'p'},
         {"platforms", required_argument, NULL, 'P'},
-        {"customized-index", no_argument, NULL, 'D'},
+        {"customized-index", no_argument, NULL, 'X'},
         {NULL, 0, NULL, 0}
     };
 
-    while ((c = getopt_long(argc, argv, "Agf:r:l:q:Q:uRC:BDSd:L:b:P:po:e:h:Im:F:EG:6OsVvxt:a",lopts,NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "Agf:r:l:q:Q:uRC:BDSd:L:b:P:po:e:h:Im:F:EG:6OsVvxXt:a",lopts,NULL)) >= 0) {
         switch (c) {
         case 'x': mplp.flag &= ~MPLP_SMART_OVERLAPS; break;
         case  1 :
@@ -1079,7 +1079,8 @@ int bam_mpileup(int argc, char *argv[])
         case 'v': mplp.flag |= MPLP_BCF | MPLP_VCF; deprecated(c); break;
         case 'u': mplp.flag |= MPLP_NO_COMP | MPLP_BCF; deprecated(c); break;
         case 'B': mplp.flag &= ~MPLP_REALN; break;
-        case 'D': has_index_file = 1; break;
+        case 'X': has_index_file = 1; break;
+        case 'D': mplp.fmt_flag |= B2B_FMT_DP; deprecated(c); break;
         case 'S': mplp.fmt_flag |= B2B_FMT_SP; deprecated(c); break;
         case 'V': mplp.fmt_flag |= B2B_FMT_DV; deprecated(c); break;
         case 'I': mplp.flag |= MPLP_NO_INDEL; deprecated(c); break;
@@ -1153,7 +1154,7 @@ int bam_mpileup(int argc, char *argv[])
     int ret;
     if (file_list) {
         if (has_index_file) {
-            fprintf(stderr,"Error: The -b option cannot be combined with -D\n"); // No customize index loc in file list mode
+            fprintf(stderr,"Error: The -b option cannot be combined with -X\n"); // No customize index loc in file list mode
             return 1;
         }
         if ( read_file_list(file_list,&nfiles,&fn) ) return 1;

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -1523,7 +1523,7 @@ static void merge_usage(FILE *to)
 "  -p         Combine @PG headers with colliding IDs [alter IDs to be distinct]\n"
 "  -s VALUE   Override random seed\n"
 "  -b FILE    List of input BAM filenames, one per line [null]\n"
-"  -D         Use customized index files\n");
+"  -X         Use customized index files\n");
     sam_global_opt_help(to, "-.O..@");
 }
 
@@ -1549,7 +1549,7 @@ int bam_merge(int argc, char *argv[])
         return 0;
     }
 
-    while ((c = getopt_long(argc, argv, "h:nru1R:f@:l:cps:b:O:t:D", lopts, NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "h:nru1R:f@:l:cps:b:O:t:X", lopts, NULL)) >= 0) {
         switch (c) {
         case 'r': flag |= MERGE_RG; break;
         case 'f': flag |= MERGE_FORCE; break;
@@ -1563,11 +1563,11 @@ int bam_merge(int argc, char *argv[])
         case 'c': flag |= MERGE_COMBINE_RG; break;
         case 'p': flag |= MERGE_COMBINE_PG; break;
         case 's': random_seed = atol(optarg); break;
-        case 'D': has_index_file = 1; break; // -D flag for index filename
+        case 'X': has_index_file = 1; break; // -X flag for index filename
         case 'b': {
             // load the list of files to read
             if (has_index_file) {
-                fprintf(stderr,"Error: The -b option cannot be combined with -D\n");
+                fprintf(stderr,"Error: The -b option cannot be combined with -X\n");
                 ret = 1; goto end;
             }
             int nfiles;

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -1151,7 +1151,7 @@ int* rtrans_build(int n, int n_targets, trans_tbl_t* translation_tbl)
   function is NOT thread safe.
  */
 int bam_merge_core2(int by_qname, char* sort_tag, const char *out, const char *mode,
-                    const char *headers, int n, char * const *fn, int flag,
+                    const char *headers, int n, char * const *fn, char * const *fn_idx,int flag,
                     const char *reg, int n_threads, const char *cmd,
                     const htsFormat *in_fmt, const htsFormat *out_fmt)
 {
@@ -1316,7 +1316,13 @@ int bam_merge_core2(int by_qname, char* sort_tag, const char *out, const char *m
             goto fail;
         }
         for (i = 0; i < n; ++i) {
-            hts_idx_t *idx = sam_index_load(fp[i], fn[i]);
+            hts_idx_t *idx = NULL;
+            // If index filename has not been specfied, look in BAM folder
+            if (fn_idx != NULL) {
+                idx = sam_index_load2(fp[i], fn[i], fn_idx[i]);
+            } else {
+                idx = sam_index_load(fp[i], fn[i]);
+            }
             // (rtrans[i*n+tid]) Look up what hout tid translates to in input tid space
             int mapped_tid = rtrans[i*hout->n_targets+tid];
             if (idx == NULL) {
@@ -1495,13 +1501,13 @@ int bam_merge_core(int by_qname, const char *out, const char *headers, int n, ch
     strcpy(mode, "wb");
     if (flag & MERGE_UNCOMP) strcat(mode, "0");
     else if (flag & MERGE_LEVEL1) strcat(mode, "1");
-    return bam_merge_core2(by_qname, NULL, out, mode, headers, n, fn, flag, reg, 0, "merge", NULL, NULL);
+    return bam_merge_core2(by_qname, NULL, out, mode, headers, n, fn, NULL, flag, reg, 0, "merge", NULL, NULL);
 }
 
 static void merge_usage(FILE *to)
 {
     fprintf(to,
-"Usage: samtools merge [-nurlf] [-h inh.sam] [-b <bamlist.fofn>] <out.bam> <in1.bam> [<in2.bam> ... <inN.bam>]\n"
+"Usage: samtools merge [-nurlf] [-h inh.sam] [-b <bamlist.fofn>] <out.bam> <in1.bam> [<in2.bam> ... <inN.bam>] [index1 index2 ... indexN]\n"
 "\n"
 "Options:\n"
 "  -n         Input files are sorted by read name\n"
@@ -1516,17 +1522,19 @@ static void merge_usage(FILE *to)
 "  -c         Combine @RG headers with colliding IDs [alter IDs to be distinct]\n"
 "  -p         Combine @PG headers with colliding IDs [alter IDs to be distinct]\n"
 "  -s VALUE   Override random seed\n"
-"  -b FILE    List of input BAM filenames, one per line [null]\n");
+"  -b FILE    List of input BAM filenames, one per line [null]\n"
+"  -D         Use customized index files\n");
     sam_global_opt_help(to, "-.O..@");
 }
 
 int bam_merge(int argc, char *argv[])
 {
-    int c, is_by_qname = 0, flag = 0, ret = 0, level = -1;
+    int c, is_by_qname = 0, flag = 0, ret = 0, level = -1, has_index_file = 0;
     char *fn_headers = NULL, *reg = NULL, mode[12];
     char *sort_tag = NULL;
     long random_seed = (long)time(NULL);
     char** fn = NULL;
+    char** fn_idx = NULL;
     int fn_size = 0;
 
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
@@ -1541,7 +1549,7 @@ int bam_merge(int argc, char *argv[])
         return 0;
     }
 
-    while ((c = getopt_long(argc, argv, "h:nru1R:f@:l:cps:b:O:t:", lopts, NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "h:nru1R:f@:l:cps:b:O:t:D", lopts, NULL)) >= 0) {
         switch (c) {
         case 'r': flag |= MERGE_RG; break;
         case 'f': flag |= MERGE_FORCE; break;
@@ -1555,8 +1563,13 @@ int bam_merge(int argc, char *argv[])
         case 'c': flag |= MERGE_COMBINE_RG; break;
         case 'p': flag |= MERGE_COMBINE_PG; break;
         case 's': random_seed = atol(optarg); break;
+        case 'D': has_index_file = 1; break; // -D flag for index filename
         case 'b': {
             // load the list of files to read
+            if (has_index_file) {
+                fprintf(stderr,"Error: The -b option cannot be combined with -D\n");
+                ret = 1; goto end;
+            }
             int nfiles;
             char **fn_read = hts_readlines(optarg, &nfiles);
             if (fn_read) {
@@ -1595,12 +1608,28 @@ int bam_merge(int argc, char *argv[])
         }
     }
 
-    int nargcfiles = argc - (optind+1);
+    int nargcfiles = 0;
+    if (has_index_file) { // Calculate # of input BAM files
+        if ((argc - optind - 1) % 2 != 0) {
+            fprintf(stderr, "Odd number of filenames detected! Each BAM file should have an index file\n");
+            return 1;
+        }
+        nargcfiles = (argc - optind - 1) / 2;
+    } else {
+        nargcfiles = argc - optind - 1;
+    }
+
     if (nargcfiles > 0) {
         // Add argc files to end of array
         fn = realloc(fn, (fn_size+nargcfiles) * sizeof(char*));
         if (fn == NULL) { ret = 1; goto end; }
         memcpy(fn+fn_size, argv + (optind+1), nargcfiles * sizeof(char*));
+
+        if(has_index_file) {
+            fn_idx = realloc(fn_idx, nargcfiles * sizeof(char*));
+            if (fn_idx == NULL) { ret = 1; goto end; }
+            memcpy(fn_idx+fn_size, argv + nargcfiles + (optind+1), nargcfiles * sizeof(char*));
+        }
     }
     if (fn_size+nargcfiles < 1) {
         print_error("merge", "You must specify at least one (and usually two or more) input files");
@@ -1611,7 +1640,7 @@ int bam_merge(int argc, char *argv[])
     sam_open_mode(mode+1, argv[optind], NULL);
     if (level >= 0) sprintf(strchr(mode, '\0'), "%d", level < 9? level : 9);
     if (bam_merge_core2(is_by_qname, sort_tag, argv[optind], mode, fn_headers,
-                        fn_size+nargcfiles, fn, flag, reg, ga.nthreads,
+                        fn_size+nargcfiles, fn, fn_idx, flag, reg, ga.nthreads,
                         "merge", &ga.in, &ga.out) < 0)
         ret = 1;
 

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -1507,7 +1507,7 @@ int bam_merge_core(int by_qname, const char *out, const char *headers, int n, ch
 static void merge_usage(FILE *to)
 {
     fprintf(to,
-"Usage: samtools merge [-nurlf] [-h inh.sam] [-b <bamlist.fofn>] <out.bam> <in1.bam> [<in2.bam> ... <inN.bam>] [index1 index2 ... indexN]\n"
+"Usage: samtools merge [-nurlf] [-h inh.sam] [-b <bamlist.fofn>] <out.bam> <in1.bam> [<in2.bam> ... <inN.bam>]\n"
 "\n"
 "Options:\n"
 "  -n         Input files are sorted by read name\n"

--- a/bam_tview.c
+++ b/bam_tview.c
@@ -334,7 +334,7 @@ static void error(const char *format, ...)
     if ( !format )
     {
         fprintf(stderr,
-"Usage: samtools tview [options] <aln.bam> [aln.bai] [ref.fasta]\n"
+"Usage: samtools tview [options] <aln.bam> [ref.fasta]\n"
 "Options:\n"
 "   -d display      output as (H)tml or (C)urses or (T)ext \n"
 "   -X              include customized index file\n"

--- a/bam_tview.c
+++ b/bam_tview.c
@@ -337,7 +337,7 @@ static void error(const char *format, ...)
 "Usage: samtools tview [options] <aln.bam> [ref.fasta]\n"
 "Options:\n"
 "   -d display      output as (H)tml or (C)urses or (T)ext \n"
-"   -D FILE         include customized index file\n"
+"   -X FILE         include customized index file\n"
 "   -p chr:pos      go directly to this position\n"
 "   -s STR          display only reads from this sample or group\n");
         sam_global_opt_help(stderr, "-.--.-");
@@ -373,11 +373,11 @@ int bam_tview_main(int argc, char *argv[])
         { NULL, 0, NULL, 0 }
     };
 
-    while ((c = getopt_long(argc, argv, "s:p:d:D:", lopts, NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "s:p:d:X:", lopts, NULL)) >= 0) {
         switch (c) {
             case 's': samples=optarg; break;
             case 'p': position=optarg; break;
-            case 'D': fn_idx=optarg; break; // -D flag for index filename
+            case 'X': fn_idx=optarg; break; // -X flag for index filename
             case 'd':
             {
                 switch(optarg[0])

--- a/bam_tview.h
+++ b/bam_tview.h
@@ -90,7 +90,8 @@ char bam_aux_getCQi(bam1_t *b, int i);
 #define TV_BASE_COLOR_SPACE 1
 
 int tv_pl_func(uint32_t tid, uint32_t pos, int n, const bam_pileup1_t *pl, void *data);
-int base_tv_init(tview_t*,const char *fn, const char *fn_fa,
+// Added fn_idx to arguments as index file
+int base_tv_init(tview_t*,const char *fn, const char *fn_fa, const char *fn_idx,
                  const char *samples, const htsFormat *fmt);
 void base_tv_destroy(tview_t*);
 int base_draw_aln(tview_t *tv, int tid, int pos);

--- a/bam_tview_curses.c
+++ b/bam_tview_curses.c
@@ -317,7 +317,7 @@ tview_t* curses_tv_init(const char *fn, const char *fn_fa, const char *samples,
         return 0;
         }
 
-    base_tv_init(base,fn,fn_fa,samples,fmt);
+    base_tv_init(base,fn,fn_fa,NULL,samples,fmt);
     /* initialize callbacks */
 #define SET_CALLBACK(fun) base->my_##fun=curses_##fun;
     SET_CALLBACK(destroy);
@@ -355,7 +355,7 @@ extern tview_t* text_tv_init(const char *fn, const char *fn_fa, const char *samp
 tview_t* curses_tv_init(const char *fn, const char *fn_fa, const char *samples,
                         const htsFormat *fmt)
     {
-    return text_tv_init(fn,fn_fa,samples,fmt);
+    return text_tv_init(fn,fn_fa,NULL,samples,fmt);
     }
 
 #endif

--- a/bam_tview_html.c
+++ b/bam_tview_html.c
@@ -314,7 +314,7 @@ static void init_pair(html_tview_t *tv,int id_ge_1, const char* pen, const char*
     }
 */
 
-tview_t* html_tv_init(const char *fn, const char *fn_fa, const char *samples,
+tview_t* html_tv_init(const char *fn, const char *fn_fa, const char *fn_idx, const char *samples,
                       const htsFormat *fmt)
     {
     char* colstr=getenv("COLUMNS");
@@ -329,7 +329,7 @@ tview_t* html_tv_init(const char *fn, const char *fn_fa, const char *samples,
     tv->screen=NULL;
     tv->out=stdout;
     tv->attributes=0;
-    base_tv_init(base,fn,fn_fa,samples,fmt);
+    base_tv_init(base,fn,fn_fa,fn_idx,samples,fmt);
     /* initialize callbacks */
 #define SET_CALLBACK(fun) base->my_##fun=html_##fun;
     SET_CALLBACK(destroy);
@@ -367,10 +367,10 @@ tview_t* html_tv_init(const char *fn, const char *fn_fa, const char *samples,
     }
 
 
-tview_t* text_tv_init(const char *fn, const char *fn_fa, const char *samples,
+tview_t* text_tv_init(const char *fn, const char *fn_fa, const char *fn_idx, const char *samples,
                       const htsFormat *fmt)
     {
-    tview_t* tv=html_tv_init(fn,fn_fa,samples,fmt);
+    tview_t* tv=html_tv_init(fn,fn_fa,fn_idx,samples,fmt);
     tv->my_drawaln=text_drawaln;
     return tv;
     }

--- a/bedcov.c
+++ b/bedcov.c
@@ -79,10 +79,10 @@ int main_bedcov(int argc, char *argv[])
         { NULL, 0, NULL, 0 }
     };
 
-    while ((c = getopt_long(argc, argv, "Q:Dj", lopts, NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "Q:Xj", lopts, NULL)) >= 0) {
         switch (c) {
         case 'Q': min_mapQ = atoi(optarg); break;
-        case 'D': has_index_file = 1; break;
+        case 'X': has_index_file = 1; break;
         case 'j': skip_DN = 1; break;
         default:  if (parse_sam_global_opt(c, optarg, lopts, &ga) == 0) break;
                   /* else fall-through */
@@ -94,7 +94,7 @@ int main_bedcov(int argc, char *argv[])
         fprintf(stderr, "Usage: samtools bedcov [options] <in.bed> <in1.bam> [...] [index1 index2 ...]\n\n");
         fprintf(stderr, "Options:\n");
         fprintf(stderr, "      -Q <int>            mapping quality threshold [0]\n");
-        fprintf(stderr, "      -D                  use customized index files\n");
+        fprintf(stderr, "      -X                  use customized index files\n");
         fprintf(stderr, "      -j                  do not include deletions (D) and ref skips (N) in bedcov computation\n");
         sam_global_opt_help(stderr, "-.--.-");
         return 1;

--- a/bedcov.c
+++ b/bedcov.c
@@ -91,7 +91,7 @@ int main_bedcov(int argc, char *argv[])
         if (usage) break;
     }
     if (usage || optind + 2 > argc) {
-        fprintf(stderr, "Usage: samtools bedcov [options] <in.bed> <in1.bam> [...] [index1 index2 ...]\n\n");
+        fprintf(stderr, "Usage: samtools bedcov [options] <in.bed> <in1.bam> [...]\n\n");
         fprintf(stderr, "Options:\n");
         fprintf(stderr, "      -Q <int>            mapping quality threshold [0]\n");
         fprintf(stderr, "      -X                  use customized index files\n");

--- a/bedcov.c
+++ b/bedcov.c
@@ -71,7 +71,7 @@ int main_bedcov(int argc, char *argv[])
     int *n_plp, dret, i, j, m, n, c, min_mapQ = 0, skip_DN = 0;
     int64_t *cnt;
     const bam_pileup1_t **plp;
-    int usage = 0;
+    int usage = 0, has_index_file = 0;
 
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
     static const struct option lopts[] = {
@@ -79,9 +79,10 @@ int main_bedcov(int argc, char *argv[])
         { NULL, 0, NULL, 0 }
     };
 
-    while ((c = getopt_long(argc, argv, "Q:j", lopts, NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "Q:Dj", lopts, NULL)) >= 0) {
         switch (c) {
         case 'Q': min_mapQ = atoi(optarg); break;
+        case 'D': has_index_file = 1; break;
         case 'j': skip_DN = 1; break;
         default:  if (parse_sam_global_opt(c, optarg, lopts, &ga) == 0) break;
                   /* else fall-through */
@@ -90,23 +91,39 @@ int main_bedcov(int argc, char *argv[])
         if (usage) break;
     }
     if (usage || optind + 2 > argc) {
-        fprintf(stderr, "Usage: samtools bedcov [options] <in.bed> <in1.bam> [...]\n\n");
+        fprintf(stderr, "Usage: samtools bedcov [options] <in.bed> <in1.bam> [...] [index1 index2 ...]\n\n");
         fprintf(stderr, "Options:\n");
         fprintf(stderr, "      -Q <int>            mapping quality threshold [0]\n");
+        fprintf(stderr, "      -D                  use customized index files\n");
         fprintf(stderr, "      -j                  do not include deletions (D) and ref skips (N) in bedcov computation\n");
         sam_global_opt_help(stderr, "-.--.-");
         return 1;
     }
+    if (has_index_file) {
+        if ((argc - optind - 1) % 2 != 0) { // Calculate # of input BAM files
+            fprintf(stderr, "ERROR: odd number of filenames detected! Each BAM file should have an index file\n");
+            return 1;
+        }
+        n = (argc - optind - 1) / 2;
+    } else {
+        n = argc - optind - 1;
+    }
+
     memset(&str, 0, sizeof(kstring_t));
-    n = argc - optind - 1;
     aux = calloc(n, sizeof(aux_t*));
     idx = calloc(n, sizeof(hts_idx_t*));
     for (i = 0; i < n; ++i) {
         aux[i] = calloc(1, sizeof(aux_t));
         aux[i]->min_mapQ = min_mapQ;
         aux[i]->fp = sam_open_format(argv[i+optind+1], "r", &ga.in);
-        if (aux[i]->fp)
-            idx[i] = sam_index_load(aux[i]->fp, argv[i+optind+1]);
+        if (aux[i]->fp) {
+            // If index filename has not been specfied, look in BAM folder
+            if (has_index_file) {
+                idx[i] = sam_index_load2(aux[i]->fp, argv[i+optind+1], argv[i+optind+n+1]);
+            } else {
+                idx[i] = sam_index_load(aux[i]->fp, argv[i+optind+1]);
+            }
+        }   
         if (aux[i]->fp == 0 || idx[i] == 0) {
             fprintf(stderr, "ERROR: fail to open index BAM file '%s'\n", argv[i+optind+1]);
             return 2;

--- a/doc/samtools-bedcov.1
+++ b/doc/samtools-bedcov.1
@@ -62,6 +62,10 @@ Counts for each alignment file supplied are reported in separate columns.
 .TP
 .B  -j
 Do not include deletions (D) and ref skips (N) in bedcov computation.
+.TP
+.B "-X"
+If this option is set, it will allows user to specify customized index file location(s) if the data 
+folder does not contain any index file. Example usage: samtools bedcov [options] -X <in.bed> </data_folder/in1.bam> [...] </index_folder/index1.bai> [...]
 
 .SH AUTHOR
 .PP

--- a/doc/samtools-depth.1
+++ b/doc/samtools-depth.1
@@ -108,6 +108,10 @@ will send the output to stdout (also the default if this option is not used).
 .TP
 .BI "-r " CHR ":" FROM "-" TO
 Only report depth in specified region.
+.TP
+.B "-X"
+If this option is set, it will allows user to specify customized index file location(s) if the data 
+folder does not contain any index file. Example usage: samtools depth [options] -X /data_folder/in1.bam [/data_folder/in2.bam [...]] /index_folder/index1.bai [/index_folder/index2.bai [...]]
 
 .SH AUTHOR
 .PP

--- a/doc/samtools-merge.1
+++ b/doc/samtools-merge.1
@@ -135,6 +135,12 @@ suffixes added to their IDs where necessary to differentiate them.
 Similarly, for each @PG ID in the set of files to merge, use the @PG line
 of the first file we find that ID in rather than adding a suffix to
 differentiate similar IDs.
+.TP
+.B -X
+If this option is set, it will allows user to specify customized index file location(s) if the data 
+folder does not contain any index file. See 
+.B EXAMPLES 
+section for sample of useage.
 
 .SH EXAMPLES
 .IP o 2
@@ -158,6 +164,12 @@ while reads from
 .I 454.bam
 will be attached
 .IR RG:Z:454 .
+
+.IP o 2
+Include customized index file as a part of arugments:
+.EX 2
+samtools merge [options] -X <out.bam> </data_folder/in1.bam> [</data_folder/in2.bam> ... </data_folder/inN.bam>] </index_folder/index1.bai> [</index_folder/index2.bai> ... </index_folder/indexN.bai>]
+.EE
 
 .SH AUTHOR
 .PP

--- a/doc/samtools-mpileup.1
+++ b/doc/samtools-mpileup.1
@@ -199,6 +199,12 @@ Filter flags: skip reads with mask bits set
 .TP
 .B -x,\ --ignore-overlaps
 Disable read-pair overlap detection.
+.TP
+.B -X
+Include customized index file as a part of arugments. See 
+.B EXAMPLES 
+section for sample of useage.
+
 .PP
 .B Output Options:
 .TP 10
@@ -302,6 +308,11 @@ technology may affect the performance of indel calling.
 Generate the consensus sequence for one diploid individual:
 .EX 2
 samtools mpileup -uf ref.fa aln.bam | bcftools call -c | vcfutils.pl vcf2fq > cns.fq
+.EE
+.IP o 2
+Include customized index file as a part of arugments.
+.EX 2
+samtools mpileup [options] -X /data_folder/in1.bam [/data_folder/in2.bam [...]] /index_folder/index1.bai [/index_folder/index2.bai [...]]
 .EE
 .IP o 2
 Phase one individual:

--- a/doc/samtools-stats.1
+++ b/doc/samtools-stats.1
@@ -438,6 +438,11 @@ Remove overlaps of paired-end reads from coverage and base count computations.
 .TP
 .BI "-g, --cov-threshold " INT
 Only bases with coverage above this value will be included in the target percentage computation [0]
+.TP
+.B "-X"
+If this option is set, it will allows user to specify customized index file location(s) if the data 
+folder does not contain any index file. 
+Example usage: samtools stats [options] -X /data_folder/data.bam /index_folder/data.bai chrM:1-10
 .RE
 
 .SH AUTHOR

--- a/doc/samtools-tview.1
+++ b/doc/samtools-tview.1
@@ -72,6 +72,10 @@ Go directly to this position
 .TP
 .BI -s \ STR
 Display only alignments from this sample or read group
+.TP
+.B -X
+If this option is set, it will allows user to specify customized index file location(s) if the data 
+folder does not contain any index file. Example usage: samtools tview [options] -X </data_folder/data.bam> [/index_folder/index.bai] [ref.fasta]
 
 .SH AUTHOR
 .PP

--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -383,7 +383,7 @@ samtools view --input-fmt cram,decode_md=0 -o aln.new.bam aln.cram
 .IP o 2
 Include customized index file as a part of arugments.
 .EX 2
-samtools view [options] -X data_folder/data.bam index_folder/data.bai chrM:1-10
+samtools view [options] -X /data_folder/data.bam /index_folder/data.bai chrM:1-10
 .EE
 
 .SH AUTHOR

--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -106,6 +106,13 @@ and
 .B -B
 options modify the data which is contained in each alignment.
 
+The
+.B -X
+option can be used to allow user to specify customized index file location(s) if the data 
+folder does not contain any index file. See 
+.B EXAMPLES 
+section for sample of useage.
+
 Finally, the
 .B -@
 option can be used to allocate additional threads to be used for compression, and the
@@ -318,6 +325,11 @@ Ignored for compatibility with previous samtools versions.
 Previously this option was required if input was in SAM format, but now the
 correct format is automatically detected by examining the first few characters
 of input.
+.TP
+.B -X
+Include customized index file as a part of arugments. See 
+.B EXAMPLES 
+section for sample of useage.
 
 .SH EXAMPLES
 .IP o 2
@@ -366,6 +378,12 @@ are equivalent to the two above.
 .EX 2
 samtools view -O cram,store_md=1,store_nm=1 -o aln.cram aln.bam
 samtools view --input-fmt cram,decode_md=0 -o aln.new.bam aln.cram
+.EE
+
+.IP o 2
+Include customized index file as a part of arugments.
+.EX 2
+samtools view [options] -X data_folder/data.bam index_folder/data.bai chrM:1-10
 .EE
 
 .SH AUTHOR

--- a/sam.h
+++ b/sam.h
@@ -103,14 +103,20 @@ extern "C" {
     static inline int samwrite(samfile_t *fp, const bam1_t *b) { return sam_write1(fp->file, fp->header, b); }
 
     /*!
-      @abstract     Load BAM/CRAM index for use with samfetch()
+      @abstract     Load BAM/CRAM index for use with samfetch() with supporting the use of index file
       @param  fp    file handler
       @param  fn    name of the BAM or CRAM file (NOT the index file)
+      @param  fnidx name of the index file
       @return       pointer to the index structure
      */
-    static inline bam_index_t *samtools_sam_index_load(samfile_t *fp, const char *fn) { return sam_index_load(fp->file, fn); }
+    static inline bam_index_t *samtools_sam_index_load(samfile_t *fp, const char *fn, const char *fnidx) {
+      if (fnidx != NULL) {
+        return sam_index_load2(fp->file, fn, fnidx);
+      }
+      return sam_index_load(fp->file, fn); 
+    }
     #undef sam_index_load
-    #define sam_index_load(fp,fn) (samtools_sam_index_load((fp), (fn)))
+    #define sam_index_load(fp,fn,fnidx) (samtools_sam_index_load((fp), (fn), (fnidx)))
 
     /*!
       @abstract Retrieve the alignments overlapping the specified region.

--- a/sam_view.c
+++ b/sam_view.c
@@ -682,7 +682,7 @@ static int usage(FILE *fp, int exit_status, int is_long_help)
 {
     fprintf(fp,
 "\n"
-"Usage: samtools view [options] <in.bam>|<in.sam>|<in.cram> [index.bai] [region ...]\n"
+"Usage: samtools view [options] <in.bam>|<in.sam>|<in.cram> [region ...]\n"
 "\n"
 "Options:\n"
 // output options

--- a/sam_view.c
+++ b/sam_view.c
@@ -507,7 +507,6 @@ int main_samview(int argc, char *argv[])
     if (is_header_only) goto view_end; // no need to print alignments
 
     if (has_index_file) {
-        printf("%d %d\n", optind, argc);
         fn_idx_in = (optind+1 < argc)? argv[optind+1] : 0;
         if (fn_idx_in == 0) {
             fprintf(stderr, "[main_samview] incorrect number of arguments for -X option. Aborting.\n");
@@ -520,8 +519,12 @@ int main_samview(int argc, char *argv[])
     }
 
     if (settings.multi_region) {
-        if ((has_index_file && optind < argc - 2) || (!has_index_file && optind < argc - 1)) { //regions have been specified in the command line
+        if (!has_index_file && optind < argc - 1) { //regions have been specified in the command line
             settings.bed = bed_hash_regions(settings.bed, argv, optind+1, argc, &filter_op); //insert(1) or filter out(0) the regions from the command line in the same hash table as the bed file
+            if (!filter_op)
+                filter_state = FILTERED;
+        } else if (has_index_file && optind < argc - 2) {
+            settings.bed = bed_hash_regions(settings.bed, argv, optind+2, argc, &filter_op); //insert(1) or filter out(0) the regions from the command line in the same hash table as the bed file
             if (!filter_op)
                 filter_state = FILTERED;
         } else {

--- a/sam_view.c
+++ b/sam_view.c
@@ -288,7 +288,7 @@ int main_samview(int argc, char *argv[])
     opterr = 0;
 
     while ((c = getopt_long(argc, argv,
-                            "SbBcCt:h1Ho:O:q:f:F:G:ul:r:T:R:L:s:@:m:x:U:MD:",
+                            "SbBcCt:h1Ho:O:q:f:F:G:ul:r:T:R:L:s:@:m:x:U:MX:",
                             lopts, NULL)) >= 0) {
         switch (c) {
         case 's':
@@ -321,7 +321,7 @@ int main_samview(int argc, char *argv[])
         case 'H': is_header_only = 1; break;
         case 'o': fn_out = strdup(optarg); break;
         case 'U': fn_un_out = strdup(optarg); break;
-        case 'D': fn_idx_in = strdup(optarg); break;
+        case 'X': fn_idx_in = strdup(optarg); break;
         case 'f': settings.flag_on |= strtol(optarg, 0, 0); break;
         case 'F': settings.flag_off |= strtol(optarg, 0, 0); break;
         case 'G': settings.flag_alloff |= strtol(optarg, 0, 0); break;
@@ -680,7 +680,7 @@ static int usage(FILE *fp, int exit_status, int is_long_help)
 "  -U FILE  output reads not selected by filters to FILE [null]\n"
 // extra input
 "  -t FILE  FILE listing reference names and lengths (see long help) [null]\n"
-"  -D FILE  include customized index file\n"
+"  -X FILE  include customized index file\n"
 // read filters
 "  -L FILE  only include reads overlapping this BED FILE [null]\n"
 "  -r STR   only include reads in read group STR [null]\n"

--- a/stats.c
+++ b/stats.c
@@ -1999,7 +1999,6 @@ static void error(const char *format, ...)
         printf("About: The program collects statistics from BAM files. The output can be visualized using plot-bamstats.\n");
         printf("Usage: samtools stats [OPTIONS] file.bam\n");
         printf("       samtools stats [OPTIONS] file.bam chr:from-to\n");
-        printf("       samtools stats -X [OPTIONS] file.bam [index.bai] [chr:from-to] (if the -X option has been set)\n");
         printf("Options:\n");
         printf("    -c, --coverage <int>,<int>,<int>    Coverage distribution min,max,step [1,1000,1]\n");
         printf("    -d, --remove-dups                   Exclude from statistics reads marked as duplicates\n");

--- a/stats.c
+++ b/stats.c
@@ -2002,7 +2002,7 @@ static void error(const char *format, ...)
         printf("Options:\n");
         printf("    -c, --coverage <int>,<int>,<int>    Coverage distribution min,max,step [1,1000,1]\n");
         printf("    -d, --remove-dups                   Exclude from statistics reads marked as duplicates\n");
-        printf("    -D, --customized-index-file <file>  Use a customized index file\n");
+        printf("    -X, --customized-index-file <file>  Use a customized index file\n");
         printf("    -f, --required-flag  <str|int>      Required flag, 0 for unset. See also `samtools flags` [0]\n");
         printf("    -F, --filtering-flag <str|int>      Filtering flag, 0 for unset. See also `samtools flags` [0]\n");
         printf("        --GC-depth <float>              the size of GC-depth bins (decreasing bin size increases memory requirement) [2e4]\n");
@@ -2272,7 +2272,7 @@ int main_stats(int argc, char *argv[])
         {"help", no_argument, NULL, 'h'},
         {"remove-dups", no_argument, NULL, 'd'},
         {"sam", no_argument, NULL, 's'},
-        {"customized-index-file", required_argument, NULL, 'D'},
+        {"customized-index-file", required_argument, NULL, 'X'},
         {"ref-seq", required_argument, NULL, 'r'},
         {"coverage", required_argument, NULL, 'c'},
         {"read-length", required_argument, NULL, 'l'},
@@ -2293,14 +2293,14 @@ int main_stats(int argc, char *argv[])
     };
     int opt;
 
-    while ( (opt=getopt_long(argc,argv,"?hdsD:xpr:c:l:i:t:m:q:f:F:g:I:S:P:@:",loptions,NULL))>0 )
+    while ( (opt=getopt_long(argc,argv,"?hdsX:xpr:c:l:i:t:m:q:f:F:g:I:S:P:@:",loptions,NULL))>0 )
     {
         switch (opt)
         {
             case 'f': info->flag_require = bam_str2flag(optarg); break;
             case 'F': info->flag_filter |= bam_str2flag(optarg); break;
             case 'd': info->flag_filter |= BAM_FDUP; break;
-            case 'D': bam_idx_fname = optarg; break;
+            case 'X': bam_idx_fname = optarg; break;
             case 's': break;
             case 'r': info->fai = fai_load(optarg);
                       if (info->fai==NULL)

--- a/stats.c
+++ b/stats.c
@@ -2363,17 +2363,14 @@ int main_stats(int argc, char *argv[])
     if ( optind<argc )
     {
         int filter = 1;
-        printf("%d, %d\n", optind, argc);
         // Prepare the region hash table for the multi-region iterator
         void *region_hash = NULL;
         if (!has_index_file) {
-            printf("%d, %d\n", optind, argc);
             region_hash = bed_hash_regions(NULL, argv, optind, argc, &filter);
         } else if (has_index_file) {
             if (optind < argc - 1){
             region_hash = bed_hash_regions(NULL, argv, optind+1, argc, &filter);
             } else {
-                printf("%d, %d\n", optind, argc);
                 if (strstr(argv[optind], ".bai") != NULL) {
                 fprintf(stderr, "If no region number(s) specified, no need to supply index file.\n");
                 goto whole_file;


### PR DESCRIPTION
The samtools has be configured with the ability to take index files at customized locations using -X flag.

Affected samtools functionalities:

- view
- stats
- bedcov
- depth
- merge/sort
- tview
- mpileup

sample usage: 
`samtools view -X in1.bam index1.bai chrM:1-1000 `
or
`samtools mpileup -X in1.bam [in2.bam [...]] index1.bai [index2.bai [...]]` 