### PR TITLE
plot-bamstats do_ref_stats computes the wrong median value when called with a target regions file

### DIFF
--- a/misc/plot-bamstats
+++ b/misc/plot-bamstats
@@ -277,6 +277,7 @@ sub do_ref_stats
             $pos = 0;
             $ireg = 0;
             $regions = $targets{$1};
+            next;
         }
         if ( defined $skip_chr ) { next; }
 


### PR DESCRIPTION
When generating the reference stats for fasta file, where the header lines are longer then the line wrap length of the sequence, the header lines are included in the regions hash and hence the wrong median value is computed.