### PR TITLE
Add --verbosity INT global option for setting hts_verbose

### DIFF
--- a/bam2depth.c
+++ b/bam2depth.c
@@ -90,7 +90,7 @@ static int usage() {
     fprintf(stderr, "   -Q <int>            mapping quality threshold [0]\n");
     fprintf(stderr, "   -r <chr:from-to>    region\n");
 
-    sam_global_opt_help(stderr, "-.--.-");
+    sam_global_opt_help(stderr, "-.--.--.");
 
     fprintf(stderr, "\n");
     fprintf(stderr, "The output is a simple tab-separated table with three columns: reference name,\n");

--- a/bam_addrprg.c
+++ b/bam_addrprg.c
@@ -173,7 +173,7 @@ static void usage(FILE *fp)
             "  -R STRING ID of @RG line in existing header to use\n"
             "  --no-PG   Do not add a PG line\n"
             );
-    sam_global_opt_help(fp, "..O..@.");
+    sam_global_opt_help(fp, "..O..@..");
 }
 
 static bool parse_args(int argc, char** argv, parsed_opts_t** opts)

--- a/bam_cat.c
+++ b/bam_cat.c
@@ -547,7 +547,7 @@ int main_cat(int argc, char *argv[])
         fprintf(stderr, "         -h FILE  copy the header from FILE [default is 1st input file]\n");
         fprintf(stderr, "         -o FILE  output BAM/CRAM\n");
         fprintf(stderr, "         --no-PG  do not add a PG line\n");
-        sam_global_opt_help(stderr, "--..-@");
+        sam_global_opt_help(stderr, "--..-@-.");
         return 1;
     }
 

--- a/bam_fastq.c
+++ b/bam_fastq.c
@@ -91,7 +91,7 @@ static void bam2fq_usage(FILE *to, const char *command)
 "  --barcode-tag TAG    Barcode tag [default: " DEFAULT_BARCODE_TAG "]\n"
 "  --quality-tag TAG    Quality tag [default: " DEFAULT_QUALITY_TAG "]\n"
 "  --index-format STR   How to parse barcode and quality tags\n\n");
-    sam_global_opt_help(to, "-.--.@");
+    sam_global_opt_help(to, "-.--.@-.");
     fprintf(to,
 "\n"
 "The files will be automatically compressed if the file names have a .gz or .bgzf extension.\n"

--- a/bam_index.c
+++ b/bam_index.c
@@ -167,7 +167,7 @@ int slow_idxstats(samFile *fp, sam_hdr_t *header) {
 static void usage_exit(FILE *fp, int exit_status)
 {
     fprintf(fp, "Usage: samtools idxstats [options] <in.bam>\n");
-    sam_global_opt_help(fp, "-.---@");
+    sam_global_opt_help(fp, "-.---@-.");
     exit(exit_status);
 }
 

--- a/bam_markdup.c
+++ b/bam_markdup.c
@@ -1489,7 +1489,7 @@ static int markdup_usage(void) {
     fprintf(stderr, "  -t               Mark primary duplicates with the name of the original in a \'do\' tag."
                                   " Mainly for information and debugging.\n");
 
-    sam_global_opt_help(stderr, "-.O..@.");
+    sam_global_opt_help(stderr, "-.O..@..");
 
     fprintf(stderr, "\nThe input file must be coordinate sorted and must have gone"
                      " through fixmates with the mate scoring option on.\n");

--- a/bam_mate.c
+++ b/bam_mate.c
@@ -407,7 +407,7 @@ void usage(FILE* where)
 "  -m           Add mate score tag\n"
 "  --no-PG      do not add a PG line\n");
 
-    sam_global_opt_help(where, "-.O..@");
+    sam_global_opt_help(where, "-.O..@-.");
 
     fprintf(where,
 "\n"

--- a/bam_md.c
+++ b/bam_md.c
@@ -179,7 +179,7 @@ int calmd_usage() {
 "  -E       extended BAQ for better sensitivity but lower specificity\n"
 "  --no-PG  do not add a PG line\n");
 
-    sam_global_opt_help(stderr, "-....@");
+    sam_global_opt_help(stderr, "-....@-.");
     return 1;
 }
 

--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -1129,7 +1129,7 @@ static void print_usage(FILE *fp, const mplp_conf_t *mplp)
 "  -a -a (or -aa)          output absolutely all positions, including unused ref. sequences\n"
 "\n"
 "Generic options:\n");
-    sam_global_opt_help(fp, "-.--.-");
+    sam_global_opt_help(fp, "-.--.--.");
 
     fprintf(fp, "\n"
 "Note that using \"samtools mpileup\" to generate BCF or VCF files is now\n"

--- a/bam_rmdup.c
+++ b/bam_rmdup.c
@@ -261,7 +261,7 @@ static int rmdup_usage(void) {
     fprintf(stderr, "Option: -s    rmdup for SE reads\n");
     fprintf(stderr, "        -S    treat PE reads as SE in rmdup (force -s)\n");
 
-    sam_global_opt_help(stderr, "-....-");
+    sam_global_opt_help(stderr, "-....--.");
     return 1;
 }
 

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -1358,7 +1358,7 @@ static void merge_usage(FILE *to)
 "  -b FILE    List of input BAM filenames, one per line [null]\n"
 "  -X         Use customized index files\n"
 "  --no-PG    do not add a PG line\n");
-    sam_global_opt_help(to, "-.O..@.");
+    sam_global_opt_help(to, "-.O..@..");
 }
 
 int bam_merge(int argc, char *argv[])
