### PR TITLE
Auto index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ language: c
 
 matrix:
   include:
-    # An optimised build with address, leak and undefined behavior checking
+    # An optimised build with address and leak checking
     - os: linux
       compiler: clang
       sudo: required
-      env: CFLAGS="-fsanitize=address" LDFLAGS="-fsanitize=address"
+      env: CFLAGS="-g -Wall -O3 -fsanitize=address" LDFLAGS="-fsanitize=address"
     - os: linux
       compiler: gcc-8
       addons:

--- a/bam_addrprg.c
+++ b/bam_addrprg.c
@@ -471,7 +471,7 @@ static bool readgroupise(parsed_opts_t *opts, state_t* state)
 
         if (opts->ga.write_index) {
             if (sam_idx_save(state->output_file) < 0) {
-                print_error_errno("addrelacerg", "writing index failed");
+                print_error_errno("addreplacerg", "[%s] Writing index failed", __func__);
                 free(idx_fn);
                 return false;
             }

--- a/doc/samtools.1
+++ b/doc/samtools.1
@@ -681,7 +681,7 @@ Display the full samtools version number in a machine-readable format.
 .PP
 Several long-options are shared between multiple samtools sub-commands:
 \fB--input-fmt\fR, \fB--input-fmt-option\fR, \fB--output-fmt\fR,
-\fB--output-fmt-option\fR, and \fB--reference\fR.
+\fB--output-fmt-option\fR, \fB--reference\fR and \fB--write-index\fR.
 The input format is typically auto-detected so specifying the format
 is usually unnecessary and the option is included for completeness.
 Note that not all subcommands have all options.  Consult the subcommand
@@ -701,7 +701,8 @@ valid options are as follows.
 .TP 4
 .BI level= INT
 Output only. Specifies the compression level from 1 to 9, or 0 for
-uncompressed.
+uncompressed.  If the output format is SAM, this also enables BGZF
+compression, otherwise SAM defaults to uncompressed.
 .TP
 .BI nthreads= INT
 Specifies the number of threads to use during encoding and/or
@@ -812,6 +813,18 @@ samtools view --input-fmt-option decode_md=0
     --output-fmt cram,version=3.0 --output-fmt-option embed_ref
     --output-fmt-option seqs_per_slice=2000 -o foo.cram foo.bam
 .EE
+.PP
+The \fB--write-index\fR option enables automatic index creation while
+writing out BAM, CRAM or bgzf SAM files.  Note to get compressed SAM
+as the output format you need to manually request a compression level,
+otherwise all SAM files are uncompressed.  SAM and BAM will use CSI
+indices while CRAM will use CRAI indices.
+.PP
+For example: to convert a BAM to a compressed SAM with CSI indexing:
+.EX 4
+samtools view -h -O sam,level=6 --write-index in.bam -o out.sam.gz
+.EE
+
 .PP
 .SH REFERENCE SEQUENCES
 .PP

--- a/padding.c
+++ b/padding.c
@@ -510,7 +510,7 @@ int main_pad2unpad(int argc, char *argv[])
     bam_hdr_t *h = 0, *h_fix = 0;
     faidx_t *fai = 0;
     int c, compress_level = -1, is_long_help = 0;
-    char in_mode[5], out_mode[6], *fn_out = 0, *fn_list = 0;
+    char in_mode[5], out_mode[6], *fn_out = 0, *fn_list = 0, *fn_out_idx = NULL;
     int ret=0;
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
 
@@ -597,9 +597,22 @@ int main_pad2unpad(int argc, char *argv[])
         ret = 1;
         goto depad_end;
     }
+    if (ga.write_index) {
+        if (!(fn_out_idx = auto_index(out, fn_out, h_fix))) {
+            ret = 1;
+            goto depad_end;
+        }
+    }
 
     // Do the depad
     if (bam_pad2unpad(in, out, h, fai) != 0) ret = 1;
+
+    if (ga.write_index) {
+        if (sam_idx_save(out) < 0) {
+            print_error_errno("depad", "writing index failed");
+            ret = 1;
+        }
+    }
 
 depad_end:
     // close files, free and return
@@ -612,6 +625,8 @@ depad_end:
         ret = 1;
     }
     free(fn_list); free(fn_out);
+    if (fn_out_idx)
+        free(fn_out_idx);
     sam_global_args_free(&ga);
     return ret;
 }
@@ -629,7 +644,7 @@ static int usage(int is_long_help)
     fprintf(stderr, "               Padded reference sequence file [null]\n");
     fprintf(stderr, "  -o FILE      Output file name [stdout]\n");
     fprintf(stderr, "  -?           Longer help\n");
