### PR TITLE
[depth] Display of only zero depth positions inisde a region

### DIFF
--- a/bam2depth.c
+++ b/bam2depth.c
@@ -317,7 +317,7 @@ int main_depth(int argc, char *argv[])
 
     if (all) {
         // Handle terminating region
-        if (last_tid < 0 && reg && all > 1) {
+        if (last_tid < 0 && reg) {
             last_tid = reg_tid;
             last_pos = beg-1;
         }

--- a/test/mpileup/depth.reg
+++ b/test/mpileup/depth.reg
@@ -46,13 +46,13 @@ P d5_all1.out  $samtools depth               xx#depth3.bam
 P d5_all2.out  $samtools depth -a            xx#depth3.bam
 P d5_all3.out  $samtools depth -aa           xx#depth3.bam
 P d5_blank.out $samtools depth     -r xy:5-6 xx#depth3.bam
-P d5_blank.out $samtools depth -a  -r xy:5-6 xx#depth3.bam
+P d5_xy1.out   $samtools depth -a  -r xy:5-6 xx#depth3.bam
 P d5_xy1.out   $samtools depth -aa -r xy:5-6 xx#depth3.bam
 P d5_xx1.out   $samtools depth     -r xx:4-10 xx#depth3.bam
 P d5_xx2.out   $samtools depth -a  -r xx:4-10 xx#depth3.bam
 P d5_xx2.out   $samtools depth -aa -r xx:4-10 xx#depth3.bam
 P d5_blank.out $samtools depth     -r xx:9    xx#depth3.bam
-P d5_blank.out $samtools depth -a  -r xx:9    xx#depth3.bam
+P d5_xx3.out   $samtools depth -a  -r xx:9    xx#depth3.bam
 P d5_xx3.out   $samtools depth -aa -r xx:9    xx#depth3.bam
 P d5_b3.out    $samtools depth     -b xx.bed3 xx#depth3.bam
 P d5_b3aa.out  $samtools depth -aa -b xx.bed3 xx#depth3.bam


### PR DESCRIPTION
When **depth** is provided with a region argument, it will only consider the reads that cover that particular region. The user has the option to display the positions inside the selected region with 0 depth by using the `-a` option. However, this only produced the desired effect only when there was at least one valid read inside the selected region (there was at least a covered position inside the selected region), which was neither desired nor documented.

This fix enables the display of all positions with 0 depth, where there is no position covered and `-a` option is selected.
Fixes #1112 
Related to #374 