@@ -2215,7 +2215,7 @@ static void sort_usage(FILE *fp)
 "  -o FILE    Write final output to FILE rather than standard output\n"
 "  -T PREFIX  Write temporary files to PREFIX.nnnn.bam\n"
 "  --no-PG    do not add a PG line\n");
-    sam_global_opt_help(fp, "-.O..@");
+    sam_global_opt_help(fp, "-.O..@-.");
 }
 
 static void complain_about_memory_setting(size_t max_mem) {

--- a/bam_split.c
+++ b/bam_split.c
@@ -87,7 +87,7 @@ static void usage(FILE *write_to)
 "  -h FILE2        ... and override the header with FILE2 (-u file only)\n"
 "  -v              verbose output\n"
 "  --no-PG         do not add a PG line\n");
-    sam_global_opt_help(write_to, "-....@.");
+    sam_global_opt_help(write_to, "-....@..");
     fprintf(write_to,
 "\n"
 "Format string expansions:\n"

--- a/bam_stat.c
+++ b/bam_stat.c
@@ -103,7 +103,7 @@ static const char *percent_json(char *buffer, long long n, long long total)
 static void usage_exit(FILE *fp, int exit_status)
 {
     fprintf(fp, "Usage: samtools flagstat [options] <in.bam>\n");
-    sam_global_opt_help(fp, "-.---@");
+    sam_global_opt_help(fp, "-.---@-.");
     fprintf(fp, "  -O, --");
     fprintf(fp, "output-fmt FORMAT[,OPT[=VAL]]...\n"
             "               Specify output format (json, tsv)\n");

--- a/bam_tview.c
+++ b/bam_tview.c
@@ -400,7 +400,7 @@ static void error(const char *format, ...)
 "   -X              include customized index file\n"
 "   -p chr:pos      go directly to this position\n"
 "   -s STR          display only reads from this sample or group\n");
-        sam_global_opt_help(stderr, "-.--.-");
+        sam_global_opt_help(stderr, "-.--.--.");
     }
     else
     {

--- a/bamshuf.c
+++ b/bamshuf.c
@@ -539,7 +539,7 @@ static int usage(FILE *fp, int n_files, int reads_store) {
             "      --no-PG  do not add a PG line\n",
             reads_store, DEF_CLEVEL, n_files);
 
-    sam_global_opt_help(fp, "-....@");
+    sam_global_opt_help(fp, "-....@-.");
     fprintf(fp,
             "  <prefix> is required unless the -o or -O options are used.\n");
 

--- a/bedcov.c
+++ b/bedcov.c
@@ -97,7 +97,7 @@ int main_bedcov(int argc, char *argv[])
         fprintf(stderr, "      -Q <int>            mapping quality threshold [0]\n");
         fprintf(stderr, "      -X                  use customized index files\n");
         fprintf(stderr, "      -j                  do not include deletions (D) and ref skips (N) in bedcov computation\n");
-        sam_global_opt_help(stderr, "-.--.-");
+        sam_global_opt_help(stderr, "-.--.--.");
         return 1;
     }
     if (has_index_file) {

--- a/coverage.c
+++ b/coverage.c
@@ -129,7 +129,7 @@ static int usage() {
             "  -h, --help              help (this page)\n");
 
     fprintf(stdout, "\nGeneric options:\n");
-    sam_global_opt_help(stdout, "-.--.-");
+    sam_global_opt_help(stdout, "-.--.--.");
 
     fprintf(stdout,
             "\nSee manpage for additional details.\n"

--- a/cut_target.c
+++ b/cut_target.c
@@ -201,7 +201,7 @@ int main_cut_target(int argc, char *argv[])
     }
     if (usage || argc == optind) {
         fprintf(stderr, "Usage: samtools targetcut [-Q minQ] [-i inPen] [-0 em0] [-1 em1] [-2 em2] <in.bam>\n");
-        sam_global_opt_help(stderr, "-.--f-");
+        sam_global_opt_help(stderr, "-.--f--.");
         return 1;
     }
     l = max_l = 0; cns = 0;

--- a/doc/samtools.1
+++ b/doc/samtools.1
@@ -681,7 +681,8 @@ Display the full samtools version number in a machine-readable format.
 .PP
 Several long-options are shared between multiple samtools sub-commands:
 \fB--input-fmt\fR, \fB--input-fmt-option\fR, \fB--output-fmt\fR,
-\fB--output-fmt-option\fR, \fB--reference\fR and \fB--write-index\fR.
+\fB--output-fmt-option\fR, \fB--reference\fR, \fB--write-index\fR,
+and \fB--verbosity\fR.
 The input format is typically auto-detected so specifying the format
 is usually unnecessary and the option is included for completeness.
 Note that not all subcommands have all options.  Consult the subcommand
@@ -824,6 +825,11 @@ For example: to convert a BAM to a compressed SAM with CSI indexing:
 .EX 4
 samtools view -h -O sam,level=6 --write-index in.bam -o out.sam.gz
 .EE
+.PP
+The \fB--verbosity \fIINT\fR option sets the verbosity level for samtools
+and HTSlib.  The default is 3 (HTS_LOG_WARNING); 2 reduces warning messages
+and 0 or 1 also reduces some error messages, while values greater than 3
+produce increasing numbers of additional warnings and logging messages.
 
 .PP
 .SH REFERENCE SEQUENCES

--- a/padding.c
+++ b/padding.c
@@ -590,7 +590,7 @@ static int usage(int is_long_help)
     fprintf(stderr, "  -o FILE      Output file name [stdout]\n");
     fprintf(stderr, "  --no-PG      do not add a PG line\n");
     fprintf(stderr, "  -?           Longer help\n");
-    sam_global_opt_help(stderr, "-...--.");
+    sam_global_opt_help(stderr, "-...--..");
 
     if (is_long_help)
         fprintf(stderr,

--- a/phase.c
+++ b/phase.c
@@ -638,7 +638,7 @@ int main_phase(int argc, char *argv[])
 //      fprintf(stderr, "         -e        do not discover SNPs (effective with -l)\n");
         fprintf(stderr, "\n");
 
-        sam_global_opt_help(stderr, "-....-");
+        sam_global_opt_help(stderr, "-....--.");
 
         return 1;
     }

--- a/sam_opts.c
+++ b/sam_opts.c
@@ -78,9 +78,9 @@ int parse_sam_global_opt(int c, const char *optarg, const struct option *lopt,
         } else if (strcmp(lopt->name, "write-index") == 0) {
             ga->write_index = 1;
             break;
-//      } else if (strcmp(lopt->name, "verbose") == 0) {
-//          ga->verbosity++;
-//          break;
+        } else if (strcmp(lopt->name, "verbosity") == 0) {
+            hts_verbose = atoi(optarg);
+            break;
         }
     }
 
