### PR TITLE
Reheader external

### DIFF
--- a/doc/samtools-reheader.1
+++ b/doc/samtools-reheader.1
@@ -45,7 +45,10 @@ samtools reheader \- replaces the header in the input file
 .PP
 samtools reheader
 .RB [ -iP ]
-.I in.header.sam in.bam
+[-c CMD | 
+.I in.header.sam
+] 
+.I in.bam
 
 .SH DESCRIPTION
 .PP
@@ -71,6 +74,18 @@ Do not generate an @PG header line.
 Perform the header edit in-place, if possible.  This only works on CRAM
 files and only if there is sufficient room to store the new header.
 The amount of space available will differ for each CRAM file.
+.TP 8
+.B -c, --command CMD
+Allow the header from 
+.I in.bam
+to be processed by external 
+.B CMD
+and read back the result. When used in this manner, the external header file
+.I in.header.sam
+has to be omitted.
+.B CMD
+must take the original header through stdin in SAM format and output the
+modified header to stdout.
 
 .SH AUTHOR
 .PP

--- a/doc/samtools-reheader.1
+++ b/doc/samtools-reheader.1
@@ -83,14 +83,41 @@ to be processed by external
 and read back the result. When used in this manner, the external header file
 .I in.header.sam
 has to be omitted.
+
 .B CMD
 must take the original header through stdin in SAM format and output the
 modified header to stdout.
