### PR TITLE
Make get_rg_sample() use header API and fix tview -s option

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -34,6 +34,9 @@ Release a.b
   for dual indicies in the same way as bcl2fastq, using a '+' sign between
   the two parts of the index.
 
+* Fixed samtools tview -s option which was not filtering reads correctly.
+  It now only shows reads from the requested sample or read group.
+
 Release 1.9 (18th July 2018)
 ----------------------------
 


### PR DESCRIPTION
Makes `samtools tview -s` work as advertised in the manual page.

It's been broken since commit c8c745e which deliberately commented out the filter due to changes resulting from the HTSlib/samtools split.  Some later commits tried to restore it, but didn't actually work properly.  This gets it back to the pre-c8c745e state.
