### PR TITLE
Fix test suite on OpenBSD

### DIFF
--- a/bam_sort.c
+++ b/bam_sort.c
@@ -1426,7 +1426,7 @@ int bam_merge(int argc, char *argv[])
         return 1;
     }
 
-    srand48(random_seed);
+    hts_srand48(random_seed);
     if (!(flag & MERGE_FORCE) && strcmp(argv[optind], "-")) {
         FILE *fp = fopen(argv[optind], "rb");
         if (fp != NULL) {

--- a/misc/wgsim.c
+++ b/misc/wgsim.c
@@ -466,7 +466,7 @@ int main(int argc, char *argv[])
     }
     if (seed <= 0) seed = time(0)&0x7fffffff;
     fprintf(stderr, "[wgsim] seed = %d\n", seed);
-    srand48(seed);
+    hts_srand48(seed);
     wgsim_core(fpout1, fpout2, argv[optind], is_hap, N, dist, std_dev, size_l, size_r);
 
     fclose(fpout1); fclose(fpout2);

--- a/test/merge/test_rtrans_build.c
+++ b/test/merge/test_rtrans_build.c
@@ -79,7 +79,7 @@ int main(int argc, char**argv)
         }
     }
     const long GIMMICK_SEED = 0x1234330e;
-    srand48(GIMMICK_SEED);
+    hts_srand48(GIMMICK_SEED);
 
     if (verbose) printf("BEGIN test 1\n");
     // setup

--- a/test/merge/test_trans_tbl_init.c
+++ b/test/merge/test_trans_tbl_init.c
@@ -324,7 +324,7 @@ int main(int argc, char**argv)
 
     // Set the seed to a fixed value so that calls to lrand48 within functions return predictable values
     const long GIMMICK_SEED = 0x1234330e;
-    srand48(GIMMICK_SEED);
+    hts_srand48(GIMMICK_SEED);
 
     sam_hdr_t* out;
     sam_hdr_t* translate;

--- a/test/mpileup/mpileup.reg
+++ b/test/mpileup/mpileup.reg
@@ -112,7 +112,7 @@ P 48.out $samtools mpileup -x -g -f mpileup.ref.fa mpileup.1.$fmt | $filter
 P 49.out $samtools mpileup -x -v -f mpileup.ref.fa mpileup.1.$fmt | $filter
 P 50.out $samtools mpileup -D -V -x -g -f mpileup.ref.fa mpileup.1.$fmt | $filter
 P 51.out $samtools mpileup -S -x -g -f mpileup.ref.fa mpileup.1.$fmt | $filter
-P 52.out $samtools mpileup -u -x -f mpileup.ref.fa mpileup.1.bam | ../vcf-miniview - | awk -v OFS='\t' '/#samtools/ {next} /^#/ {print; next} {gsub(/[=,][-+]?[0-9]+(e[-+]?[0-9]+)?\.[0-9][0-9]+/,"&#del",$8);gsub(/[0-9]#del/,"",$8);print}'
+P 52.out $samtools mpileup -u -x -f mpileup.ref.fa mpileup.1.bam | ../vcf-miniview - | awk -v OFS='\t' '/#samtools/ {next} /^#/ {print; next} {gsub(/[=,][-+]?[0-9]+(e[-+]?[0-9]+)?\.[0-9][0-9]+/,"&#del",$8); gsub(/[0-9]#del/,"",$8); print}'
 
 # # -o/e/h for indel scores
 P 53.out $samtools mpileup -e 1       -u -x -f mpileup.ref.fa indels.$fmt|$filter|awk '/INDEL/'


### PR DESCRIPTION
Samtools compiles fine on OpenBSD but there are test suite failures due to two separate causes:

1. `/bin/sh` on OpenBSD is ksh and it expands `{a,b,c}` brace notation somewhat differently from bash, which can be avoided by reformatting the awk expression to be a little clearer (it's not intended to be a shell brace expression at all!).

2. The `samtools merge -c -p` tests fail due to [OpenBSD's `srand48()`](https://www.mail-archive.com/tech@openbsd.org/msg21465.html) seeding a [stronger random number sequence](https://lwn.net/Articles/625506/) that differs from the prescribed POSIX sequence. There are various ways to fix this, but the best way may be to use the existing _htslib/hts_os.h_ to provide tools to get OpenBSD to also produce the (weaker, but for HTS purposes we probably value cross-platform repeatability more) standard POSIX sequences. Cf PR samtools/htslib#1002.