### PR TITLE
Check for gzopen() failure and print error messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ bam_tview_html.o: bam_tview_html.c config.h $(bam_tview_h)
 bam_flags.o: bam_flags.c config.h $(htslib_sam_h)
 bamshuf.o: bamshuf.c config.h $(htslib_sam_h) $(htslib_hts_h) $(htslib_ksort_h) samtools.h $(htslib_thread_pool_h) $(sam_opts_h) $(htslib_khash_h)
 bamtk.o: bamtk.c config.h $(htslib_hts_h) samtools.h version.h
-bedcov.o: bedcov.c config.h $(htslib_kstring_h) $(htslib_sam_h) $(htslib_thread_pool_h) $(sam_opts_h) $(htslib_kseq_h)
+bedcov.o: bedcov.c config.h $(htslib_kstring_h) $(htslib_sam_h) $(htslib_thread_pool_h) samtools.h $(sam_opts_h) $(htslib_kseq_h)
 bedidx.o: bedidx.c config.h $(bedidx_h) $(htslib_ksort_h) $(htslib_kseq_h) $(htslib_khash_h)
 cut_target.o: cut_target.c config.h $(htslib_hts_h) $(htslib_sam_h) $(htslib_faidx_h) samtools.h $(sam_opts_h)
 dict.o: dict.c config.h $(htslib_kseq_h) $(htslib_hts_h)

--- a/bedcov.c
+++ b/bedcov.c
@@ -34,6 +34,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include "htslib/kstring.h"
 #include "htslib/sam.h"
 #include "htslib/thread_pool.h"
+#include "samtools.h"
 #include "sam_opts.h"
 
 #include "htslib/kseq.h"
@@ -139,6 +140,10 @@ int main_bedcov(int argc, char *argv[])
     cnt = calloc(n, 8);
 
     fp = gzopen(argv[optind], "rb");
+    if (fp == NULL) {
+        print_error_errno("bedcov", "can't open BED file '%s'", argv[optind]);
+        return 2;
+    }
     ks = ks_init(fp);
     n_plp = calloc(n, sizeof(int));
     plp = calloc(n, sizeof(bam_pileup1_t*));

--- a/misc/ace2sam.c
+++ b/misc/ace2sam.c
@@ -93,7 +93,8 @@ int main(int argc, char *argv[])
     s.l = s.m = 0; s.s = 0;
     af_n = af_max = af_i = 0; af = 0;
     for (i = 0; i < N_TMPSTR; ++i) t[i].l = t[i].m = 0, t[i].s = 0;
-    fp = strcmp(argv[1], "-")? gzopen(argv[optind], "r") : gzdopen(fileno(stdin), "r");
+    fp = strcmp(argv[optind], "-")? gzopen(argv[optind], "r") : gzdopen(fileno(stdin), "r");
+    if (fp == NULL) fatal("can't open input file");
     ks = ks_init(fp);
     while (ks_getuntil(ks, 0, &s, &dret) >= 0) {
         if (strcmp(s.s, "CO") == 0) { // contig sequence

--- a/misc/wgsim.c
+++ b/misc/wgsim.c
@@ -38,6 +38,7 @@
 #include <stdint.h>
 #include <ctype.h>
 #include <string.h>
+#include <errno.h>
 #include <zlib.h>
 #include "../version.h"
 #include "htslib/kseq.h"
@@ -241,6 +242,12 @@ void wgsim_core(FILE *fpout1, FILE *fpout2, const char *fn, int is_hap, uint64_t
     mut_t *target;
     int max_loop, max_loop_err = 0;
 
+    fp_fa = gzopen(fn, "r");
+    if (fp_fa == NULL) {
+        fprintf(stderr, "[wgsim] can't open '%s': %s\n", fn, strerror(errno));
+        return;
+    }
+
     l = size_l > size_r? size_l : size_r;
     qstr = (char*)calloc(l+1, 1);
     tmp_seq[0] = (uint8_t*)calloc(l+2, 1);
@@ -250,7 +257,6 @@ void wgsim_core(FILE *fpout1, FILE *fpout2, const char *fn, int is_hap, uint64_t
 
     Q = (ERR_RATE == 0.0)? 'I' : (int)(-10.0 * log(ERR_RATE) / log(10.0) + 0.499) + 33;
 
-    fp_fa = gzopen(fn, "r");
     ks = kseq_init(fp_fa);
     tot_len = n_ref = 0;
     fprintf(stderr, "[%s] calculating the total length of the reference sequence...\n", __func__);


### PR DESCRIPTION
Ensure that all instances of `gzopen()` have appropriate error checking. In a couple of cases, lift the `gzopen` to above some allocations so that the error path doesn't need to undo the allocations. Down in _misc/*.c_ the infrastructure is lacking and we don't go to great lengths to e.g. return a non-zero status.

Fixes another few instances of #51.

Noticed in bedcov by @rotifergirl (see https://twitter.com/Julie_B92/status/1097867250642628608).