### PR TITLE
Add PG lines with view

### DIFF
--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -349,6 +349,9 @@ of input.
 Include customized index file as a part of arugments. See
 .B EXAMPLES
 section for sample of useage.
+.TP
+.B --no-PG
+Do not add a @PG line to the header of the output file.
 
 .SH EXAMPLES
 .IP o 2

--- a/test/dat/view.004.expected.sam
+++ b/test/dat/view.004.expected.sam
@@ -1,0 +1,64 @@
+@HD	VN:1.4	SO:coordinate
+@RG	ID:grp1	DS:Group 1	LB:Library 1	SM:Sample
+@RG	ID:grp2	DS:Group 2	LB:Library 2	SM:Sample
+@RG	ID:grp3	DS:Group 3	SM:Sample
+@PG	ID:prog1	PN:emacs	CL:emacs	VN:23.1.1
+@PG	ID:samtools	PN:samtools	PP:prog1
+@CO	The MIT License
+@CO	
+@CO	Copyright (c) 2014 Genome Research Ltd.
+@CO	
+@CO	Permission is hereby granted, free of charge, to any person obtaining a copy
+@CO	of this software and associated documentation files (the "Software"), to deal
+@CO	in the Software without restriction, including without limitation the rights
+@CO	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+@CO	copies of the Software, and to permit persons to whom the Software is
+@CO	furnished to do so, subject to the following conditions:
+@CO	
+@CO	The above copyright notice and this permission notice shall be included in
+@CO	all copies or substantial portions of the Software.
+@CO	
+@CO	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+@CO	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+@CO	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+@CO	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+@CO	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+@CO	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+@CO	THE SOFTWARE.
+@SQ	SN:ref1	LN:56	M5:08c04d512d4797d9ba2a156c1daba468
+@SQ	SN:ref2	LN:60	M5:7c35feac7036c1cdef3bee0cc4b21437
+@SQ	SN:ref3_unused	LN:70	M5:5fdd18c2c6ecac4838996d029bf395b5
+ref1_grp1_p001	99	ref1	1	0	10M	=	25	34	CGAGCTCGGT	!!!!!!!!!!	RG:Z:grp1	BC:Z:ACGT	H0:i:1	aa:A:!	ab:A:~	fa:f:3.14159	za:Z:Hello world!	ha:H:DEADBEEF	ba:B:c,-128,0,127	bb:B:C,0,127,255	bc:B:s,-32768,0,32767	bd:B:S,0,32768,65535	be:B:i,-2147483648,0,2147483647	bf:B:I,0,2147483648,4294967295	bg:B:f,2.71828,6.626e-34,2.9979e+09	NM:i:0	MD:Z:10
+ref1_grp2_p001	99	ref1	3	1	10M	=	27	34	AGCTCGGTAC	""""""""""	RG:Z:grp2	BC:Z:TGCA	H0:i:1	aa:A:A	ab:A:Z	fa:f:6.67e-11	za:Z:!"$%^&*()	ha:H:CAFE	NM:i:0	MD:Z:10
+ref1_grp1_p002	99	ref1	5	2	10M	=	29	34	CTCGGTACCC	##########	RG:Z:grp1	BC:Z:AATTCCGG	H0:i:1	aa:A:a	ab:A:z	fa:f:4.3597e-18	za:Z:Another string	ha:H:2000AD	NM:i:0	MD:Z:10
+ref1_grp2_p002	99	ref1	7	3	10M	=	31	34	CGGTACCCGG	$$$$$$$$$$	fa:f:6.022e+23	RG:Z:grp2	NM:i:0	MD:Z:10
+ref1_grp1_p003	99	ref1	9	4	10M	=	33	34	GTACCCGGGG	%%%%%%%%%%	fa:f:1.66e-27	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp2_p003	99	ref1	11	5	10M	=	35	34	ACCCGGGGAT	&&&&&&&&&&	RG:Z:grp2	ia:i:4294967295	NM:i:0	MD:Z:10
+ref1_grp1_p004	99	ref1	13	6	10M	=	37	34	CCGGGGATCC	''''''''''	fa:f:1.38e-23	za:Z:xRG:Z:grp2	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp2_p004	99	ref1	15	7	10M	=	39	34	GGGGATCCTC	((((((((((	RG:Z:grp2	ia:i:-2147483648	NM:i:0	MD:Z:10
+ref1_grp1_p005	99	ref1	17	8	10M	=	41	34	GGATCCTCTA	))))))))))	RG:Z:grp1	ia:i:40000	NM:i:0	MD:Z:10
+ref1_grp2_p005	99	ref1	19	9	10M	=	43	34	ATCCTCTAGA	**********	RG:Z:grp2	ia:i:-1000	NM:i:0	MD:Z:10
+ref1_grp1_p006	99	ref1	21	10	10M	=	45	34	CCTCTAGAGT	++++++++++	RG:Z:grp1	ia:i:255	NM:i:0	MD:Z:10
+ref1_grp2_p006	99	ref1	23	11	10M	=	47	34	TCTAGAGTCG	,,,,,,,,,,	RG:Z:grp2	ia:i:-1	NM:i:0	MD:Z:10
+ref1_grp1_p001	147	ref1	25	12	10M	=	1	-34	TAGAGTCGAC	----------	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp2_p001	147	ref1	27	13	10M	=	3	-34	GAGTCGACCT	..........	RG:Z:grp2	NM:i:0	MD:Z:10
+ref1_grp1_p002	147	ref1	29	14	10M	=	5	-34	GTCGACCTGC	//////////	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp2_p002	147	ref1	31	15	10M	=	7	-34	CGACCTGCAG	0000000000	RG:Z:grp2	NM:i:0	MD:Z:10
+ref1_grp1_p003	147	ref1	33	16	10M	=	9	-34	ACCTGCAGGC	1111111111	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp2_p003	147	ref1	35	17	10M	=	11	-34	CTGCAGGCAT	2222222222	RG:Z:grp2	NM:i:0	MD:Z:10
+ref12_grp1_p001	97	ref1	36	50	10M	ref2	2	0	TGCAGGCATG	AAAAAAAAAA	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp1_p004	147	ref1	37	18	10M	=	13	-34	GCAGGCATGC	3333333333	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp2_p004	147	ref1	39	19	10M	=	15	-34	AGGCATGCAA	4444444444	RG:Z:grp2	NM:i:0	MD:Z:10
+ref1_grp1_p005	147	ref1	41	20	10M	=	17	-34	GCATGCAAGC	5555555555	RG:Z:grp1	NM:i:0	MD:Z:10
+ref1_grp2_p005	147	ref1	43	21	10M	=	19	-34	ATGCAAGCTT	6666666666	RG:Z:grp2	NM:i:0	MD:Z:10
+ref1_grp1_p006	147	ref1	45	22	10M	=	21	-34	GCAAGCTTGA	7777777777	RG:Z:grp1	NM:i:0	MD:Z:10
+ref12_grp2_p001	97	ref1	46	50	10M	ref2	12	0	CAAGCTTGAG	AAAAAAAAAA	RG:Z:grp2	NM:i:0	MD:Z:10
+ref1_grp2_p006	147	ref1	47	23	10M	=	23	-34	AAGCTTGAGT	8888888888	RG:Z:grp2	NM:i:0	MD:Z:10
+ref2_grp3_p001	83	ref2	1	99	15M	=	31	45	ATTCTATAGTGTCAC	~~~~~~~~~~~~~~~	RG:Z:grp3	NM:i:0	MD:Z:15
+ref12_grp1_p001	145	ref2	2	50	10M	ref1	36	0	TTCTATAGTG	BBBBBBBBBB	RG:Z:grp1	NM:i:0	MD:Z:10
+ref12_grp2_p001	145	ref2	12	50	10M	ref1	46	0	TCACCTAAAT	BBBBBBBBBB	RG:Z:grp2	NM:i:0	MD:Z:10
+ref2_grp3_p002	147	ref2	16	99	15M	=	46	45	CTAAATAGCTTGGCG	}}}}}}}}}}}}}}}	RG:Z:grp3	NM:i:0	MD:Z:15
+ref2_grp3_p001	163	ref2	31	99	15M	=	1	-45	CTGTTTCCTGTGTGA	|||||||||||||||	RG:Z:grp3	NM:i:13	MD:Z:0T0A0A1C0A0T0G0G0T0C0A1A0G0
+ref2_grp3_p002	99	ref2	46	99	15M	=	16	-45	CTGTTTCCTGTGTGA	{{{{{{{{{{{{{{{	RG:Z:grp3	NM:i:0	MD:Z:15
+unaligned_grp3_p001	77	*	0	0	*	*	0	0	CACTCGTTCATGACG	0123456789abcde	RG:Z:grp3
+unaligned_grp3_p001	141	*	0	0	*	*	0	0	GAAAGTGAGGAGGTG	edcba9876543210	RG:Z:grp3

--- a/test/test.pl
+++ b/test/test.pl
@@ -1294,7 +1294,7 @@ sub run_view_test
     if (!$res && $args{compare_sam} && $args{out}) {
         # Convert output back to sam and compare
         my $sam_name = "$args{out}.sam";
-        my @cmd2 = ("$$opts{bin}/samtools", 'view', '-h');
+        my @cmd2 = ("$$opts{bin}/samtools", 'view', '-h', '--no-PG');
         if (!$args{pipe}) {
             push(@cmd2, '-o', $sam_name);
         }
@@ -1596,9 +1596,8 @@ sub bam_compare
         if (!defined($bytes2)) { die "Error reading $bam2 : $!\n"; }
         if ($bytes1 != $bytes2 || $buffer1 ne $buffer2) {
             $fail = 1;
-            last;
         }
-    } while ($bytes1 && $bytes2);
+    } while ($bytes1 && $bytes2 && !$fail);
     close($b1) || die "Error running bgzip -c -d $bam1\n";
     close($b2) || die "Error running bgzip -c -d $bam2\n";
     if ($fail) {
@@ -1838,7 +1837,7 @@ sub test_view
     my $bam_with_ur_out = sprintf("%s.test%03d.bam", $out, $test);
     run_view_test($opts,
                   msg => "$test: SAM -> BAM -> SAM",
-                  args => ['-b', $sam_with_ur],
+                  args => ['-b', $sam_with_ur, '--no-PG'],
                   out => $bam_with_ur_out,
                   compare_sam => $sam_with_ur);
     $test++;
@@ -1847,13 +1846,13 @@ sub test_view
     my $uncomp_bam = sprintf("%s.test%03d.bam", $out, $test);
     run_view_test($opts,
                   msg => "$test: SAM -> uncompressed BAM",
-                  args => ['-u', $sam_with_ur],
+                  args => ['-u', $sam_with_ur, '--no-PG'],
                   out => $uncomp_bam,
                   compare_bam => $bam_with_ur_out);
     $test++;
     run_view_test($opts,
                   msg => "$test: uncompressed BAM -> SAM and compare",
-                  args => ['-h', $uncomp_bam],
+                  args => ['-h', $uncomp_bam, '--no-PG'],
                   out => sprintf("%s.test%03d.sam", $out, $test),
                   compare => $sam_with_ur);
     $test++;
@@ -1862,13 +1861,13 @@ sub test_view
     my $fastcomp_bam = sprintf("%s.test%03d.bam", $out, $test);
     run_view_test($opts,
                   msg => "$test: SAM -> fast compressed BAM",
-                  args => ['-1', $sam_with_ur],
+                  args => ['-1', $sam_with_ur, '--no-PG'],
                   out => $fastcomp_bam,
                   compare_bam => $bam_with_ur_out);
     $test++;
     run_view_test($opts,
                   msg => "$test: fast compressed BAM -> SAM and compare",
-                  args => ['-h', $fastcomp_bam],
+                  args => ['-h', $fastcomp_bam, '--no-PG'],
                   out => sprintf("%s.test%03d.sam", $out, $test),
                   compare => $sam_with_ur);
     $test++;
@@ -1877,7 +1876,7 @@ sub test_view
     my $cram_with_ur_out = sprintf("%s.test%03d.cram", $out, $test);
     run_view_test($opts,
                   msg => "$test: SAM -> CRAM -> SAM (UR header tags)",
-                  args => ['-C', $sam_with_ur],
+                  args => ['-C', $sam_with_ur, '--no-PG'],
                   out => $cram_with_ur_out,
                   compare_sam => $sam_with_ur);
     $test++;
@@ -1885,7 +1884,7 @@ sub test_view
     # SAM -> CRAM -> SAM with M5 tags
     run_view_test($opts,
                   msg => "$test: SAM -> CRAM -> SAM (M5 header tags)",
-                  args => ['-C', $sam_no_ur],
+                  args => ['-C', $sam_no_ur, '--no-PG'],
                   out => sprintf("%s.test%03d.cram", $out, $test),
                   compare_sam => $sam_no_ur,
                   ref_path => $ref_path);
@@ -1895,7 +1894,7 @@ sub test_view
     my $cram_from_bam = sprintf("%s.test%03d.cram", $out, $test);
     run_view_test($opts,
                   msg => "$test: BAM -> CRAM with UR -> SAM",
-                  args => ['-C', $bam_with_ur_out],
+                  args => ['-C', $bam_with_ur_out, '--no-PG'],
                   out => $cram_from_bam,
                   compare_sam => $sam_with_ur);
     $test++;
@@ -1904,14 +1903,14 @@ sub test_view
     my $bam_no_ur = sprintf("%s.test%03d.bam", $out, $test);
     run_view_test($opts,
                   msg => "$test: SAM -> BAM (M5 header tags)",
-                  args => ['-b', $sam_no_ur],
+                  args => ['-b', $sam_no_ur, '--no-PG'],
                   out => $bam_no_ur,
                   compare_sam => $sam_no_ur);
     $test++;
     my $cram_no_ur = sprintf("%s.test%03d.cram", $out, $test);
     run_view_test($opts,
                   msg => "$test: SAM -> BAM -> CRAM -> SAM (M5 header tags)",
-                  args => ['-C', $bam_no_ur],
+                  args => ['-C', $bam_no_ur, '--no-PG'],
                   out => $cram_no_ur,
                   compare_sam => $sam_no_ur,
                   ref_path => $ref_path);
@@ -1921,7 +1920,7 @@ sub test_view
     my $bam_from_cram = sprintf("%s.test%03d.bam", $out, $test);
     run_view_test($opts,
                   msg => "$test: CRAM -> BAM with UR",
-                  args => ['-b', $cram_from_bam],
+                  args => ['-b', $cram_from_bam, '--no-PG'],
                   out => $bam_from_cram,
                   compare_sam => $sam_with_ur);
     $test++;
@@ -1929,7 +1928,7 @@ sub test_view
     # SAM -> BAM -> CRAM -> BAM -> SAM with M5 tags
     run_view_test($opts,
                   msg => "$test: CRAM -> BAM with M5",
-                  args => ['-b', $cram_no_ur],
+                  args => ['-b', $cram_no_ur, '--no-PG'],
                   out => sprintf("%s.test%03d.bam", $out, $test),
                   compare_sam => $sam_no_ur,
                   ref_path => $ref_path);
@@ -1938,14 +1937,14 @@ sub test_view
     # Write to stdout
     run_view_test($opts,
                   msg => "$test: SAM -> SAM via stdout",
-                  args => ['-h', $sam_with_ur],
+                  args => ['-h', $sam_with_ur, '--no-PG'],
                   out => sprintf("%s.test%03d.sam", $out, $test),
                   redirect => 1,
                   compare => $sam_with_ur);
     $test++;
     run_view_test($opts,
                   msg => "$test: SAM -> BAM via stdout",
-                  args => ['-b', $sam_with_ur],
+                  args => ['-b', $sam_with_ur, '--no-PG'],
                   out => sprintf("%s.test%03d.bam", $out, $test),
                   redirect => 1,
                   compare_bam => $bam_with_ur_out);
@@ -1953,7 +1952,7 @@ sub test_view
     my $cram_via_stdout = sprintf("%s.test%03d.cram", $out, $test);
     run_view_test($opts,
                   msg => "$test: SAM -> CRAM via stdout",
-                  args => ['-C', $sam_with_ur],
+                  args => ['-C', $sam_with_ur, '--no-PG'],
                   out => $cram_via_stdout,
                   redirect => 1,
                   compare_sam => $sam_with_ur);
@@ -1962,21 +1961,21 @@ sub test_view
     # Read from stdin
     run_view_test($opts,
                   msg => "$test: SAM from stdin -> SAM",
-                  args => ['-h', '-'],
+                  args => ['-h', '-', '--no-PG'],
                   out => sprintf("%s.test%03d.sam", $out, $test),
                   stdin => $sam_with_ur,
                   compare => $sam_with_ur);
     $test++;
     run_view_test($opts,
                   msg => "$test: BAM from stdin -> SAM",
-                  args => ['-h', '-'],
+                  args => ['-h', '-', '--no-PG'],
                   out => sprintf("%s.test%03d.sam", $out, $test),
                   stdin => $bam_with_ur_out,
                   compare => $sam_with_ur);
     $test++;
     run_view_test($opts,
                   msg => "$test: CRAM from stdin -> SAM",
-                  args => ['-h', '-'],
+                  args => ['-h', '-', '--no-PG'],
                   out => sprintf("%s.test%03d.sam", $out, $test),
                   stdin => $cram_with_ur_out,
                   compare => $sam_with_ur);
@@ -1989,19 +1988,19 @@ sub test_view
 
     run_view_test($opts,
                   msg => "$test: samtools view -H (SAM input)",
-                  args => ['-H', $sam_with_ur],
+                  args => ['-H', $sam_with_ur, '--no-PG'],
                   out => sprintf("%s.test%03d.header", $out, $test),
                   compare => $sam_header);
     $test++;
     run_view_test($opts,
                   msg => "$test: samtools view -H (BAM input)",
-                  args => ['-H', $bam_with_ur_out],
+                  args => ['-H', $bam_with_ur_out, '--no-PG'],
                   out => sprintf("%s.test%03d.header", $out, $test),
                   compare => $sam_header);
     $test++;
     run_view_test($opts,
                   msg => "$test: samtools view -H (CRAM input)",
-                  args => ['-H', $cram_with_ur_out],
+                  args => ['-H', $cram_with_ur_out, '--no-PG'],
                   out => sprintf("%s.test%03d.header", $out, $test),
                   compare => $sam_header);
     $test++;
@@ -2012,19 +2011,19 @@ sub test_view
 
     run_view_test($opts,
                   msg => "$test: No headers (SAM input)",
-                  args => [$sam_with_ur],
+                  args => [$sam_with_ur, '--no-PG'],
                   out => sprintf("%s.test%03d.body", $out, $test),
                   compare => $sam_body);
     $test++;
     run_view_test($opts,
                   msg => "$test: No headers (BAM input)",
-                  args => [$bam_with_ur_out],
+                  args => [$bam_with_ur_out, '--no-PG'],
                   out => sprintf("%s.test%03d.body", $out, $test),
                   compare => $sam_body);
     $test++;
     run_view_test($opts,
                   msg => "$test: No headers (CRAM input)",
-                  args => [$cram_with_ur_out],
+                  args => [$cram_with_ur_out, '--no-PG'],
                   out => sprintf("%s.test%03d.body", $out, $test),
                   compare => $sam_body);
     $test++;
@@ -2114,7 +2113,7 @@ sub test_view
             # Filter test
             run_view_test($opts,
                           msg => "$test: Filter @{$$filter[2]} ($$ip[0] input)",
-                          args => ['-h', @{$$filter[2]}, $$ip[1]],
+                          args => ['-h', @{$$filter[2]}, $$ip[1], '--no-PG'],
                           out => sprintf("%s.test%03d.sam", $out, $test),
                           compare => $sam_file,
                           expect_fail => $$filter[3]);
@@ -2123,7 +2122,7 @@ sub test_view
             # Count test
             run_view_test($opts,
                           msg => "$test: Count @{$$filter[2]} ($$ip[0] input)",
-                          args => ['-c', @{$$filter[2]}, $$ip[1]],
+                          args => ['-c', @{$$filter[2]}, $$ip[1], '--no-PG'],
                           out => sprintf("%s.test%03d.count", $out, $test),
                           redirect => 1,
                           compare_count => $sam_file,
@@ -2140,14 +2139,14 @@ sub test_view
     my $bam_with_ur_out2 = sprintf("%s.test%03d.bam", $out, $test);
     run_view_test($opts,
                   msg => "$test: 1bp reads file SAM -> BAM -> SAM",
-                  args => ['-b', $sam_with_ur2],
+                  args => ['-b', $sam_with_ur2, '--no-PG'],
                   out => $bam_with_ur_out2,
                   compare_sam => $sam_with_ur2);
     $test++;
     my $cram_with_ur_out2 = sprintf("%s.test%03d.cram", $out, $test);
     run_view_test($opts,
                   msg => "$test: 1bp reads file SAM -> CRAM -> SAM",
-                  args => ['-C', $sam_with_ur2],
+                  args => ['-C', $sam_with_ur2, '--no-PG'],
                   out => $cram_with_ur_out2,
                   compare_sam => $sam_with_ur2);
 
@@ -2250,14 +2249,14 @@ sub test_view
             # Region test
             run_view_test($opts,
                           msg => "$test: Region @{$$rt[3]} @{$$rt[4]} ($$ip[0] input)",
-                          args => ['-h', @{$$rt[3]}, $input_file, @{$$rt[4]}],
+                          args => ['-h', @{$$rt[3]}, $input_file, @{$$rt[4]}, '--no-PG'],
                           out => sprintf("%s.test%03d.sam", $out, $test),
                           compare => $sam_file);
             $test++;
             # Count test
             run_view_test($opts,
                           msg => "$test: Count @{$$rt[3]} @{$$rt[4]} ($$ip[0] input)",
-                          args => ['-c', @{$$rt[3]}, $input_file, @{$$rt[4]}],
+                          args => ['-c', @{$$rt[3]}, $input_file, @{$$rt[4]}, '--no-PG'],
                           out => sprintf("%s.test%03d.count", $out, $test),
                           redirect => 1,
                           compare_count => $sam_file);
@@ -2276,7 +2275,7 @@ sub test_view
     my $bam_no_m5 = "$$opts{tmp}/view.001.no_sq.bam";
     run_view_test($opts,
                   msg => "$test: Make BAM with no M5/UR tags",
-                  args => ['-b', $sam_no_m5],
+                  args => ['-b', $sam_no_m5, '--no-PG'],
                   out => $bam_no_m5,
                   compare_sam => $sam_no_m5);
     $test++;
@@ -2289,7 +2288,7 @@ sub test_view
         foreach my $topt (['-t', $ref_idx], ['-T', $ref_file]) {
             run_view_test($opts,
                           msg => "$test: Add \@SQ with $topt->[0] ($in->[0] -> SAM)",
-                          args => ['-h', @$topt, $in->[1]],
+                          args => ['-h', @$topt, $in->[1], '--no-PG'],
                           out => sprintf("%s.test%03d.sam", $out, $test),
                           compare => $sam_no_m5);
             $test++;
@@ -2302,7 +2301,7 @@ sub test_view
             my $bam = sprintf("%s.test%03d.bam", $out, $test);
             run_view_test($opts,
                           msg => "$test: Add \@SQ with $topt->[0] ($in->[0] -> BAM)",
-                          args => ['-b', @$topt, $in->[1]],
+                          args => ['-b', @$topt, $in->[1], '--no-PG'],
                           out => $bam,
                           compare_sam => $sam_no_m5);
             $test++;
@@ -2315,7 +2314,7 @@ sub test_view
             my $cram = sprintf("%s.test%03d.cram", $out, $test);
             run_view_test($opts,
                           msg => "$test: Add \@SQ with $topt->[0] ($in->[0] -> CRAM)",
-                          args => ['-C', @$topt, $in->[1]],
+                          args => ['-C', @$topt, $in->[1], '--no-PG'],
                           out => $cram,
                           compare_sam => $sam_with_ur);
             $test++;
@@ -2326,14 +2325,14 @@ sub test_view
     my $cram_no_ur_t = sprintf("%s.test%03d.cram", $out, $test);
     run_view_test($opts,
                   msg => "$test: Make CRAM with no UR field",
-                  args => ['-C', $sam_no_ur],
+                  args => ['-C', $sam_no_ur, '--no-PG'],
                   ref_path => "$$opts{path}/dat/cram_md5",
                   out => $cram_no_ur_t);
     $test++;
 
     run_view_test($opts,
                   msg => "$test: Decoding CRAM with no UR field via -T",
-                  args => ['-T', $ref_file, $cram_no_ur_t],
+                  args => ['-T', $ref_file, $cram_no_ur_t, '--no-PG'],
                   out => sprintf("%s.test%03d.sam", $out, $test),
                   compare => $sam_no_ur);
     $test++;
@@ -2344,7 +2343,7 @@ sub test_view
     my $b_op_expected = "$$opts{path}/dat/view.003.expected.sam";
     run_view_test($opts,
                   msg => "$test: CIGAR B-operator removal",
-                  args => ['-h', '-B', $b_op_sam],
+                  args => ['-h', '-B', $b_op_sam, '--no-PG'],
                   out => sprintf("%s.test%03d.sam", $out, $test),
                   compare => $b_op_expected);
     $test++;
@@ -2354,14 +2353,14 @@ sub test_view
     my $big_bam = sprintf("%s.test%03d.bam", $out, $test);
     run_view_test($opts,
                   msg => "$test: Big SAM -> BAM",
-                  args => ['-b', $big_sam],
+                  args => ['-b', $big_sam, '--no-PG'],
                   out => $big_bam);
     $test++;
 
     foreach my $threads (2, 4) {
         run_view_test($opts,
                       msg => "$test: Big SAM -> BAM ($threads threads)",
-                      args => ['-b', '-@', $threads, $big_sam],
+                      args => ['-b', '-@', $threads, $big_sam, '--no-PG'],
                       out => sprintf("%s.test%03d.bam", $out, $test),
                       compare_bam => $big_bam);
         $test++;
@@ -2371,7 +2370,7 @@ sub test_view
     my $big_cram = sprintf("%s.test%03d.cram", $out, $test);
     run_view_test($opts,
                   msg => "$test: Big SAM -> CRAM",
-                  args => ['-C', $big_sam],
+                  args => ['-C', $big_sam, '--no-PG'],
                   out => $big_cram,
                   compare_sam => $big_sam,
                   pipe => 1);
@@ -2380,7 +2379,7 @@ sub test_view
     foreach my $threads (2, 4) {
         run_view_test($opts,
                       msg => "$test: Big SAM -> CRAM ($threads threads)",
-                      args => ['-C', '-@', $threads, $big_sam],
+                      args => ['-C', '-@', $threads, $big_sam, '--no-PG'],
                       out => sprintf("%s.test%03d.cram", $out, $test),
                       compare_sam => $big_sam,
                       pipe => 1);
@@ -2404,6 +2403,14 @@ sub test_view
             $test++;
         }
     }
+
+    my $b_pg_sam      = "$$opts{path}/dat/view.001.sam";
+    my $b_pg_expected = "$$opts{path}/dat/view.004.expected.sam";
+    run_view_test($opts,
+                  msg => "$test: SAM add PG",
+                  args => ['-h', $b_pg_sam],
+                  out => sprintf("%s.test%03d.sam", $out, $test),
+                  compare => $b_pg_expected);
 }
 
 # cat SAM files in the same way as samtools cat does with BAMs
@@ -2473,7 +2480,7 @@ sub test_cat
         $bams[$i] = sprintf("%s.%d.bam", $out, $i + 1);
         run_view_test($opts,
                       msg =>  sprintf("Generate BAM file #%d", $i + 1),
-                      args => ['-b', $sams[$i]],
+                      args => ['-b', $sams[$i], '--no-PG'],
                       out => $bams[$i],
                       compare_sam => $sams[$i],
                       pipe => 1);
@@ -2486,7 +2493,7 @@ sub test_cat
         $crams[$i] = sprintf("%s.%d.cram", $out, $i + 1);
         run_view_test($opts,
                       msg =>  sprintf("Generate CRAM file #%d", $i + 1),
-                      args => ['-C', $sams[$i]],
+                      args => ['-C', $sams[$i], '--no-PG'],
                       out => $crams[$i],
                       compare_sam => $sams[$i],
                       pipe => 1);
@@ -2610,7 +2617,7 @@ sub test_bam2fq
     # Make a BAM file with the test data
     run_view_test($opts,
                   msg =>  "Generate BAM file$nthreads",
-                  args => ['-b', $sam, @$threads],
+                  args => ['-b', $sam, @$threads, '--no-PG'],
                   out => $bam,
                   compare_sam => $sam,
                   pipe => 1);
@@ -2618,7 +2625,7 @@ sub test_bam2fq
     # Make a CRAM file with the test data
     run_view_test($opts,
                   msg =>  "Generate CRAM file$nthreads",
-                  args => ['-C', $sam, @$threads],
+                  args => ['-C', $sam, @$threads, '--no-PG'],
                   out => $cram,
                   ref_path => "$$opts{path}/dat/cram_md5",
                   compare_sam => $sam,
@@ -2699,7 +2706,7 @@ sub test_depad
     # Make a BAM file with the test data
     run_view_test($opts,
                   msg =>  "Generate BAM file",
-                  args => ['-b', $pad_sam],
+                  args => ['-b', $pad_sam, '--no-PG'],
                   out => $pad_bam,
                   compare_sam => $pad_sam);
 
@@ -2727,6 +2734,7 @@ sub test_depad
                 my @args = $use_t ? ('-T', $ref) : ();
                 if ($format->[0]) { push(@args, $format->[0]); }
                 push(@args, $input->[1]);
+                push(@args, '--no-PG');
                 my $compare = $format->[1] eq 'sam' ? 'compare' : 'compare_sam';
                 run_view_test($opts,
                               msg => "depad $format->[0] ($input->[0] input)",
@@ -2968,9 +2976,9 @@ sub test_reheader
     my $fn = "$$opts{path}/dat/view.001";
 
     # Create local BAM and CRAM inputs
-    system("$$opts{bin}/samtools view -b $fn.sam > $fn.tmp.bam")  == 0 or die "failed to create bam: $?";
-    system("$$opts{bin}/samtools view -C --output-fmt-option version=2.1 $fn.sam > $fn.tmp.v21.cram") == 0 or die "failed to create cram: $?";
-    system("$$opts{bin}/samtools view -C --output-fmt-option version=3.0 $fn.sam > $fn.tmp.v30.cram") == 0 or die "failed to create cram: $?";
+    system("$$opts{bin}/samtools view -b --no-PG $fn.sam > $fn.tmp.bam")  == 0 or die "failed to create bam: $?";
+    system("$$opts{bin}/samtools view -C --no-PG --output-fmt-option version=2.1 $fn.sam > $fn.tmp.v21.cram") == 0 or die "failed to create cram: $?";
+    system("$$opts{bin}/samtools view -C --no-PG --output-fmt-option version=3.0 $fn.sam > $fn.tmp.v30.cram") == 0 or die "failed to create cram: $?";
 
     # Fudge @PG lines.  The version number will differ each commit.
     # Also the pathname will differ for each install. We'll take it on faith
@@ -2978,21 +2986,21 @@ sub test_reheader
     test_cmd($opts,
              out=>'reheader/1_view1.sam.expected',
              err=>'reheader/1_view1.sam.expected.err',
-             cmd=>"$$opts{bin}/samtools reheader $$opts{path}/reheader/hdr.sam $fn.tmp.bam | $$opts{bin}/samtools view -h | perl -pe 's/\tVN:.*//'",
+             cmd=>"$$opts{bin}/samtools reheader $$opts{path}/reheader/hdr.sam $fn.tmp.bam | $$opts{bin}/samtools view -h --no-PG | perl -pe 's/\tVN:.*//'",
              exp_fix=>1,
              reorder_header => 1);
 
     test_cmd($opts,
              out=>'reheader/2_view1.sam.expected',
              err=>'reheader/2_view1.sam.expected.err',
-             cmd=>"$$opts{bin}/samtools reheader $$opts{path}/reheader/hdr.sam $fn.tmp.v21.cram | $$opts{bin}/samtools view -h | perl -pe 's/\tVN:.*//'",
+             cmd=>"$$opts{bin}/samtools reheader $$opts{path}/reheader/hdr.sam $fn.tmp.v21.cram | $$opts{bin}/samtools view -h --no-PG | perl -pe 's/\tVN:.*//'",
              exp_fix=>1,
              reorder_header => 1);
 
     test_cmd($opts,
              out=>'reheader/2_view1.sam.expected',
              err=>'reheader/2_view1.sam.expected.err',
-             cmd=>"$$opts{bin}/samtools reheader $$opts{path}/reheader/hdr.sam $fn.tmp.v30.cram | $$opts{bin}/samtools view -h | perl -pe 's/\tVN:.*//'",
+             cmd=>"$$opts{bin}/samtools reheader $$opts{path}/reheader/hdr.sam $fn.tmp.v30.cram | $$opts{bin}/samtools view -h --no-PG | perl -pe 's/\tVN:.*//'",
              exp_fix=>1,
              reorder_header => 1);
 
@@ -3000,28 +3008,28 @@ sub test_reheader
     test_cmd($opts,
              out=>'reheader/3_view1.sam.expected',
              err=>'reheader/3_view1.sam.expected.err',
-             cmd=>"$$opts{bin}/samtools reheader --in-place $$opts{path}/reheader/hdr.sam $fn.tmp.v21.cram && $$opts{bin}/samtools view -h $fn.tmp.v21.cram | perl -pe 's/\tVN:.*//'",
+             cmd=>"$$opts{bin}/samtools reheader --in-place $$opts{path}/reheader/hdr.sam $fn.tmp.v21.cram && $$opts{bin}/samtools view -h --no-PG $fn.tmp.v21.cram | perl -pe 's/\tVN:.*//'",
              exp_fix=>1,
              reorder_header => 1);
 
     test_cmd($opts,
              out=>'reheader/3_view1.sam.expected',
              err=>'reheader/3_view1.sam.expected.err',
-             cmd=>"$$opts{bin}/samtools reheader --in-place $$opts{path}/reheader/hdr.sam $fn.tmp.v30.cram && $$opts{bin}/samtools view -h $fn.tmp.v30.cram | perl -pe 's/\tVN:.*//'",
+             cmd=>"$$opts{bin}/samtools reheader --in-place $$opts{path}/reheader/hdr.sam $fn.tmp.v30.cram && $$opts{bin}/samtools view -h --no-PG $fn.tmp.v30.cram | perl -pe 's/\tVN:.*//'",
              exp_fix=>1,
              reorder_header => 1);
 
     test_cmd($opts,
              out=>'reheader/4_view1.sam.expected',
              err=>'reheader/1_view1.sam.expected.err',
-             cmd=>"$$opts{bin}/samtools reheader -c \"sed \'s/2014 Genome/2019 Genome/g\'\" $fn.tmp.bam | $$opts{bin}/samtools view -h | perl -pe 's/\tVN:.*//'",
+             cmd=>"$$opts{bin}/samtools reheader -c \"sed \'s/2014 Genome/2019 Genome/g\'\" $fn.tmp.bam | $$opts{bin}/samtools view -h --no-PG | perl -pe 's/\tVN:.*//'",
              exp_fix=>1,
              reorder_header => 1);
 
     test_cmd($opts,
              out=>'reheader/5_view1.sam.expected',
              err=>'reheader/1_view1.sam.expected.err',
-             cmd=>"$$opts{bin}/samtools reheader -c \"sed \'s/2014 Genome/2019 Genome/g\'\" $fn.tmp.v30.cram | $$opts{bin}/samtools view -h | perl -pe 's/\tVN:.*//'",
+             cmd=>"$$opts{bin}/samtools reheader -c \"sed \'s/2014 Genome/2019 Genome/g\'\" $fn.tmp.v30.cram | $$opts{bin}/samtools view -h --no-PG | perl -pe 's/\tVN:.*//'",
              exp_fix=>1,
              reorder_header => 1);
 }


### PR DESCRIPTION
Add a `@PG` line when producing a new SAM/BAM/CRAM file with `samtools view`. 
Avoid this behaviour with the `--no-PG` option.