### PR TITLE
Fix use of internal headers + travis update to spot this

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,8 +72,8 @@ script:
     autoreconf -i && \
     (cd $HTSDIR && \
       autoreconf -i && \
-      ./configure --prefix=`pwd`/../inst LDFLAGS="$LDFLAGS -Wl,-rpath,`pwd`/../inst/lib" && \
-      make install \
+      ./configure --prefix=`pwd`/../inst && \
+      make -e install \
     ) && \
     (./configure --enable-werror --with-htslib=`pwd`/inst  LDFLAGS="$LDFLAGS -Wl,-rpath,`pwd`/inst/lib" || \
       (cat config.log; /bin/false) \

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,14 +50,6 @@ addons:
     - liblzma-dev
     - libbz2-dev
 
-# For MacOSX systems
-before_install:
-  - |
-    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      HOMEBREW_NO_AUTO_UPDATE=1 brew install xz || \
-      ( brew update && brew install xz )
-    fi
-
 before_script:
   # Clone htslib, trying the same branch name in the owners' copy of htslib.
   # If this exists then the user is likely making a joint PR to htslib and

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,11 @@ addons:
 
 # For MacOSX systems
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then HOMEBREW_NO_AUTO_UPDATE=1 brew install xz || ( brew update && brew install xz ); fi
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      HOMEBREW_NO_AUTO_UPDATE=1 brew install xz || \
+      ( brew update && brew install xz )
+    fi
 
 before_script:
   # Clone htslib, trying the same branch name in the owners' copy of htslib.
@@ -63,4 +67,19 @@ before_script:
   # Logic for choosing which to use is in the .travis/clone script.
   - .travis/clone "git://github.com/$(dirname $TRAVIS_REPO_SLUG)/htslib.git" "$HTSDIR" "$TRAVIS_BRANCH"
 
-script: autoreconf -i && (cd $HTSDIR && autoreconf -i && ./configure --prefix=`pwd`/../inst LDFLAGS="$LDFLAGS -Wl,-rpath,`pwd`/../inst/lib" && make install) && (./configure --enable-werror --with-htslib=`pwd`/inst  LDFLAGS="$LDFLAGS -Wl,-rpath,`pwd`/inst/lib" || (cat config.log; /bin/false)) && if test "x$DO_MAINTAINER_CHECKS" = "xyes" ; then make -e maintainer-check ; fi && make -e && make -e test BGZIP=inst/bin/bgzip
+script:
+  - |
+    autoreconf -i && \
+    (cd $HTSDIR && \
+      autoreconf -i && \
+      ./configure --prefix=`pwd`/../inst LDFLAGS="$LDFLAGS -Wl,-rpath,`pwd`/../inst/lib" && \
+      make install \
+    ) && \
+    (./configure --enable-werror --with-htslib=`pwd`/inst  LDFLAGS="$LDFLAGS -Wl,-rpath,`pwd`/inst/lib" || \
+      (cat config.log; /bin/false) \
+    ) && \
+    if test "x$DO_MAINTAINER_CHECKS" = "xyes" ; then
+        make -e maintainer-check
+    fi && \
+    make -e && \
+    make -e test BGZIP=inst/bin/bgzip

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - os: linux
       compiler: clang
       sudo: required
-      env: CFLAGS="-g -Wall -O3 -fsanitize=address" LDFLAGS="-fsanitize=address"
+      env: CFLAGS="-g -Wall -O3 -fsanitize=address" LDFLAGS="-fsanitize=address -Wl,-rpath,`pwd`/inst/lib"
     - os: linux
       compiler: gcc-8
       addons:
@@ -41,7 +41,7 @@ matrix:
 
 env:
   global:
-    - HTSDIR=./htslib
+    - HTSDIR=./hidden-htslib
 
 # For linux systems
 addons:
@@ -63,4 +63,4 @@ before_script:
   # Logic for choosing which to use is in the .travis/clone script.
   - .travis/clone "git://github.com/$(dirname $TRAVIS_REPO_SLUG)/htslib.git" "$HTSDIR" "$TRAVIS_BRANCH"
 
-script: autoreconf -i && (cd htslib && autoreconf -i) && (./configure --enable-werror || (cat config.log; /bin/false)) && if test "x$DO_MAINTAINER_CHECKS" = "xyes" ; then make -e maintainer-check ; fi && make -e && make -e test
+script: autoreconf -i && (cd $HTSDIR && autoreconf -i && ./configure --prefix=`pwd`/../inst LDFLAGS="$LDFLAGS -Wl,-rpath,`pwd`/../inst/lib" && make install) && (./configure --enable-werror --with-htslib=`pwd`/inst  LDFLAGS="$LDFLAGS -Wl,-rpath,`pwd`/inst/lib" || (cat config.log; /bin/false)) && if test "x$DO_MAINTAINER_CHECKS" = "xyes" ; then make -e maintainer-check ; fi && make -e && make -e test BGZIP=inst/bin/bgzip

--- a/bam_reheader.c
+++ b/bam_reheader.c
@@ -35,7 +35,6 @@ DEALINGS IN THE SOFTWARE.  */
 #include "htslib/hfile.h"
 #include "htslib/cram.h"
 #include "samtools.h"
-#include "textutils_internal.h"
 
 #define BUF_SIZE 0x10000
 

--- a/test/maintainer/check_copyright.pl
+++ b/test/maintainer/check_copyright.pl
@@ -41,7 +41,7 @@ exit($errors ? 1 : 0);
 
 sub check {
     # Ignore embedded copied of htslib
-    if (m#/htslib[^/]*$# && -d $_) {
+    if (m#/[^/]*htslib[^/]*$# && -d $_) {
         $File::Find::prune = 1;
         return;
     }

--- a/test/maintainer/check_spaces.pl
+++ b/test/maintainer/check_spaces.pl
@@ -41,7 +41,7 @@ exit($errors ? 1 : 0);
 
 sub check {
     # Ignore embedded copied of htslib
-    if (m#/htslib[^/]*$# && -d $_) {
+    if (m#/[^/]*htslib[^/]*$# && -d $_) {
         $File::Find::prune = 1;
         return;
     }

--- a/test/split/test_filter_header_rg.c
+++ b/test/split/test_filter_header_rg.c
@@ -28,8 +28,9 @@ DEALINGS IN THE SOFTWARE.  */
 #include <unistd.h>
 #include <stdbool.h>
 #include "samtools.h"
-#include "header.h"
-#include "textutils_internal.h"
+#include <string.h>
+#include <stdlib.h>
+#include "htslib/kstring.h"
 
 int line_cmp(const void *av, const void *bv) {
     const char *a = *(const char **) av;


### PR DESCRIPTION
We spot dependence on htslib source rather than htslib install by not letting samtools automatically compile htslib itself.

Note there is some nuance with LDFLAGS shenanigans where we cannot override it as expected due to make -e, so the rpath hackery is duplicated (but harmless).