-    sam_global_opt_help(stderr, "-...--");
+    sam_global_opt_help(stderr, "-...--.");
 
     if (is_long_help)
         fprintf(stderr,

--- a/sam_opts.c
+++ b/sam_opts.c
@@ -76,7 +76,7 @@ int parse_sam_global_opt(int c, const char *optarg, const struct option *lopt,
             ga->nthreads = atoi(optarg);
             break;
         } else if (strcmp(lopt->name, "write-index") == 0) {
-            ga->write_index=1;
+            ga->write_index = 1;
             break;
 //      } else if (strcmp(lopt->name, "verbose") == 0) {
 //          ga->verbosity++;

--- a/sam_opts.c
+++ b/sam_opts.c
@@ -75,6 +75,9 @@ int parse_sam_global_opt(int c, const char *optarg, const struct option *lopt,
         } else if (strcmp(lopt->name, "threads") == 0) {
             ga->nthreads = atoi(optarg);
             break;
+        } else if (strcmp(lopt->name, "write-index") == 0) {
+            ga->write_index=1;
+            break;
 //      } else if (strcmp(lopt->name, "verbose") == 0) {
 //          ga->verbosity++;
 //          break;
@@ -84,6 +87,18 @@ int parse_sam_global_opt(int c, const char *optarg, const struct option *lopt,
     if (!lopt->name) {
         fprintf(stderr, "Unexpected global option: %s\n", lopt->name);
         return -1;
+    }
+
+    /*
+     * SAM format with compression enabled implies SAM.bgzf
+     */
+    if (ga->out.format == sam) {
+        hts_opt *opts = (hts_opt *)ga->out.specific;
+        while (opts) {
+            if (opts->opt == HTS_OPT_COMPRESSION_LEVEL)
+                ga->out.compression = bgzf;
+            opts = opts->next;
+        }
     }
 
     return r;
@@ -136,6 +151,9 @@ void sam_global_opt_help(FILE *fp, const char *shortopts) {
         else if (strcmp(lopts[i].name, "threads") == 0)
             fprintf(fp,"threads INT\n"
                     "               Number of additional threads to use [0]\n");
+        else if (strcmp(lopts[i].name, "write-index") == 0)
+            fprintf(fp,"write-index\n"
+                    "               Automatically index the output files [off]\n");
 //      else if (strcmp(lopts[i].name, "verbose") == 0)
 //          fprintf(fp,"verbose\n"
 //                  "               Increment level of verbosity\n");

--- a/sam_opts.h
+++ b/sam_opts.h
@@ -35,6 +35,7 @@ typedef struct sam_global_args {
     htsFormat out;
     char *reference;
     int nthreads;
+    int write_index;
     //int verbosity;
 } sam_global_args;
 
@@ -47,7 +48,8 @@ enum {
     SAM_OPT_OUTPUT_FMT_OPTION,
     SAM_OPT_REFERENCE,
     SAM_OPT_NTHREADS,
-    //SAM_OPT_VERBOSE
+    SAM_OPT_WRITE_INDEX,
+    //SAM_OPT_VERBOSE,
 };
 
 #define SAM_OPT_VAL(val, defval) ((val) == '-')? '?' : (val)? (val) : (defval)
@@ -64,7 +66,8 @@ enum {
     {"output-fmt",        required_argument, NULL, SAM_OPT_VAL(o3, SAM_OPT_OUTPUT_FMT)}, \
     {"output-fmt-option", required_argument, NULL, SAM_OPT_VAL(o4, SAM_OPT_OUTPUT_FMT_OPTION)}, \
     {"reference",         required_argument, NULL, SAM_OPT_VAL(o5, SAM_OPT_REFERENCE)}, \
-    {"threads",           required_argument, NULL, SAM_OPT_VAL(o6, SAM_OPT_NTHREADS)}
+    {"threads",           required_argument, NULL, SAM_OPT_VAL(o6, SAM_OPT_NTHREADS)}, \
+    {"write-index",       no_argument,       NULL, SAM_OPT_WRITE_INDEX}
     //{"verbose",           no_argument,       NULL, SAM_OPT_VERBOSE}
 
 /*

--- a/sam_view.c
+++ b/sam_view.c
@@ -559,7 +559,7 @@ int main_samview(int argc, char *argv[])
                 goto view_end;
             }
         }
-        if (*out_format || is_header ||
+        if (*out_format || ga.write_index || is_header ||
             out_mode[1] == 'b' || out_mode[1] == 'c' ||
             (ga.out.format != sam && ga.out.format != unknown_format))  {
             if (sam_hdr_write(out, header) != 0) {

--- a/samtools.h
+++ b/samtools.h
@@ -40,4 +40,16 @@ void print_error_errno(const char *subcommand, const char *format, ...) CHECK_PR
 
 void check_sam_close(const char *subcmd, samFile *fp, const char *fname, const char *null_fname, int *retp);
 
+/*
+ * Utility function to add an index to a file we've opened for write.
+ * NB: Call this after writing the header and before writing sequences.
+ *
+ * The returned index filename should be freed by the caller, but only
+ * after sam_idx_save has been called.
+ *
+ * Returns index filename on success,
+ *         NULL on failure.
+ */
+char *auto_index(htsFile *fp, const char *fn, bam_hdr_t *header);
+
 #endif

--- a/test/test.pl
+++ b/test/test.pl
@@ -822,6 +822,18 @@ sub test_index
     cmd("$$opts{bin}/samtools index${threads} $$opts{path}/dat/test_input_1_b.bam $$opts{tmp}/test_input_1_b.bam.bai");
     test_cmd($opts,out=>'dat/test_input_1_b.X.expected',cmd=>"$$opts{bin}/samtools view${threads} -X $$opts{path}/dat/test_input_1_b.bam $$opts{tmp}/test_input_1_b.bam.bai ref2");
     test_cmd($opts,out=>'dat/test_input_1_ab.X.expected',cmd=>"$$opts{bin}/samtools merge${threads} -O sam - -X -cp -R ref2 $$opts{path}/dat/test_input_1_a.bam $$opts{path}/dat/test_input_1_b.bam $$opts{path}/dat/test_input_1_a.bam.bai $$opts{tmp}/test_input_1_b.bam.bai");
+
+    # Check auto-indexing
+    cmd("$$opts{bin}/samtools view${threads} --write-index -o $$opts{path}/dat/auto_indexed.bam $$opts{path}/dat/mpileup.1.sam");
+    test_cmd($opts,out=>"dat/auto_indexed.bam.csi", cmd=>"$$opts{bin}/samtools index${threads} -c $$opts{path}/dat/auto_indexed.bam $$opts{tmp}/auto_indexed.csi && cat $$opts{tmp}/auto_indexed.csi", binary=>1);
+
+    cmd("$$opts{bin}/samtools view${threads} -T $$opts{path}/dat/mpileup.ref.fa --write-index -o $$opts{path}/dat/auto_indexed.cram $$opts{path}/dat/mpileup.1.sam");
+    test_cmd($opts,out=>"dat/auto_indexed.cram.crai", cmd=>"$$opts{bin}/samtools index${threads} $$opts{path}/dat/auto_indexed.cram $$opts{tmp}/auto_indexed.crai && cat $$opts{tmp}/auto_indexed.crai", binary=>1);
+
+    print "test_index:\n";
+    print "$$opts{bin}/samtools view${threads} -h --write-index -O sam,level=5 -o $$opts{path}/dat/auto_indexed.sam $$opts{path}/dat/mpileup.1.sam\n\n";
+    cmd("$$opts{bin}/samtools view${threads} -h --write-index -O sam,level=5 -o $$opts{path}/dat/auto_indexed.sam $$opts{path}/dat/mpileup.1.sam");
+    test_cmd($opts,out=>"dat/auto_indexed.sam.csi", cmd=>"$$opts{bin}/samtools index${threads} -c $$opts{path}/dat/auto_indexed.sam $$opts{tmp}/auto_indexed.csi && cat $$opts{tmp}/auto_indexed.csi", binary=>1);
 }
 
 sub test_mpileup

--- a/test/test.pl
+++ b/test/test.pl
@@ -830,8 +830,6 @@ sub test_index
     cmd("$$opts{bin}/samtools view${threads} -T $$opts{path}/dat/mpileup.ref.fa --write-index -o $$opts{path}/dat/auto_indexed.cram $$opts{path}/dat/mpileup.1.sam");
     test_cmd($opts,out=>"dat/auto_indexed.cram.crai", cmd=>"$$opts{bin}/samtools index${threads} $$opts{path}/dat/auto_indexed.cram $$opts{tmp}/auto_indexed.crai && cat $$opts{tmp}/auto_indexed.crai", binary=>1);
 
-    print "test_index:\n";
-    print "$$opts{bin}/samtools view${threads} -h --write-index -O sam,level=5 -o $$opts{path}/dat/auto_indexed.sam $$opts{path}/dat/mpileup.1.sam\n\n";
     cmd("$$opts{bin}/samtools view${threads} -h --write-index -O sam,level=5 -o $$opts{path}/dat/auto_indexed.sam $$opts{path}/dat/mpileup.1.sam");
     test_cmd($opts,out=>"dat/auto_indexed.sam.csi", cmd=>"$$opts{bin}/samtools index${threads} -c $$opts{path}/dat/auto_indexed.sam $$opts{tmp}/auto_indexed.csi && cat $$opts{tmp}/auto_indexed.csi", binary=>1);
 }


### PR DESCRIPTION
1. Fixed the travis build so it behaves as claimed in the comment - an *optimised* build doing address sanitizer. 

2. Added a global --write-index option to enable the auto-indexing code.  This requires the auto_index PR of htslib merging first.