### PR TITLE
Add on-the-fly indexing for samtools sort

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -35,7 +35,7 @@ Changes affecting the whole of samtools, or multiple sub-commands:
 
  * A new global '--write-index' option has been added.  This allows output
    sam.gz/bam/cram files to be indexed while they are being written out.
-   This should work with addreplacerg, depad, markdup, merge, split,
+   This should work with addreplacerg, depad, markdup, merge, sort, split,
    and view. (#1062)
 
  * A global '--verbosity' option has been added to enable/disable


### PR DESCRIPTION
For some reason this one was missed when the feature was added for other sub-commands.  This adds it for position sorted files (a warning is printed and the option ignored if sorting by name or aux tag).