### PR TITLE
add another argument to function sam_header2key_val to solve a bug might be triggered

### DIFF
--- a/sam_header.c
+++ b/sam_header.c
@@ -722,7 +722,7 @@ void *sam_header2key_val(void *iter, const char type[2], const char key_tag[2], 
         *_key = key->value;
         *_value = value->value;
         if(!l->next){
-            eof = true;
+            *eof = true;
         }
         return l->next;
     }

--- a/sam_header.c
+++ b/sam_header.c
@@ -696,7 +696,7 @@ char **sam_header2list(const void *_dict, char type[2], char key_tag[2], int *_n
     return ret;
 }
 
-void *sam_header2key_val(void *iter, const char type[2], const char key_tag[2], const char value_tag[2], const char **_key, const char **_value)
+void *sam_header2key_val(void *iter, const char type[2], const char key_tag[2], const char value_tag[2], const char **_key, const char **_value, bool* eof)
 {
     list_t *l = iter;
     if ( !l ) return NULL;
@@ -721,6 +721,9 @@ void *sam_header2key_val(void *iter, const char type[2], const char key_tag[2], 
 
         *_key = key->value;
         *_value = value->value;
+        if(!l->next){
+            eof = true;
+        }
         return l->next;
     }
     return l;

--- a/sam_header.c
+++ b/sam_header.c
@@ -696,7 +696,7 @@ char **sam_header2list(const void *_dict, char type[2], char key_tag[2], int *_n
     return ret;
 }
 
-void *sam_header2key_val(void *iter, const char type[2], const char key_tag[2], const char value_tag[2], const char **_key, const char **_value, bool* eof)
+void *sam_header2key_val(void *iter, const char type[2], const char key_tag[2], const char value_tag[2], const char **_key, const char **_value, int* eof)
 {
     list_t *l = iter;
     if ( !l ) return NULL;
@@ -722,7 +722,7 @@ void *sam_header2key_val(void *iter, const char type[2], const char key_tag[2], 
         *_key = key->value;
         *_value = value->value;
         if(!l->next){
-            *eof = true;
+            *eof = 1;
         }
         return l->next;
     }

--- a/sam_header.h
+++ b/sam_header.h
@@ -37,10 +37,16 @@ extern "C" {
     /*
         // Usage example
         const char *key, *val;
+        bool* eof = false;
         void *iter = sam_header_parse2(bam->header->text);
-        while ( iter = sam_header_key_val(iter, "RG","ID","SM" &key,&val) ) printf("%s\t%s\n", key,val);
+        while ((iter = sam_header_key_val(iter, "RG","ID","SM" &key,&val)) || eof){
+            printf("%s\t%s\n", key,val);
+            if(eof){
+                eof = false;
+            }
+        }
     */
-    void *sam_header2key_val(void *iter, const char type[2], const char key_tag[2], const char value_tag[2], const char **key, const char **value);
+    void *sam_header2key_val(void *iter, const char type[2], const char key_tag[2], const char value_tag[2], const char **key, const char **value, bool* eof);
     char **sam_header2list(const void *_dict, char type[2], char key_tag[2], int *_n);
 
     /*

--- a/sam_header.h
+++ b/sam_header.h
@@ -37,16 +37,16 @@ extern "C" {
     /*
         // Usage example
         const char *key, *val;
-        bool* eof = false;
+        int eof = 0;
         void *iter = sam_header_parse2(bam->header->text);
-        while ((iter = sam_header_key_val(iter, "RG","ID","SM" &key,&val)) || eof){
+        while ((iter = sam_header_key_val(iter, "RG","ID","SM" &key, &val, &eof)) || eof){
             printf("%s\t%s\n", key,val);
             if(eof){
-                eof = false;
+                eof = 0;
             }
         }
     */
-    void *sam_header2key_val(void *iter, const char type[2], const char key_tag[2], const char value_tag[2], const char **key, const char **value, bool* eof);
+    void *sam_header2key_val(void *iter, const char type[2], const char key_tag[2], const char value_tag[2], const char **key, const char **value, int* eof);
     char **sam_header2list(const void *_dict, char type[2], char key_tag[2], int *_n);
 
     /*

--- a/stats.c
+++ b/stats.c
@@ -1987,9 +1987,10 @@ void init_group_id(stats_t *stats, const char *id)
         stats->sam_header->dict = sam_header_parse2(stats->sam_header->text);
     void *iter = stats->sam_header->dict;
     const char *key, *val;
+    bool eof = false;
     int n = 0;
     stats->rg_hash = khash_str2int_init();
-    while ( (iter = sam_header2key_val(iter, "RG","ID","SM", &key, &val)) )
+    while ( (iter = sam_header2key_val(iter, "RG","ID","SM", &key, &val, &eof))  || eof)
     {
         if ( !strcmp(id,key) || (val && !strcmp(id,val)) )
         {
@@ -2000,6 +2001,9 @@ void init_group_id(stats_t *stats, const char *id)
             k = kh_put(kh_rg, stats->rg_hash, key, &ret);
             kh_value(stats->rg_hash, k) = val;
             n++;
+        }
+        if(eof){
+            eof = false;
         }
     }
     if ( !n )

--- a/stats.c
+++ b/stats.c
@@ -1987,8 +1987,7 @@ void init_group_id(stats_t *stats, const char *id)
         stats->sam_header->dict = sam_header_parse2(stats->sam_header->text);
     void *iter = stats->sam_header->dict;
     const char *key, *val;
-    bool eof = false;
-    int n = 0;
+    int n = 0, eof = 0;
     stats->rg_hash = khash_str2int_init();
     while ( (iter = sam_header2key_val(iter, "RG","ID","SM", &key, &val, &eof))  || eof)
     {
@@ -2003,7 +2002,7 @@ void init_group_id(stats_t *stats, const char *id)
             n++;
         }
         if(eof){
-            eof = false;
+            eof = 0;
         }
     }
     if ( !n )


### PR DESCRIPTION
In the original code of sam_header2key_val, when the last line of bam header parsed, it return NULL to its caller, if the tag we want to get is just in the last line, and we use a while loop to iterate through sam_header2key_val and test its return value as whether this while loop will continue or not, then in the while loop, we will never got the last line record checked.

In my version, I add another argument eof to sam_header2key_val, which indicate the eof of bam header, and use its value as another sentinel of the while loop, then we can simply use just one while loop to iterate all lines in bam header now.

I have modified all the example and source code using this modification, I think it is ugly somehow, but haven't got a better idea to use just one while loop only to iterate all lines and got all wanted key-value checked in the while loop.