@@ -154,9 +154,9 @@ void sam_global_opt_help(FILE *fp, const char *shortopts) {
         else if (strcmp(lopts[i].name, "write-index") == 0)
             fprintf(fp,"write-index\n"
                     "               Automatically index the output files [off]\n");
-//      else if (strcmp(lopts[i].name, "verbose") == 0)
-//          fprintf(fp,"verbose\n"
-//                  "               Increment level of verbosity\n");
+        else if (strcmp(lopts[i].name, "verbosity") == 0)
+            fprintf(fp,"verbosity INT\n"
+                    "               Set level of verbosity\n");
     }
 }
 

--- a/sam_opts.h
+++ b/sam_opts.h
@@ -36,7 +36,6 @@ typedef struct sam_global_args {
     char *reference;
     int nthreads;
     int write_index;
-    //int verbosity;
 } sam_global_args;
 
 #define SAM_GLOBAL_ARGS_INIT {{0},{0}}
@@ -49,7 +48,7 @@ enum {
     SAM_OPT_REFERENCE,
     SAM_OPT_NTHREADS,
     SAM_OPT_WRITE_INDEX,
-    //SAM_OPT_VERBOSE,
+    SAM_OPT_VERBOSITY,
 };
 
 #define SAM_OPT_VAL(val, defval) ((val) == '-')? '?' : (val)? (val) : (defval)
