### PR TITLE
Fixed invalid assertion.

### DIFF
--- a/bam_fastq.c
+++ b/bam_fastq.c
@@ -913,9 +913,9 @@ static bool bam2fq_mainloop(bam2fq_state_t *state, bam2fq_opts_t* opts)
     bam1_t* b = NULL;
 
     while (true) {
-        assert(b == NULL);
-        b = bam_init1();
-        if (b == NULL ) {
+        if (!b)
+            b = bam_init1();
+        if (b == NULL) {
             perror("[bam2fq_mainloop] Malloc error for bam record buffer.");
             valid = false;
             break;
@@ -928,11 +928,8 @@ static bool bam2fq_mainloop(bam2fq_state_t *state, bam2fq_opts_t* opts)
         }
         at_eof = res < 0;
 
-        if (!at_eof && filter_it_out(b, state)) {
-            bam_destroy1(b);
-            b = NULL;
+        if (!at_eof && filter_it_out(b, state))
             continue;
-        }
         if (!at_eof) ++n_reads;
 
         if (at_eof || !current_qname || (strcmp(current_qname, bam_get_qname(b)) != 0)) {

--- a/doc/samtools-fasta.1
+++ b/doc/samtools-fasta.1
@@ -57,7 +57,9 @@ Converts a BAM or CRAM into either FASTQ or FASTA format depending on the
 command invoked. The files will be automatically compressed if the
 file names have a .gz or .bgzf extension.
 
-The input to this program must be collated by name.
+If the input contains read-pairs which are to be interleaved or
+written to separate files in the same order, then the input should
+be first collated by name.
 Use
 .B samtools collate
 or


### PR DESCRIPTION
b may not be set to NULL if the "b_score > score[rp]" condition later on is not met.  I don't understand what this is attempting to do, but given b isn't always NULL we shouldn't assert that it is.  Possibly we need another fix?

Local example file for @jenniferliddle at `~jkb/lustre/minhash/NA12878.chr10.10M.cram`

NB: this file isn't sorted by name, but actually I don't care either as I'm not splitting into separate files and I'm not processing anything in pairs.  I just want to output sequence in original orientation (for which samtools fastq should work amiably).  So this is input that's not expected by the tool, but obviously it shouldn't crash.  (Samtools 1.9 doesn't so this is new functionality that appeared in 0f8febc1)