### PR TITLE
Prepare for 64-bit positions

### DIFF
--- a/bam_index.c
+++ b/bam_index.c
@@ -149,9 +149,9 @@ int slow_idxstats(samFile *fp, sam_hdr_t *header) {
     if (ret == -1) {
         int i;
         for (i = 0; i < sam_hdr_nref(header); i++) {
-            printf("%s\t%d\t%"PRIu64"\t%"PRIu64"\n",
+            printf("%s\t%"PRId64"\t%"PRIu64"\t%"PRIu64"\n",
                    sam_hdr_tid2name(header, i),
-                   sam_hdr_tid2len(header, i),
+                   (int64_t) sam_hdr_tid2len(header, i),
                    counts[i][0], counts[i][1]);
         }
         printf("*\t0\t%"PRIu64"\t%"PRIu64"\n", counts[-1][0], counts[-1][1]);
@@ -229,7 +229,7 @@ int bam_idxstats(int argc, char *argv[])
         int i;
         for (i = 0; i < sam_hdr_nref(header); ++i) {
             // Print out contig name and length
-            printf("%s\t%d", sam_hdr_tid2name(header, i), sam_hdr_tid2len(header, i));
+            printf("%s\t%"PRId64, sam_hdr_tid2name(header, i), (int64_t) sam_hdr_tid2len(header, i));
             // Now fetch info about it from the meta bin
             uint64_t u, v;
             hts_idx_get_stat(idx, i, &u, &v);

--- a/bam_mate.c
+++ b/bam_mate.c
@@ -316,7 +316,7 @@ static int bam_mating_core(samFile *in, samFile *out, int remove_reads, int prop
                 if (pre->core.tid == cur->core.tid && !(cur->core.flag&(BAM_FUNMAP|BAM_FMUNMAP))
                     && !(pre->core.flag&(BAM_FUNMAP|BAM_FMUNMAP))) // if safe set TLEN/ISIZE
                 {
-                    uint32_t cur5, pre5;
+                    int32_t cur5, pre5;
                     cur5 = (cur->core.flag&BAM_FREVERSE)? cur_end : cur->core.pos;
                     pre5 = (pre->core.flag&BAM_FREVERSE)? pre_end : pre->core.pos;
                     cur->core.isize = pre5 - cur5; pre->core.isize = cur5 - pre5;

--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -337,8 +337,8 @@ static int mplp_func(void *data, bam1_t *b)
         if (ma->conf->fai && b->core.tid >= 0) {
             has_ref = mplp_get_ref(ma, b->core.tid, &ref, &ref_len);
             if (has_ref && ref_len <= b->core.pos) { // exclude reads outside of the reference sequence
-                fprintf(stderr,"[%s] Skipping because %d is outside of %d [ref:%d]\n",
-                        __func__, b->core.pos, ref_len, b->core.tid);
+                fprintf(stderr,"[%s] Skipping because %"PRId64" is outside of %d [ref:%d]\n",
+                        __func__, (int64_t) b->core.pos, ref_len, b->core.tid);
                 skip = 1;
                 continue;
             }
@@ -542,7 +542,7 @@ static int mpileup(mplp_conf_t *conf, int n, char **fn, char **fn_idx)
         for (i=0; i < sam_hdr_nref(h); i++)
         {
             str.l = 0;
-            ksprintf(&str, "##contig=<ID=%s,length=%d>", sam_hdr_tid2name(h, i), sam_hdr_tid2len(h, i));
+            ksprintf(&str, "##contig=<ID=%s,length=%"PRId64">", sam_hdr_tid2name(h, i), (int64_t) sam_hdr_tid2len(h, i));
             bcf_hdr_append(bcf_hdr, str.s);
         }
         free(str.s);
@@ -830,7 +830,7 @@ static int mpileup(mplp_conf_t *conf, int n, char **fn, char **fn_idx)
                                         putc('*', pileup_fp);
                                     break;
                                 case MPLP_PRINT_POS:
-                                    fprintf(pileup_fp, "%d", p->b->core.pos + 1);
+                                    fprintf(pileup_fp, "%"PRId64, (int64_t) p->b->core.pos + 1);
                                     break;
                                 case MPLP_PRINT_MAPQ:
                                     c = p->b->core.qual + 33;
@@ -844,7 +844,7 @@ static int mpileup(mplp_conf_t *conf, int n, char **fn, char **fn_idx)
                                         putc('*', pileup_fp);
                                     break;
                                 case MPLP_PRINT_PNEXT:
-                                    fprintf(pileup_fp, "%d", p->b->core.mpos + 1);
+                                    fprintf(pileup_fp, "%"PRId64, (int64_t) p->b->core.mpos + 1);
                                     break;
                                 }
                             }

--- a/stats.c
+++ b/stats.c
@@ -1021,7 +1021,7 @@ static void remove_overlaps(bam1_t *bam_line, khash_t(qn2pair) *read_pairs, stat
 
     char *qname = bam_get_qname(bam_line);
     if ( !qname ) {
-        fprintf(stderr, "Error retrieving qname for line starting at pos %d\n", bam_line->core.pos);
+        fprintf(stderr, "Error retrieving qname for line starting at pos %"PRId64"\n", (int64_t) bam_line->core.pos);
         return;
     }
 

--- a/test/merge/test_bam_translate.c
+++ b/test/merge/test_bam_translate.c
@@ -31,10 +31,11 @@ DEALINGS IN THE SOFTWARE.  */
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>
+#include <inttypes.h>
 
 void dump_read(bam1_t* b) {
     printf("->core.tid:(%d)\n", b->core.tid);
-    printf("->core.pos:(%d)\n", b->core.pos);
+    printf("->core.pos:(%"PRId64")\n", (int64_t) b->core.pos);
     printf("->core.bin:(%d)\n", b->core.bin);
     printf("->core.qual:(%d)\n", b->core.qual);
     printf("->core.l_qname:(%d)\n", b->core.l_qname);
@@ -42,8 +43,8 @@ void dump_read(bam1_t* b) {
     printf("->core.n_cigar:(%d)\n", b->core.n_cigar);
     printf("->core.l_qseq:(%d)\n", b->core.l_qseq);
     printf("->core.mtid:(%d)\n", b->core.mtid);
-    printf("->core.mpos:(%d)\n", b->core.mpos);
-    printf("->core.isize:(%d)\n", b->core.isize);
+    printf("->core.mpos:(%"PRId64")\n", (int64_t) b->core.mpos);
+    printf("->core.isize:(%"PRId64")\n", (int64_t) b->core.isize);
     if (b->data) {
         printf("->data:");
         int i;

--- a/test/merge/test_trans_tbl_init.c
+++ b/test/merge/test_trans_tbl_init.c
@@ -27,6 +27,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include "../../bam_sort.c"
 #include <assert.h>
 #include <regex.h>
+#include <inttypes.h>
 
 typedef struct refseq_info {
     const char *name;
@@ -38,7 +39,7 @@ void dump_header(sam_hdr_t* hdr) {
     int i;
     for (i = 0; i < sam_hdr_nref(hdr); ++i) {
         printf("->target_name[%d]:(%s)\n", i, sam_hdr_tid2name(hdr, i));
-        printf("->target_len[%d]:(%d)\n", i, sam_hdr_tid2len(hdr, i));
+        printf("->target_len[%d]:(%"PRId64")\n", i, (int64_t) sam_hdr_tid2len(hdr, i));
     }
 
     printf("->text:(");

--- a/test/test.c
+++ b/test/test.c
@@ -33,6 +33,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <htslib/sam.h>
 
 #include "test.h"
@@ -71,7 +72,7 @@ void dump_hdr(const sam_hdr_t* hdr)
     printf("idx\ttarget_len\ttarget_name:\n");
     int32_t target;
     for (target = 0; target < sam_hdr_nref(hdr); ++target) {
-        printf("%d\t%u\t\"%s\"\n", target, sam_hdr_tid2len(hdr, target), sam_hdr_tid2name(hdr, target));
+        printf("%d\t%"PRId64"\t\"%s\"\n", target, (int64_t) sam_hdr_tid2len(hdr, target), sam_hdr_tid2name(hdr, target));
     }
     printf("text: \"%s\"\n", sam_hdr_str((sam_hdr_t*)hdr));
 }


### PR DESCRIPTION
This does not add 64-bit position support, it just ensures samtools will build without warnings (using gcc/clang -Wall) when built against both 32-bit and 64-bit position branches of HTSlib.

Makes various printf()s use PRId64 for positions.  The values are cast to (int64_t) so both 32-bit and 64-bit versions work.

Fix `isize` calculation in bam_mate.c so it sign-extends correctly.