### PR TITLE
Don't break people's names across (source file) lines

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -103,8 +103,8 @@ Release 1.9 (18th July 2018)
    - Fixed compilation problems when using C_INCLUDE_PATH. (#870; #817 reported
      by Robert Boissy)
 
-   - Fixed --version when built from a Git repository. (#844, thanks to John
-     Marshall)
+   - Fixed --version when built from a Git repository. (#844, thanks to
+     John Marshall)
 
    - Use noenhanced mode for title in plot-bamstats.  Prevents unwanted
      interpretation of characters like underscore in gnuplot version 5. (#829,

--- a/doc/samtools-faidx.1
+++ b/doc/samtools-faidx.1
@@ -120,8 +120,8 @@ Print help message and exit.
 
 .SH AUTHOR
 .PP
-Written by Heng Li, with modifications by Andrew Whitwham and Robert
-Davies, all from the Sanger Institute.
+Written by Heng Li, with modifications by Andrew Whitwham and Robert Davies,
+all from the Sanger Institute.
 
 .SH SEE ALSO
 .IR samtools (1),

--- a/doc/samtools-fasta.1
+++ b/doc/samtools-fasta.1
@@ -261,8 +261,8 @@ The existing default of 0 is retained for reasons of compatibility.
 
 .SH AUTHOR
 .PP
-Written by Heng Li, with modifications by Martin Pollard and Jennifer
-Liddle, all from the Sanger Institute.
+Written by Heng Li, with modifications by Martin Pollard and Jennifer Liddle,
+all from the Sanger Institute.
 
 .SH SEE ALSO
 .IR samtools (1),

--- a/doc/samtools-fqidx.1
+++ b/doc/samtools-fqidx.1
@@ -118,8 +118,8 @@ Print help message and exit.
 
 .SH AUTHOR
 .PP
-Written by Heng Li, with modifications by Andrew Whitwham and Robert
-Davies, all from the Sanger Institute.
+Written by Heng Li, with modifications by Andrew Whitwham and Robert Davies,
+all from the Sanger Institute.
 
 .SH SEE ALSO
 .IR samtools (1),

--- a/doc/samtools.1
+++ b/doc/samtools.1
@@ -929,8 +929,8 @@ Heng Li from the Sanger Institute wrote the original C version of
 samtools.  Bob Handsaker from the Broad Institute implemented the BGZF
 library.  Petr Danecek and Heng Li wrote the VCF/BCF implementation.
 James Bonfield from the Sanger Institute developed the CRAM
-implementation.  Other large code contributions have been made by John
-Marshall, Rob Davies, Martin Pollard, Andrew Whitwham, Valeriu Ohan
+implementation.  Other large code contributions have been made by
+John Marshall, Rob Davies, Martin Pollard, Andrew Whitwham, Valeriu Ohan
 (all while primarily at the Sanger Institute), with numerous other
 smaller but valuable contributions.  See the per-command manual pages
 for further authorship.


### PR DESCRIPTION
Minor, but some people care about this.

The man pages will be reflowed when they're displayed which might break some names across lines again, but at least this keeps these linguistic units together when the files are being edited.

* @daviesrob appears sometimes as Rob and sometimes as Robert… 🤔 

* The _AUTHORS_ file has not kept up. It might benefit from being updated from _doc/samtools.1_'s AUTHOR section.

* It is observed once again (see also https://github.com/samtools/samtools/pull/894#issuecomment-409490067) that the AUTHOR sections on the individual man pages arguably unfairly de-emphasise those who have contributed significantly and generally to samtools but who have not invented new subcommands.