### PR TITLE
Fix proper float division

### DIFF
--- a/stats.c
+++ b/stats.c
@@ -1428,7 +1428,7 @@ float gcd_percentile(gc_depth_t *gcd, int N, int p)
     float n,d;
     int k;
 
-    n = p*(N+1)/100;
+    n = (float)p*(N+1)/100;
     k = n;
     if ( k<=0 )
         return gcd[0].depth;


### PR DESCRIPTION
Without explicit casting, n holds an integer value, equal to k, which makes d always equal 0.