### PR TITLE
Added the ability to sort unmapped data by minhash.

### DIFF
--- a/bam_sort.c
+++ b/bam_sort.c
@@ -38,6 +38,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <getopt.h>
 #include <assert.h>
 #include <pthread.h>
+#include <inttypes.h>
 #include "htslib/ksort.h"
 #include "htslib/hts_os.h"
 #include "htslib/khash.h"
@@ -98,6 +99,7 @@ KLIST_INIT(hdrln, char*, hdrln_free_char)
 
 static int g_is_by_qname = 0;
 static int g_is_by_tag = 0;
+static int g_is_by_minhash = 0;
 static char g_sort_tag[2] = {0,0};
 
 static int strnum_cmp(const char *_a, const char *_b)
@@ -134,8 +136,11 @@ typedef struct {
 } heap1_t;
 
 static inline int bam1_cmp_by_tag(const bam1_tag a, const bam1_tag b);
+static inline int bam1_cmp_by_minhash(const bam1_tag a, const bam1_tag b);
 
 // Function to compare reads in the heap and determine which one is < the other
+// Note, unlike the bam1_cmp_by_X functions which return <0, 0, >0 this
+// is strictly 0 or 1 only.
 static inline int heap_lt(const heap1_t a, const heap1_t b)
 {
     if (!a.entry.bam_record)
@@ -146,6 +151,9 @@ static inline int heap_lt(const heap1_t a, const heap1_t b)
     if (g_is_by_tag) {
         int t;
         t = bam1_cmp_by_tag(a.entry, b.entry);
+        if (t != 0) return t > 0;
+    } else if (g_is_by_minhash) {
+        int t = bam1_cmp_by_minhash(a.entry, b.entry);
         if (t != 0) return t > 0;
     } else if (g_is_by_qname) {
         int t, fa, fb;
@@ -1699,6 +1707,12 @@ static int bam_merge_simple(int by_qname, char *sort_tag, const char *out,
     ks_heapmake(heap, heap_size, heap);
     while (heap->pos != HEAP_EMPTY) {
         bam1_t *b = heap->entry.bam_record;
+        if (g_is_by_minhash && b->core.tid == -1) {
+            // Remove the cached minhash value
+            b->core.pos = -1;
+            b->core.mpos = -1;
+            b->core.isize = 0;
+        }
         if (sam_write1(fpout, hout, b) < 0) {
             print_error_errno(cmd, "failed writing to \"%s\"", out);
             goto fail;
@@ -1857,12 +1871,45 @@ static inline int bam1_cmp_by_tag(const bam1_tag a, const bam1_tag b)
     }
 }
 
+// Sort by minimiser (stored in bam1_tag.u.pos).
+// If equal, sort by position.
+//
+// The 64-bit sort key is split over the bam pos and isize fields.
+// This permits it to survive writing to temporary file and coming back.
+static inline int bam1_cmp_by_minhash(const bam1_tag a, const bam1_tag b)
+{
+    const bam1_t *A = a.bam_record;
+    const bam1_t *B = b.bam_record;
+
+    if (!A) return 1;
+    if (!B) return 0;
+
+    if (A->core.tid != -1 || B->core.tid != -1)
+        return bam1_cmp_core(a,b);
+
+    const uint64_t m_a = (((uint64_t)A->core.pos)<<32)|(uint32_t)A->core.mpos;
+    const uint64_t m_b = (((uint64_t)B->core.pos)<<32)|(uint32_t)B->core.mpos;
+
+    if (m_a < m_b) // by hash
+        return -1;
+    else if (m_a > m_b)
+        return 1;
+    else if (A->core.isize < B->core.isize) // by hash location in seq
+        return -1;
+    else if (A->core.isize > B->core.isize)
+        return 1;
+    else
+        return bam1_cmp_core(a,b);
+}
+
 // Function to compare reads and determine which one is < the other
 // Handle sort-by-pos, sort-by-name, or sort-by-tag
 static inline int bam1_lt(const bam1_tag a, const bam1_tag b)
 {
     if (g_is_by_tag) {
         return bam1_cmp_by_tag(a, b) < 0;
+    } else if (g_is_by_minhash) {
+        return bam1_cmp_by_minhash(a, b) < 0;
     } else {
         return bam1_cmp_core(a,b) < 0;
     }
@@ -1886,7 +1933,7 @@ typedef struct {
 //        -1 for failure
 static int write_buffer(const char *fn, const char *mode, size_t l, bam1_tag *buf,
                         const sam_hdr_t *h, int n_threads, const htsFormat *fmt,
-                        char *arg_list, int no_pg, int write_index)
+                        int clear_minhash, char *arg_list, int no_pg, int write_index)
 {
     size_t i;
     samFile* fp;
@@ -1894,22 +1941,27 @@ static int write_buffer(const char *fn, const char *mode, size_t l, bam1_tag *bu
 
     fp = sam_open_format(fn, mode, fmt);
     if (fp == NULL) return -1;
-    if (!no_pg && sam_hdr_add_pg((sam_hdr_t *)h, "samtools",
-                                 "VN", samtools_version(),
+    if (!no_pg && sam_hdr_add_pg((sam_hdr_t *)h, "samtools", "VN", samtools_version(),
                                  arg_list ? "CL": NULL,
                                  arg_list ? arg_list : NULL,
                                  NULL)) {
         goto fail;
     }
-    if (sam_hdr_write(fp, (sam_hdr_t *)h) != 0) goto fail;
+    if (sam_hdr_write(fp, h) != 0) goto fail;
 
-    if (write_index) {
+    if (write_index)
         if (!(out_idx_fn = auto_index(fp, fn, (sam_hdr_t *)h))) goto fail;
-    }
 
     if (n_threads > 1) hts_set_threads(fp, n_threads);
     for (i = 0; i < l; ++i) {
-        if (sam_write1(fp, (sam_hdr_t *)h, buf[i].bam_record) < 0) goto fail;
+        bam1_t *b = buf[i].bam_record;
+        if (clear_minhash && b->core.tid == -1) {
+            // Remove the cached minhash value
+            b->core.pos = -1;
+            b->core.mpos = -1;
+            b->core.isize = 0;
+        }
+        if (sam_write1(fp, h, b) < 0) goto fail;
     }
 
     if (write_index) {
@@ -2012,18 +2064,206 @@ err:
     return ret;
 }
 
+/*
+ * Computes the minhash of a sequence using both forward and reverse strands.
+ *
+ * This is used as a sort key for unmapped data, to collate like sequences
+ * together and to improve compression ratio.
+ *
+ * The minhash is returned and *pos filled out with location of this hash
+ * key in the sequence if pos != NULL.
+ */
+static uint64_t minhash(bam1_t *b, int kmer, int *pos, int *rev) {
+    uint64_t hashf = 0, minhashf = UINT64_MAX;
+    uint64_t hashr = 0, minhashr = UINT64_MAX;
+    int minhashpf = 0, minhashpr = 0, i;
+    uint64_t mask = (1L<<(2*kmer))-1;
+    unsigned char *seq = bam_get_seq(b);
+    int len = b->core.l_qseq;
+
+    // Lookup tables for bam_seqi to 0123 fwd/rev hashes
+    // =ACM GRSV TWYH KDBN
+#define X 0
+    unsigned char L[16] = {
+        X,0,1,X,  2,X,X,X,  3,X,X,X,  X,X,X,X,
+    };
+    uint64_t R[16] = {
+        X,3,2,X,  1,X,X,X,  0,X,X,X,  X,X,X,X,
+    };
+    for (i = 0; i < 16; i++)
+        R[i] <<= 2*(kmer-1);
+
+    // Punt homopolymers somewhere central in the hash space
+#define XOR (0xdead7878beef7878 & mask)
+
+    // Initialise hash keys
+    for (i = 0; i < kmer-1 && i < len; i++) {
+        int base = bam_seqi(seq, i);
+        hashf = (hashf<<2) | L[base];
+        hashr = (hashr>>2) | R[base];
+    }
+
+    // Loop to find minimum
+    for (; i < len; i++) {
+        int base = bam_seqi(seq, i);
+
+        hashf = ((hashf<<2) | L[base]) & mask;
+        hashr =  (hashr>>2) | R[base];
+
+        if (minhashf > (hashf^XOR))
+            minhashf = (hashf^XOR), minhashpf = i;
+        if (minhashr > (hashr^XOR))
+            minhashr = (hashr^XOR), minhashpr = len-i+kmer-2;
+
+    }
+
+    if (minhashf <= minhashr) {
+        if (rev) *rev = 0;
+        if (pos) *pos = minhashpf;
+        return minhashf;
+    } else {
+        if (rev) *rev = 1;
+        if (pos) *pos = minhashpr;
+        return minhashr;
+    }
+}
+
+//--- Start of candidates to punt to htslib
+/*!
+ * @abstract
+ * Extracts the sequence (in current alignment orientation) from
+ * a bam record and places it in buf, which is nul terminated.
+ *
+ * @param b     The bam structure
+ * @param buf   A buffer at least b->core.l_qseq+1 bytes long
+ */
+static void bam_to_seq(bam1_t *b, char *buf) {
+    int i;
+    uint8_t *seq = bam_get_seq(b);
+    for (i = 0; i < b->core.l_qseq; i++)
+        buf[i] = seq_nt16_str[bam_seqi(seq, i)];
+    buf[i] = 0;
+}
+
+/*!
+ * @abstract
+ * Writes a new sequence, of length b->core.l_qseq, to a BAM record.
+ *
+ * If a sequence of a new length is required the caller must first make
+ * room for it by updating the bam1_t struct.
+ *
+ * @param b     The bam structure
+ * @param buf   A buffer at least b->core.l_qseq bytes long
+ */
+static void seq_to_bam(bam1_t *b, char *buf) {
+    int i;
+    uint8_t *seq = bam_get_seq(b);
+    for (i = 0; i < b->core.l_qseq; i++)
+        bam_set_seqi(seq, i, seq_nt16_table[(unsigned char)buf[i]]);
+}
+
+/*!
+ * @abstract Reverse complements a BAM record.
+ *
+ * It's possible to do this inline, but complex due to the 4-bit sequence
+ * encoding.  For now I take the dumb approach.
+ *
+ * @param b  Pointer to a BAM alignment
+ *
+ * @return   0 on success, -1 on failure (ENOMEM)
+ */
+static int reverse_complement(bam1_t *b) {
+    static char comp[256] = {
+        'N','N','N','N', 'N','N','N','N', 'N','N','N','N', 'N','N','N','N',//00
+        'N','N','N','N', 'N','N','N','N', 'N','N','N','N', 'N','N','N','N',//10
+        'N','N','N','N', 'N','N','N','N', 'N','N','N','N', 'N','N','N','N',//20
+        'N','N','N','N', 'N','N','N','N', 'N','N','N','N', 'N','N','N','N',//30
+
+       //    *   *   *    *   E   F   *    *   I   J   *    L   *   *   O
+        '@','T','V','G', 'H','E','F','C', 'D','I','H','M', 'L','K','N','O',//40
+       //P   Q   *   *    *   *   *   *    X   Y   Z   [    \   ]   ^   _
+        'P','Q','Y','S', 'A','A','B','W', 'X','Y','Z','[','\\','[','^','_',//50
+       //`   *   *   *    *   E   F   *    *   I   J   *    L   *   *   O
+        '`','t','v','g', 'h','e','f','c', 'd','i','j','m', 'l','k','n','o',//60
+       //P   Q   *   *    *   *   *   *    X   Y   Z   {    |   }   ~   DEL
+        'p','q','y','s', 'a','a','b','w', 'x','y','z','{', '|','}','~',127,//70
+
+        'N','N','N','N', 'N','N','N','N', 'N','N','N','N', 'N','N','N','N',//80
+        'N','N','N','N', 'N','N','N','N', 'N','N','N','N', 'N','N','N','N',//90
+        'N','N','N','N', 'N','N','N','N', 'N','N','N','N', 'N','N','N','N',//A0
+        'N','N','N','N', 'N','N','N','N', 'N','N','N','N', 'N','N','N','N',//B0
+
+        'N','N','N','N', 'N','N','N','N', 'N','N','N','N', 'N','N','N','N',//C0
+        'N','N','N','N', 'N','N','N','N', 'N','N','N','N', 'N','N','N','N',//D0
+        'N','N','N','N', 'N','N','N','N', 'N','N','N','N', 'N','N','N','N',//E0
+        'N','N','N','N', 'N','N','N','N', 'N','N','N','N', 'N','N','N','N',//F0
+    };
+    char seq_[10000], *seq = seq_;
+    uint8_t *qual = bam_get_qual(b);
+    int i, j;
+
+    if (b->core.l_qseq >= 10000)
+        if (!(seq = malloc(b->core.l_qseq+1)))
+            return -1;
+
+    bam_to_seq(b, seq);
+
+    for (i = 0, j = b->core.l_qseq-1; i < j; i++, j--) {
+        unsigned char tmp = seq[i];
+        seq[i] = comp[(unsigned char)seq[j]];
+        seq[j] = comp[tmp];
+        tmp = qual[i];
+        qual[i] = qual[j];
+        qual[j] = tmp;
+    }
+    if (i ==j)
+        seq[i] = comp[(unsigned char)seq[i]];
+
+    seq_to_bam(b, seq);
+
+    if (seq != seq_)
+        free(seq);
+
+    b->core.flag ^= 0x10;
+
+    return 0;
+}
+//--- End of candidates to punt to htslib
+
 static void *worker(void *data)
 {
     worker_t *w = (worker_t*)data;
     char *name;
     w->error = 0;
 
-    if (!g_is_by_qname && !g_is_by_tag) {
+    if (!g_is_by_qname && !g_is_by_tag && !g_is_by_minhash) {
         if (ks_radixsort(w->buf_len, w->buf, w->h) < 0) {
             w->error = errno;
             return NULL;
         }
     } else {
+        if (g_is_by_minhash) {
+            int i;
+            for (i = 0; i < w->buf_len; i++) {
+                bam1_t *b = w->buf[i].bam_record;
+                if (b->core.tid != -1)
+                    continue;
+
+                int pos = 0, rev = 0;
+                uint64_t mh = minhash(b, g_is_by_minhash, &pos, &rev);
+                if (rev)
+                    reverse_complement(b);
+
+                // Store 64-bit hash in unmapped pos and mpos fields.
+                // The position of hash is in isize, which we use for
+                // resolving ties when sorting by hash key.
+                // These are unused for completely unmapped data and
+                // will be reset during final output.
+                b->core.pos = mh>>31;
+                b->core.mpos = mh&0x7fffffff;
+                b->core.isize = 65535-pos >=0 ? 65535-pos : 0;
+            }
+        }
         ks_mergesort(sort, w->buf_len, w->buf, 0);
     }
 
@@ -2051,10 +2291,10 @@ static void *worker(void *data)
             return 0;
         }
 
-        if (write_buffer(name, "wcx1", w->buf_len, w->buf, w->h, 0, &fmt, NULL, 1, 0) < 0)
+        if (write_buffer(name, "wcx1", w->buf_len, w->buf, w->h, 0, &fmt, 0, NULL, 1, 0) < 0)
             w->error = errno;
     } else {
-        if (write_buffer(name, "wbx1", w->buf_len, w->buf, w->h, 0, NULL, NULL, 1, 0) < 0)
+        if (write_buffer(name, "wbx1", w->buf_len, w->buf, w->h, 0, NULL, 0, NULL, 1, 0) < 0)
             w->error = errno;
     }
 
@@ -2111,6 +2351,7 @@ static int sort_blocks(int n_files, size_t k, bam1_tag *buf, const char *prefix,
     return n_files + n_threads;
 }
 
+
 /*!
   @abstract Sort an unsorted BAM file based on the chromosome order
   and the leftmost position of an alignment
@@ -2135,7 +2376,7 @@ static int sort_blocks(int n_files, size_t k, bam1_tag *buf, const char *prefix,
  */
 int bam_sort_core_ext(int is_by_qname, char* sort_by_tag, const char *fn, const char *prefix,
                       const char *fnout, const char *modeout,
-                      size_t _max_mem, int n_threads,
+                      size_t _max_mem, int by_minimiser, int n_threads,
                       const htsFormat *in_fmt, const htsFormat *out_fmt,
                       char *arg_list, int no_pg, int write_index)
 {
@@ -2158,6 +2399,7 @@ int bam_sort_core_ext(int is_by_qname, char* sort_by_tag, const char *fn, const 
 
     if (n_threads < 2) n_threads = 1;
     g_is_by_qname = is_by_qname;
+    g_is_by_minhash = by_minimiser;
     if (sort_by_tag) {
         g_is_by_tag = 1;
         g_sort_tag[0] = sort_by_tag[0];
@@ -2184,11 +2426,23 @@ int bam_sort_core_ext(int is_by_qname, char* sort_by_tag, const char *fn, const 
     else
         new_so = "coordinate";
 
-    if ((-1 == sam_hdr_update_hd(header, "SO", new_so))
-     && (-1 == sam_hdr_add_line(header, "HD", "VN", SAM_FORMAT_VERSION, "SO", new_so, NULL))
-     ) {
-        print_error("sort", "failed to change sort order header to '%s'\n", new_so);
-        goto err;
+    if (by_minimiser) {
+        const char *new_ss = "coordinate:minhash";
+        if ((-1 == sam_hdr_update_hd(header, "SO", new_so, "SS", new_ss))
+            && (-1 == sam_hdr_add_line(header, "HD", "VN", SAM_FORMAT_VERSION,
+                                       "SO", new_so, "SS", new_ss, NULL))
+            ) {
+            print_error("sort", "failed to change sort order header to 'SO:%s SS:%s'\n",
+                        new_so, new_ss);
+            goto err;
+        }
+    } else {
+        if ((-1 == sam_hdr_update_hd(header, "SO", new_so))
+            && (-1 == sam_hdr_add_line(header, "HD", "VN", SAM_FORMAT_VERSION, "SO", new_so, NULL))
+            ) {
+            print_error("sort", "failed to change sort order header to 'SO:%s'\n", new_so);
+            goto err;
+        }
     }
 
     if (-1 == sam_hdr_remove_tag_hd(header, "GO")) {
@@ -2275,7 +2529,8 @@ int bam_sort_core_ext(int is_by_qname, char* sort_by_tag, const char *fn, const 
 
     // write the final output
     if (n_files == 0 && num_in_mem < 2) { // a single block
-        if (write_buffer(fnout, modeout, k, buf, header, n_threads, out_fmt, arg_list, no_pg, write_index) != 0) {
+        if (write_buffer(fnout, modeout, k, buf, header, n_threads, out_fmt,
+                         g_is_by_minhash, arg_list, no_pg, write_index) != 0) {
             print_error_errno("sort", "failed to create \"%s\"", fnout);
             goto err;
         }
@@ -2329,7 +2584,7 @@ int bam_sort_core(int is_by_qname, const char *fn, const char *prefix, size_t ma
     char *fnout = calloc(strlen(prefix) + 4 + 1, 1);
     if (!fnout) return -1;
     sprintf(fnout, "%s.bam", prefix);
-    ret = bam_sort_core_ext(is_by_qname, NULL, fn, prefix, fnout, "wb", max_mem, 0, NULL, NULL, NULL, 1, 0);
+    ret = bam_sort_core_ext(is_by_qname, NULL, fn, prefix, fnout, "wb", max_mem, 0, 0, NULL, NULL, NULL, 1, 0);
     free(fnout);
     return ret;
 }
@@ -2341,6 +2596,8 @@ static void sort_usage(FILE *fp)
 "Options:\n"
 "  -l INT     Set compression level, from 0 (uncompressed) to 9 (best)\n"
 "  -m INT     Set maximum memory per thread; suffix K/M/G recognized [768M]\n"
+"  -M         Use minimiser for clustering unaligned/unplaced reads\n"
+"  -K INT     Kmer size to use for minimiser [20]\n"
 "  -n         Sort by read name\n"
 "  -t TAG     Sort by value of TAG. Uses position as secondary index (or read name if -n is set)\n"
 "  -o FILE    Write final output to FILE rather than standard output\n"
@@ -2370,6 +2627,7 @@ int bam_sort(int argc, char *argv[])
 {
     size_t max_mem = SORT_DEFAULT_MEGS_PER_THREAD << 20;
     int c, nargs, is_by_qname = 0, ret, o_seen = 0, level = -1, no_pg = 0;
+    int by_minimiser = 0, minimiser_kmer = 20;
     char* sort_tag = NULL, *arg_list = NULL;
     char *fnout = "-", modeout[12];
     kstring_t tmpprefix = { 0, 0, NULL };
@@ -2383,7 +2641,7 @@ int bam_sort(int argc, char *argv[])
         { NULL, 0, NULL, 0 }
     };
 
-    while ((c = getopt_long(argc, argv, "l:m:no:O:T:@:t:", lopts, NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "l:m:no:O:T:@:t:MK:", lopts, NULL)) >= 0) {
         switch (c) {
         case 'o': fnout = optarg; o_seen = 1; break;
         case 'n': is_by_qname = 1; break;
@@ -2398,7 +2656,15 @@ int bam_sort(int argc, char *argv[])
             }
         case 'T': kputs(optarg, &tmpprefix); break;
         case 'l': level = atoi(optarg); break;
-        case 1: no_pg = 1; break;
+        case   1: no_pg = 1; break;
+        case 'M': by_minimiser = 1; break;
+        case 'K':
+            minimiser_kmer = atoi(optarg);
+            if (minimiser_kmer < 1)
+                minimiser_kmer = 1;
+            else if (minimiser_kmer > 31)
+                minimiser_kmer = 31;
+            break;
 
         default:  if (parse_sam_global_opt(c, optarg, lopts, &ga) == 0) break;
                   /* else fall-through */
@@ -2453,7 +2719,8 @@ int bam_sort(int argc, char *argv[])
     }
 
     ret = bam_sort_core_ext(is_by_qname, sort_tag, (nargs > 0)? argv[optind] : "-",
-                            tmpprefix.s, fnout, modeout, max_mem, ga.nthreads,
+                            tmpprefix.s, fnout, modeout, max_mem,
+                            by_minimiser * minimiser_kmer, ga.nthreads,
                             &ga.in, &ga.out, arg_list, no_pg, ga.write_index);
     if (ret >= 0)
         ret = EXIT_SUCCESS;

--- a/doc/samtools-sort.1
+++ b/doc/samtools-sort.1
@@ -51,6 +51,9 @@ samtools sort
 .IR out.bam ]
 .RB [ -O
 .IR format ]
+.RB [ -M ]
+.RB [ -K
+.IR kmerLen ]
 .RB [ -n ]
 .RB [ -t
 .IR tag ]
@@ -88,6 +91,9 @@ instead if you need name collated data without a full lexicographical sort.
 .SH OPTIONS
 
 .TP 11
+.BI "-K " INT
+Sets the kmer size to be used in the \fB-M\fR option. [20]
+.TP
 .BI "-l " INT
 Set the desired compression level for the final output file, ranging from 0
 (uncompressed) or 1 (fastest but minimal compression) to 9 (best compression
@@ -108,6 +114,17 @@ suffix.
 .IP
 To prevent sort from creating a huge number of temporary files, it enforces a
 minimum value of 1M for this setting.
+.TP
+.B "-M "
+Sort unmapped reads (those in chromosome "*") by their sequence
+minimiser (Schleimer et al., 2003; Roberts et al., 2004), also reverse
+complementing as appropriate.  This has the effect of collating some
+similar data together, improving the compressibility of the unmapped
+sequence.  The minimiser kmer size is adjusted using the \fB-K\fR
+option.  Note data compressed in this manner may need to be name
+collated prior to conversion back to fastq.
+.IP
+Mapped sequences are sorted by chromosome and position.
 .TP
 .B -n
 Sort by read names (i.e., the


### PR DESCRIPTION
This has the effect of clumping similar sequences together, improving
the efficiency of LZ based compression methods.  This is extremely
simplistic with a single kmer and no assembly of minhashes into
contigs.  Hence it's not going to achieve ratios like Minicom (which
uses sketches), but it is fast, uses minimal memory and is achievable
as part of "samtools sort".

Credit for ideas also go to Tony Cox from Illumina.

Some stats on SRR445724.fastq (as unaligned SAM):

```
            bpb         ctime   dtime
Spring      0.4041      1986    374     (tested on seq3, -q bsc -i)
CRAM        1.9494         ?      ?     (default CRAM)
CRAM-M20    0.6306       148     26     (dtime from view -c -@8)
"+Z7s100k   0.5055       677     27     (archive mode for V3.0)
v31-small   0.5017      +498     46     (scramble -V3.1 -Xsmall -s100000 -Z -7 -t8)
```

Total file sizes:
```
-rw-r--r-- 1 jkb team117 3214122305 Aug 14 15:27 /tmp/_1.cram (orig)
-rw-r--r-- 1 jkb team117 2611100075 Aug 14 15:30 /tmp/_2.cram (minhash20)
-rw-r--r-- 1 jkb team117 2404005175 Aug 14 15:44 /tmp/_3.cram ("+Z7s100k)
-rw-r--r-- 1 jkb team117 2090644964 Aug 14 16:21 /tmp/_4.cram (V3.1 small)
-rw-r--r-- 1 jkb team117 2004008960 Aug 14 16:52 SRR445724.spring
```
Not super compression unless we engage slow modes, but a big win for
not much CPU expenditure.