### PR TITLE
Fix plot-bamstats quality heatmap on newer gnuplot

### DIFF
--- a/misc/plot-bamstats
+++ b/misc/plot-bamstats
@@ -815,7 +815,7 @@ sub plot_qualities
         for (my $iqual=1; $iqual<@$cycle; $iqual++) { print $fh "\t$$cycle[$iqual]"; }
         print $fh "\n";
     }
-    print $fh "end\nend\n";
+    print $fh "\nend\n";
     if ( $is_paired )
     {
         @ytics = ();
@@ -840,7 +840,7 @@ sub plot_qualities
             for (my $iqual=1; $iqual<@$cycle; $iqual++) { print $fh "\t$$cycle[$iqual]"; }
             print $fh "\n";
         }
-        print $fh "end\nend\n";
+        print $fh "\nend\n";
     }
     close($fh);
     plot($$args{gp});


### PR DESCRIPTION
Replace `end\nend\n` with `\nend\n`, which works in both old and new gnuplot.

Fixes #1065 (samtools-1.6 and 1.9: plot-bamstats generates broken gnuplot script)