### PR TITLE
Delete the "samtools import" subcommand.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,10 @@ Release a.b
    "chr" prefixes added to or removed from each sequence name as appropriate
    and listing both "M" and "MT" alternatives for mitochondria.
 
+ * The samtools import command, labelled as obsolete in May 2009 and
+   removed from all help and documentation later that year, has
+   finally been removed.  Use samtools view instead.
+
 Release 1.10 (6th December 2019)
 --------------------------------
 

--- a/bamtk.c
+++ b/bamtk.c
@@ -46,7 +46,6 @@ int bam_fillmd(int argc, char *argv[]);
 int bam_idxstats(int argc, char *argv[]);
 int bam_markdup(int argc, char *argv[]);
 int main_samview(int argc, char *argv[]);
-int main_import(int argc, char *argv[]);
 int main_reheader(int argc, char *argv[]);
 int main_cut_target(int argc, char *argv[]);
 int main_phase(int argc, char *argv[]);
@@ -137,6 +136,11 @@ static void usage(FILE *fp)
 int _CRT_glob = 0;
 #endif
 
+static void bam_import_err(void) {
+    fprintf(stderr, "[main] \"samtools import\" has been removed. "
+            "Please use \"samtools view\" instead.\n");
+}
+
 int main(int argc, char *argv[])
 {
 #ifdef _WIN32
@@ -157,7 +161,7 @@ int main(int argc, char *argv[])
 
     int ret = 0;
     if (strcmp(argv[1], "view") == 0)           ret = main_samview(argc-1, argv+1);
-    else if (strcmp(argv[1], "import") == 0)    ret = main_import(argc-1, argv+1);
+    else if (strcmp(argv[1], "import") == 0)    { bam_import_err(); return 1; }
     else if (strcmp(argv[1], "mpileup") == 0)   ret = bam_mpileup(argc-1, argv+1);
     else if (strcmp(argv[1], "merge") == 0)     ret = bam_merge(argc-1, argv+1);
     else if (strcmp(argv[1], "sort") == 0)      ret = bam_sort(argc-1, argv+1);

--- a/sam_view.c
+++ b/sam_view.c
@@ -891,19 +891,3 @@ static int usage(FILE *fp, int exit_status, int is_long_help)
 
     return exit_status;
 }
-
-int main_import(int argc, char *argv[])
-{
-    int argc2, ret;
-    char **argv2;
-    if (argc != 4) {
-        fprintf(stderr, "Usage: samtools import <in.ref_list> <in.sam> <out.bam>\n");
-        return 1;
-    }
-    argc2 = 6;
-    argv2 = calloc(6, sizeof(char*));
-    argv2[0] = "import", argv2[1] = "-o", argv2[2] = argv[3], argv2[3] = "-bt", argv2[4] = argv[1], argv2[5] = argv[2];
-    ret = main_samview(argc2, argv2);
-    free(argv2);
-    return ret;
-}


### PR DESCRIPTION
This was deleted from the help / usage statements in 2009 (cc207d8)
between 0.1.5 and 0.1.6.  Thus it has never been a documented command
since the official launch of Samtools.

Import was just a wrapper around view, but the wrapper broke when we
added PG headers.  While a fix is trivial, this PR simply removes the
dead and untested code instead.

Fixes #1182 in as far as turning the segmentation fault into a handled
usage error instead.