### PR TITLE
Ensure tview test prints the correct number of columns [minor]

### DIFF
--- a/test/test.pl
+++ b/test/test.pl
@@ -2463,6 +2463,9 @@ sub test_large_positions
 {
     my ($opts) = @_;
 
+    # Ensure the tview test prints out the expected number of columns
+    local $ENV{COLUMNS} = 80;
+
     # Simple round-trip
     my $longref = "$$opts{tmp}/longref.sam.gz";
     cmd("$$opts{bgzip} -c $$opts{path}/large_pos/longref.sam > $longref");


### PR DESCRIPTION
Fixes #1162 - "test_large_positions" failure due to exported COLUMNS environment variable with a value other than 80.