### PR TITLE
[view, depad] Add support for reading remote reference files

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,11 @@
 Release a.b
 -----------
 
+ * samtools view now accepts remote URIs for FASTA and FAI files.
+   Furthermore, the reference and index file can be provided in a single
+   argument, such as
+   samtools view -T ftp://x.com/ref.fa##idx##ftp://y.com/index.fa.fai a.cram
+
  * samtools depth can now include deletions (D) when computing the base
    coverage depth, if the user adds the -J option to the command line.
 

--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -221,7 +221,8 @@ optionally compressed by
 and ideally indexed by
 .B samtools
 .BR faidx .
-If an index is not present, one will be generated for you.
+If an index is not present one will be generated for you, if the reference
+file is local.
 .TP
 .BI "-L " FILE
 Only output alignments overlapping the input BED

--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -223,6 +223,21 @@ and ideally indexed by
 .BR faidx .
 If an index is not present one will be generated for you, if the reference
 file is local.
+
+If the reference file is not local,
+but is accessed instead via an https://, s3:// or other URL,
+the index file will need to be supplied by the server alongside the reference.
+It is possible to have the reference and index files in different locations
+by supplying both to this option seperated by the string "##idx##",
+for example:
+
+.B -T ftp://x.com/ref.fa##idx##ftp://y.com/index.fa.fai
+
+However, note that only the location of the reference will be stored
+in the output file header.
+If this method is used to make CRAM files, the cram reader may not be able to
+find the index, and may not be able to decode the file unless it can get
+the references it needs using a different method.
 .TP
 .BI "-L " FILE
 Only output alignments overlapping the input BED


### PR DESCRIPTION
Use the new [HTSlib](https://github.com/samtools/htslib/pull/1017) method `fai_path`, which offers support for remote reference and index files.
Also, the reference file and the index file can now be provided as a single string argument, using the format **reference.fa##idx##index.fa.fai** (e.g. `samtools view -o align.cram -T ref.fa##idx##index.fa.fai align.bam`).

Fixes https://github.com/samtools/htslib/issues/933