@@ -67,8 +66,8 @@ enum {
     {"output-fmt-option", required_argument, NULL, SAM_OPT_VAL(o4, SAM_OPT_OUTPUT_FMT_OPTION)}, \
     {"reference",         required_argument, NULL, SAM_OPT_VAL(o5, SAM_OPT_REFERENCE)}, \
     {"threads",           required_argument, NULL, SAM_OPT_VAL(o6, SAM_OPT_NTHREADS)}, \
-    {"write-index",       no_argument,       NULL, SAM_OPT_WRITE_INDEX}
-    //{"verbose",           no_argument,       NULL, SAM_OPT_VERBOSE}
+    {"write-index",       no_argument,       NULL, SAM_OPT_WRITE_INDEX}, \
+    {"verbosity",         required_argument, NULL, SAM_OPT_VERBOSITY}
 
 /*
  * Processes a standard "global" samtools long option.

--- a/sam_view.c
+++ b/sam_view.c
@@ -853,7 +853,7 @@ static int usage(FILE *fp, int exit_status, int is_long_help)
 "  -S       ignored (input format is auto-detected)\n"
 "  --no-PG  do not add a PG line\n");
 
-    sam_global_opt_help(fp, "-.O.T@.");
+    sam_global_opt_help(fp, "-.O.T@..");
     fprintf(fp, "\n");
 
     if (is_long_help)

--- a/stats.c
+++ b/stats.c
@@ -2038,7 +2038,7 @@ static void HTS_NORETURN error(const char *format, ...)
         printf("    -x, --sparse                        Suppress outputting IS rows where there are no insertions.\n");
         printf("    -p, --remove-overlaps               Remove overlaps of paired-end reads from coverage and base count computations.\n");
         printf("    -g, --cov-threshold <int>           Only bases with coverage above this value will be included in the target percentage computation [0]\n");
-        sam_global_opt_help(stdout, "-.--.@");
+        sam_global_opt_help(stdout, "-.--.@-.");
         printf("\n");
     }
     else


### PR DESCRIPTION
Currently the only way for users to crank up `hts_verbose` for debugging purposes is to use `htsfile -vvv`. It would be good to be able to debug e.g. networking and S3 access problems by cranking up the logging in `samtools` invocations too.

This adds a `--verbosity INT` global option. As this pretty much has to be a long option, it seems better to have an option that sets the level directly rather than make people type stuff like

    samtools view --verbose --verbose --verbose --verbose s3://bucket/blah.bam

(It might be worth in future also adding a less flexible `--verbose` global option that just sets it to 6 or so…)