+.B CMD
+is passed to the system's command shell.
+Care should be taken to ensure the command is quoted correctly to avoid unwanted
+shell expansions (for example of $ variables).
+
+.B CMD
+must return an exit status of zero.
+
+.SH EXAMPLES
+
+.IP \(bu 2
+Remove comment lines
+.EX 2
+samtools reheader -c 'grep -v ^@CO' in.bam
+.EE
+.IP \(bu 2
+Add \(lqChr\(rq prefix to chromosome names.  Note extra backslashes before
+dollar signs to prevent unwanted shell variable expansion.
+.EX 2
+samtools reheader -c 'perl -pe "s/^(@SQ.*)(\(rstSN:)(\(rsd+|X|Y|MT)(\(rss|\(rs$)/\(rs$1Chr\(rs$2\(rs$3/"' in.bam
+.EE
+.IP \(bu 2
+Remove \(lqChr\(rq prefix
+.EX 2
+samtools reheader -c 'perl -pe "s/^(@SQ.*)(\(rstSN:)Chr/\(rs$1\(rs$2/"' in.bam
+.EE
 
 .SH AUTHOR
 .PP
-Written by Heng Li with modifications by James Bonfield, both from the
-Sanger Institute.
+Written by Heng Li with modifications by James Bonfield and Valeriu Ohan,
+all from the Sanger Institute.
 
 .SH SEE ALSO
 .IR samtools (1)

--- a/test/reheader/4_view1.sam.expected
+++ b/test/reheader/4_view1.sam.expected
@@ -1,0 +1,64 @@
+@HD
+@RG	ID:grp1	DS:Group 1	LB:Library 1	SM:Sample
+@RG	ID:grp2	DS:Group 2	LB:Library 2	SM:Sample
+@RG	ID:grp3	DS:Group 3	SM:Sample
+@PG	ID:prog1	PN:emacs	CL:emacs
+@CO	The MIT License
+@CO	
+@CO	Copyright (c) 2019 Genome Research Ltd.
+@CO	
+@CO	Permission is hereby granted, free of charge, to any person obtaining a copy
+@CO	of this software and associated documentation files (the "Software"), to deal
+@CO	in the Software without restriction, including without limitation the rights
+@CO	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+@CO	copies of the Software, and to permit persons to whom the Software is
+@CO	furnished to do so, subject to the following conditions:
+@CO	
+@CO	The above copyright notice and this permission notice shall be included in
+@CO	all copies or substantial portions of the Software.
+@CO	
+@CO	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+@CO	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+@CO	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+@CO	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+@CO	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+@CO	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+@CO	THE SOFTWARE.
+@SQ	SN:ref1	LN:56	M5:08c04d512d4797d9ba2a156c1daba468
+@SQ	SN:ref2	LN:60	M5:7c35feac7036c1cdef3bee0cc4b21437
+@SQ	SN:ref3_unused	LN:70	M5:5fdd18c2c6ecac4838996d029bf395b5
+@PG	ID:samtools	PN:samtools	PP:prog1
+ref1_grp1_p001	99	ref1	1	0	10M	=	25	34	CGAGCTCGGT	!!!!!!!!!!	RG:Z:grp1	BC:Z:ACGT	H0:i:1	aa:A:!	ab:A:~	fa:f:3.14159	za:Z:Hello world!	ha:H:DEADBEEF	ba:B:c,-128,0,127	bb:B:C,0,127,255	bc:B:s,-32768,0,32767	bd:B:S,0,32768,65535	be:B:i,-2147483648,0,2147483647	bf:B:I,0,2147483648,4294967295	bg:B:f,2.71828,6.626e-34,2.9979e+09	NM:i:0	MD:Z:10
+ref1_grp2_p001	99	ref1	3	1	10M	=	27	34	AGCTCGGTAC	""""""""""	RG:Z:grp2	BC:Z:TGCA	H0:i:1	aa:A:A	ab:A:Z	fa:f:6.67e-11	za:Z:!"$%^&*()	ha:H:CAFE	NM:i:0	MD:Z:10
+ref1_grp1_p002	99	ref1	5	2	10M	=	29	34	CTCGGTACCC	##########	RG:Z:grp1	BC:Z:AATTCCGG	H0:i:1	aa:A:a	ab:A:z	fa:f:4.3597e-18	za:Z:Another string	ha:H:2000AD	NM:i:0	MD:Z:10
+ref1_grp2_p002	99	ref1	7	3	10M	=	31	34	CGGTACCCGG	$$$$$$$$$$	fa:f:6.022e+23	RG:Z:grp2	NM:i:0	MD:Z:10
+ref1_grp1_p003	99	ref1	9	4	10M	=	33	34	GTACCCGGGG	%%%%%%%%%%	fa:f:1.66e-27	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp2_p003	99	ref1	11	5	10M	=	35	34	ACCCGGGGAT	&&&&&&&&&&	RG:Z:grp2	ia:i:4294967295	NM:i:0	MD:Z:10
+ref1_grp1_p004	99	ref1	13	6	10M	=	37	34	CCGGGGATCC	''''''''''	fa:f:1.38e-23	za:Z:xRG:Z:grp2	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp2_p004	99	ref1	15	7	10M	=	39	34	GGGGATCCTC	((((((((((	RG:Z:grp2	ia:i:-2147483648	NM:i:0	MD:Z:10
+ref1_grp1_p005	99	ref1	17	8	10M	=	41	34	GGATCCTCTA	))))))))))	RG:Z:grp1	ia:i:40000	NM:i:0	MD:Z:10
+ref1_grp2_p005	99	ref1	19	9	10M	=	43	34	ATCCTCTAGA	**********	RG:Z:grp2	ia:i:-1000	NM:i:0	MD:Z:10
+ref1_grp1_p006	99	ref1	21	10	10M	=	45	34	CCTCTAGAGT	++++++++++	RG:Z:grp1	ia:i:255	NM:i:0	MD:Z:10
+ref1_grp2_p006	99	ref1	23	11	10M	=	47	34	TCTAGAGTCG	,,,,,,,,,,	RG:Z:grp2	ia:i:-1	NM:i:0	MD:Z:10
+ref1_grp1_p001	147	ref1	25	12	10M	=	1	-34	TAGAGTCGAC	----------	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp2_p001	147	ref1	27	13	10M	=	3	-34	GAGTCGACCT	..........	RG:Z:grp2	NM:i:0	MD:Z:10
+ref1_grp1_p002	147	ref1	29	14	10M	=	5	-34	GTCGACCTGC	//////////	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp2_p002	147	ref1	31	15	10M	=	7	-34	CGACCTGCAG	0000000000	RG:Z:grp2	NM:i:0	MD:Z:10
+ref1_grp1_p003	147	ref1	33	16	10M	=	9	-34	ACCTGCAGGC	1111111111	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp2_p003	147	ref1	35	17	10M	=	11	-34	CTGCAGGCAT	2222222222	RG:Z:grp2	NM:i:0	MD:Z:10
+ref12_grp1_p001	97	ref1	36	50	10M	ref2	2	0	TGCAGGCATG	AAAAAAAAAA	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp1_p004	147	ref1	37	18	10M	=	13	-34	GCAGGCATGC	3333333333	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp2_p004	147	ref1	39	19	10M	=	15	-34	AGGCATGCAA	4444444444	RG:Z:grp2	NM:i:0	MD:Z:10
+ref1_grp1_p005	147	ref1	41	20	10M	=	17	-34	GCATGCAAGC	5555555555	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp2_p005	147	ref1	43	21	10M	=	19	-34	ATGCAAGCTT	6666666666	RG:Z:grp2	NM:i:0	MD:Z:10
+ref1_grp1_p006	147	ref1	45	22	10M	=	21	-34	GCAAGCTTGA	7777777777	RG:Z:grp1	NM:i:0	MD:Z:10
+ref12_grp2_p001	97	ref1	46	50	10M	ref2	12	0	CAAGCTTGAG	AAAAAAAAAA	RG:Z:grp2	NM:i:0	MD:Z:10
+ref1_grp2_p006	147	ref1	47	23	10M	=	23	-34	AAGCTTGAGT	8888888888	RG:Z:grp2	NM:i:0	MD:Z:10
+ref2_grp3_p001	83	ref2	1	99	15M	=	31	45	ATTCTATAGTGTCAC	~~~~~~~~~~~~~~~	RG:Z:grp3	NM:i:0	MD:Z:15
+ref12_grp1_p001	145	ref2	2	50	10M	ref1	36	0	TTCTATAGTG	BBBBBBBBBB	RG:Z:grp1	NM:i:0	MD:Z:10
+ref12_grp2_p001	145	ref2	12	50	10M	ref1	46	0	TCACCTAAAT	BBBBBBBBBB	RG:Z:grp2	NM:i:0	MD:Z:10
+ref2_grp3_p002	147	ref2	16	99	15M	=	46	45	CTAAATAGCTTGGCG	}}}}}}}}}}}}}}}	RG:Z:grp3	NM:i:0	MD:Z:15
+ref2_grp3_p001	163	ref2	31	99	15M	=	1	-45	CTGTTTCCTGTGTGA	|||||||||||||||	RG:Z:grp3	NM:i:13	MD:Z:0T0A0A1C0A0T0G0G0T0C0A1A0G0
+ref2_grp3_p002	99	ref2	46	99	15M	=	16	-45	CTGTTTCCTGTGTGA	{{{{{{{{{{{{{{{	RG:Z:grp3	NM:i:0	MD:Z:15
+unaligned_grp3_p001	77	*	0	0	*	*	0	0	CACTCGTTCATGACG	0123456789abcde	RG:Z:grp3
+unaligned_grp3_p001	141	*	0	0	*	*	0	0	GAAAGTGAGGAGGTG	edcba9876543210	RG:Z:grp3

--- a/test/reheader/5_view1.sam.expected
+++ b/test/reheader/5_view1.sam.expected
@@ -1,0 +1,64 @@
+@HD
+@RG	ID:grp1	DS:Group_1	LB:Library_1	SM:Sample
+@RG	ID:grp2	DS:Group_2	LB:Library_2	SM:Sample
+@RG	ID:grp3	DS:Group_3	LB:Library_3	SM:Sample
+@SQ	SN:ref1	LN:56	M5:08c04d512d4797d9ba2a156c1daba468
+@SQ	SN:ref2	LN:60	M5:7c35feac7036c1cdef3bee0cc4b21437
+@CO	The MIT License
+@CO	
+@CO	Copyright (c) 2019 Genome Research Ltd.
+@CO	
+@CO	Permission is hereby granted, free of charge, to any person obtaining a copy
+@CO	of this software and associated documentation files (the "Software"), to deal
+@CO	in the Software without restriction, including without limitation the rights
+@CO	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+@CO	copies of the Software, and to permit persons to whom the Software is
+@CO	furnished to do so, subject to the following conditions:
+@CO	
+@CO	The above copyright notice and this permission notice shall be included in
+@CO	all copies or substantial portions of the Software.
+@CO	
+@CO	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+@CO	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+@CO	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+@CO	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+@CO	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+@CO	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+@CO	THE SOFTWARE.
+@PG	ID:prog1	PN:emacs	CL:emacs
+@PG	ID:samtools	PN:samtools	PP:prog1
+@PG	ID:samtools.1	PN:samtools	PP:samtools
+ref1_grp1_p001	99	ref1	1	0	10M	=	25	34	CGAGCTCGGT	!!!!!!!!!!	BC:Z:ACGT	H0:i:1	aa:A:!	ab:A:~	fa:f:3.14159	za:Z:Hello world!	ha:H:DEADBEEF	ba:B:c,-128,0,127	bb:B:C,0,127,255	bc:B:s,-32768,0,32767	bd:B:S,0,32768,65535	be:B:i,-2147483648,0,2147483647	bf:B:I,0,2147483648,4294967295	bg:B:f,2.71828,6.626e-34,2.9979e+09	MD:Z:10	NM:i:0	RG:Z:grp1
+ref1_grp2_p001	99	ref1	3	1	10M	=	27	34	AGCTCGGTAC	""""""""""	BC:Z:TGCA	H0:i:1	aa:A:A	ab:A:Z	fa:f:6.67e-11	za:Z:!"$%^&*()	ha:H:CAFE	MD:Z:10	NM:i:0	RG:Z:grp2
+ref1_grp1_p002	99	ref1	5	2	10M	=	29	34	CTCGGTACCC	##########	BC:Z:AATTCCGG	H0:i:1	aa:A:a	ab:A:z	fa:f:4.3597e-18	za:Z:Another string	ha:H:2000AD	MD:Z:10	NM:i:0	RG:Z:grp1
+ref1_grp2_p002	99	ref1	7	3	10M	=	31	34	CGGTACCCGG	$$$$$$$$$$	fa:f:6.022e+23	MD:Z:10	NM:i:0	RG:Z:grp2
+ref1_grp1_p003	99	ref1	9	4	10M	=	33	34	GTACCCGGGG	%%%%%%%%%%	fa:f:1.66e-27	MD:Z:10	NM:i:0	RG:Z:grp1
+ref1_grp2_p003	99	ref1	11	5	10M	=	35	34	ACCCGGGGAT	&&&&&&&&&&	ia:i:4294967295	MD:Z:10	NM:i:0	RG:Z:grp2
+ref1_grp1_p004	99	ref1	13	6	10M	=	37	34	CCGGGGATCC	''''''''''	fa:f:1.38e-23	za:Z:xRG:Z:grp2	MD:Z:10	NM:i:0	RG:Z:grp1
+ref1_grp2_p004	99	ref1	15	7	10M	=	39	34	GGGGATCCTC	((((((((((	ia:i:-2147483648	MD:Z:10	NM:i:0	RG:Z:grp2
+ref1_grp1_p005	99	ref1	17	8	10M	=	41	34	GGATCCTCTA	))))))))))	ia:i:40000	MD:Z:10	NM:i:0	RG:Z:grp1
+ref1_grp2_p005	99	ref1	19	9	10M	=	43	34	ATCCTCTAGA	**********	ia:i:-1000	MD:Z:10	NM:i:0	RG:Z:grp2
+ref1_grp1_p006	99	ref1	21	10	10M	=	45	34	CCTCTAGAGT	++++++++++	ia:i:255	MD:Z:10	NM:i:0	RG:Z:grp1
+ref1_grp2_p006	99	ref1	23	11	10M	=	47	34	TCTAGAGTCG	,,,,,,,,,,	ia:i:-1	MD:Z:10	NM:i:0	RG:Z:grp2
+ref1_grp1_p001	147	ref1	25	12	10M	=	1	-34	TAGAGTCGAC	----------	MD:Z:10	NM:i:0	RG:Z:grp1
+ref1_grp2_p001	147	ref1	27	13	10M	=	3	-34	GAGTCGACCT	..........	MD:Z:10	NM:i:0	RG:Z:grp2
+ref1_grp1_p002	147	ref1	29	14	10M	=	5	-34	GTCGACCTGC	//////////	MD:Z:10	NM:i:0	RG:Z:grp1
+ref1_grp2_p002	147	ref1	31	15	10M	=	7	-34	CGACCTGCAG	0000000000	MD:Z:10	NM:i:0	RG:Z:grp2
+ref1_grp1_p003	147	ref1	33	16	10M	=	9	-34	ACCTGCAGGC	1111111111	MD:Z:10	NM:i:0	RG:Z:grp1
+ref1_grp2_p003	147	ref1	35	17	10M	=	11	-34	CTGCAGGCAT	2222222222	MD:Z:10	NM:i:0	RG:Z:grp2
+ref12_grp1_p001	97	ref1	36	50	10M	ref2	2	0	TGCAGGCATG	AAAAAAAAAA	MD:Z:10	NM:i:0	RG:Z:grp1
+ref1_grp1_p004	147	ref1	37	18	10M	=	13	-34	GCAGGCATGC	3333333333	MD:Z:10	NM:i:0	RG:Z:grp1
+ref1_grp2_p004	147	ref1	39	19	10M	=	15	-34	AGGCATGCAA	4444444444	MD:Z:10	NM:i:0	RG:Z:grp2
+ref1_grp1_p005	147	ref1	41	20	10M	=	17	-34	GCATGCAAGC	5555555555	MD:Z:10	NM:i:0	RG:Z:grp1
+ref1_grp2_p005	147	ref1	43	21	10M	=	19	-34	ATGCAAGCTT	6666666666	MD:Z:10	NM:i:0	RG:Z:grp2
+ref1_grp1_p006	147	ref1	45	22	10M	=	21	-34	GCAAGCTTGA	7777777777	MD:Z:10	NM:i:0	RG:Z:grp1
+ref12_grp2_p001	97	ref1	46	50	10M	ref2	12	0	CAAGCTTGAG	AAAAAAAAAA	MD:Z:10	NM:i:0	RG:Z:grp2
+ref1_grp2_p006	147	ref1	47	23	10M	=	23	-34	AAGCTTGAGT	8888888888	MD:Z:10	NM:i:0	RG:Z:grp2
+ref2_grp3_p001	83	ref2	1	99	15M	=	31	45	ATTCTATAGTGTCAC	~~~~~~~~~~~~~~~	MD:Z:15	NM:i:0	RG:Z:grp3
+ref12_grp1_p001	145	ref2	2	50	10M	ref1	36	0	TTCTATAGTG	BBBBBBBBBB	MD:Z:10	NM:i:0	RG:Z:grp1
+ref12_grp2_p001	145	ref2	12	50	10M	ref1	46	0	TCACCTAAAT	BBBBBBBBBB	MD:Z:10	NM:i:0	RG:Z:grp2
+ref2_grp3_p002	147	ref2	16	99	15M	=	46	45	CTAAATAGCTTGGCG	}}}}}}}}}}}}}}}	MD:Z:15	NM:i:0	RG:Z:grp3
+ref2_grp3_p001	163	ref2	31	99	15M	=	1	-45	CTGTTTCCTGTGTGA	|||||||||||||||	MD:Z:0T0A0A1C0A0T0G0G0T0C0A1A0G0	NM:i:13	RG:Z:grp3
+ref2_grp3_p002	99	ref2	46	99	15M	=	16	-45	CTGTTTCCTGTGTGA	{{{{{{{{{{{{{{{	MD:Z:15	NM:i:0	RG:Z:grp3
+unaligned_grp3_p001	77	*	0	0	*	*	0	0	CACTCGTTCATGACG	0123456789abcde	RG:Z:grp3
+unaligned_grp3_p001	141	*	0	0	*	*	0	0	GAAAGTGAGGAGGTG	edcba9876543210	RG:Z:grp3

--- a/test/test.pl
+++ b/test/test.pl
@@ -2865,6 +2865,18 @@ sub test_reheader
              err=>'reheader/3_view1.sam.expected.err',
              cmd=>"$$opts{bin}/samtools reheader --in-place $$opts{path}/reheader/hdr.sam $fn.tmp.v30.cram && $$opts{bin}/samtools view -h $fn.tmp.v30.cram | perl -pe 's/\tVN:.*//'",
 	     exp_fix=>1);
+
+    test_cmd($opts,
+             out=>'reheader/4_view1.sam.expected',
+             err=>'reheader/1_view1.sam.expected.err',
+             cmd=>"$$opts{bin}/samtools reheader -c \"sed \'s/2014 Genome/2019 Genome/g\'\" $fn.tmp.bam | $$opts{bin}/samtools view -h | perl -pe 's/\tVN:.*//'",
+	     exp_fix=>1);
+	     
+    test_cmd($opts,
+             out=>'reheader/5_view1.sam.expected',
+             err=>'reheader/1_view1.sam.expected.err',
+             cmd=>"$$opts{bin}/samtools reheader -c \"sed \'s/2014 Genome/2019 Genome/g\'\" $fn.tmp.v30.cram | $$opts{bin}/samtools view -h | perl -pe 's/\tVN:.*//'",
+         exp_fix=>1);    
 }
 
 sub test_addrprg


### PR DESCRIPTION
Allow an external application to modify the header of the target file and pass back the result to _samtools_. The external app will read the original header through **stdin** and output the modified header on **stdout**.

Fixes #999.