### PR TITLE
Convert some remaining samtools code to use HTSlib API directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ coverage.o: coverage.c config.h $(htslib_sam_h) $(htslib_hts_h) $(samtools_h) $(
 bam_addrprg.o: bam_addrprg.c config.h $(htslib_sam_h) $(htslib_kstring_h) $(samtools_h) $(htslib_thread_pool_h) $(sam_opts_h)
 bam_aux.o: bam_aux.c config.h $(bam_h)
 bam_cat.o: bam_cat.c config.h $(htslib_bgzf_h) $(htslib_sam_h) $(htslib_cram_h) $(htslib_kstring_h) $(samtools_h) $(sam_opts_h)
-bam_color.o: bam_color.c config.h $(bam_h)
+bam_color.o: bam_color.c config.h $(htslib_sam_h)
 bam_fastq.o: bam_fastq.c config.h $(htslib_sam_h) $(htslib_klist_h) $(htslib_kstring_h) $(htslib_bgzf_h) $(htslib_thread_pool_h) $(samtools_h) $(sam_opts_h)
 bam_index.o: bam_index.c config.h $(htslib_hts_h) $(htslib_sam_h) $(htslib_khash_h) $(samtools_h) $(sam_opts_h)
 bam_lpileup.o: bam_lpileup.c config.h $(bam_plbuf_h) $(bam_lpileup_h) $(htslib_ksort_h)

--- a/bam.c
+++ b/bam.c
@@ -125,21 +125,21 @@ int bam_remove_B(bam1_t *b)
     uint8_t *seq, *qual, *p;
     // test if removal is necessary
     if (b->core.flag & BAM_FUNMAP) return 0; // unmapped; do nothing
-    cigar = bam1_cigar(b);
+    cigar = bam_get_cigar(b);
     for (k = 0; k < b->core.n_cigar; ++k)
         if (bam_cigar_op(cigar[k]) == BAM_CBACK) break;
     if (k == b->core.n_cigar) return 0; // no 'B'
     if (bam_cigar_op(cigar[0]) == BAM_CBACK) goto rmB_err; // cannot be removed
     // allocate memory for the new CIGAR
-    if (b->data_len + (b->core.n_cigar + 1) * 4 > b->m_data) { // not enough memory
-        b->m_data = b->data_len + b->core.n_cigar * 4;
+    if (b->l_data + (b->core.n_cigar + 1) * 4 > b->m_data) { // not enough memory
+        b->m_data = b->l_data + b->core.n_cigar * 4;
         kroundup32(b->m_data);
         b->data = (uint8_t*)realloc(b->data, b->m_data);
-        cigar = bam1_cigar(b); // after realloc, cigar may be changed
+        cigar = bam_get_cigar(b); // after realloc, cigar may be changed
     }
     new_cigar = (uint32_t*)(b->data + (b->m_data - b->core.n_cigar * 4)); // from the end of b->data
     // the core loop
-    seq = bam1_seq(b); qual = bam1_qual(b);
+    seq = bam_get_seq(b); qual = bam_get_qual(b);
     no_qual = (qual[0] == 0xff); // test whether base quality is available
     i = j = 0; end_j = -1;
     for (k = l = 0; k < b->core.n_cigar; ++k) {
@@ -168,9 +168,9 @@ int bam_remove_B(bam1_t *b)
                 if (i != j) { // no need to copy if i == j
                     int u, c, c0;
                     for (u = 0; u < len; ++u) { // construct the consensus
-                        c = bam1_seqi(seq, i+u);
+                        c = bam_seqi(seq, i+u);
                         if (j + u < end_j) { // in an overlap
-                            c0 = bam1_seqi(seq, j+u);
+                            c0 = bam_seqi(seq, j+u);
                             if (c != c0) { // a mismatch; choose the better base
                                 if (qual[j+u] < qual[i+u]) { // the base in the 2nd segment is better
                                     bam1_seq_seti(seq, j+u, c);
@@ -202,9 +202,9 @@ int bam_remove_B(bam1_t *b)
     p = b->data + b->core.l_qname + l * 4;
     memmove(p, seq, (j+1)>>1); p += (j+1)>>1; // set SEQ
     memmove(p, qual, j); p += j; // set QUAL
-    memmove(p, bam1_aux(b), bam_get_l_aux(b)); p += bam_get_l_aux(b); // set optional fields
+    memmove(p, bam_get_aux(b), bam_get_l_aux(b)); p += bam_get_l_aux(b); // set optional fields
     b->core.n_cigar = l, b->core.l_qseq = j; // update CIGAR length and query length
-    b->data_len = p - b->data; // update record length
+    b->l_data = p - b->data; // update record length
     return 0;
 
 rmB_err:

--- a/bam_aux.c
+++ b/bam_aux.c
@@ -50,13 +50,13 @@ int bam_aux_drop_other(bam1_t *b, uint8_t *s)
 {
     if (s) {
         uint8_t *p, *aux;
-        aux = bam1_aux(b);
+        aux = bam_get_aux(b);
         p = s - 2;
         __skip_tag(s);
         memmove(aux, p, s - p);
-        b->data_len -= bam_get_l_aux(b) - (s - p);
+        b->l_data -= bam_get_l_aux(b) - (s - p);
     } else {
-        b->data_len -= bam_get_l_aux(b);
+        b->l_data -= bam_get_l_aux(b);
     }
     return 0;
 }

--- a/bam_color.c
+++ b/bam_color.c
@@ -25,7 +25,9 @@ DEALINGS IN THE SOFTWARE.  */
 #include <config.h>
 
 #include <ctype.h>
-#include "bam.h"
+#include <string.h>
+
+#include "htslib/sam.h"
 
 /*!
  @abstract     Get the color encoding the previous and current base
@@ -45,10 +47,10 @@ char bam_aux_getCSi(bam1_t *b, int i)
 
     cs = bam_aux2Z(c);
     // adjust for strandedness and leading adaptor
-    if(bam1_strand(b)) {
+    if(bam_is_rev(b)) {
         i = strlen(cs) - 1 - i;
         // adjust for leading hard clip
-        uint32_t cigar = bam1_cigar(b)[0];
+        uint32_t cigar = bam_get_cigar(b)[0];
         if((cigar & BAM_CIGAR_MASK) == BAM_CHARD_CLIP) {
         i -= cigar >> BAM_CIGAR_SHIFT;
         }
@@ -74,10 +76,10 @@ char bam_aux_getCQi(bam1_t *b, int i)
 
     cq = bam_aux2Z(c);
     // adjust for strandedness
-    if(bam1_strand(b)) {
+    if(bam_is_rev(b)) {
         i = strlen(cq) - 1 - i;
         // adjust for leading hard clip
-        uint32_t cigar = bam1_cigar(b)[0];
+        uint32_t cigar = bam_get_cigar(b)[0];
         if((cigar & BAM_CIGAR_MASK) == BAM_CHARD_CLIP) {
         i -= (cigar >> BAM_CIGAR_SHIFT);
         }
@@ -135,28 +137,28 @@ char bam_aux_getCEi(bam1_t *b, int i)
     cs = bam_aux2Z(c);
 
     // adjust for strandedness and leading adaptor
-    if(bam1_strand(b)) { //reverse strand
+    if(bam_is_rev(b)) { //reverse strand
         cs_i = strlen(cs) - 1 - i;
         // adjust for leading hard clip
-        uint32_t cigar = bam1_cigar(b)[0];
+        uint32_t cigar = bam_get_cigar(b)[0];
         if((cigar & BAM_CIGAR_MASK) == BAM_CHARD_CLIP) {
             cs_i -= cigar >> BAM_CIGAR_SHIFT;
         }
         // get current color
         cur_color = cs[cs_i];
         // get previous base.  Note: must rc adaptor
-        prev_b = (cs_i == 1) ? "TGCAN"[(int)bam_aux_nt2int(cs[0])] : bam_nt16_rev_table[bam1_seqi(bam1_seq(b), i+1)];
+        prev_b = (cs_i == 1) ? "TGCAN"[(int)bam_aux_nt2int(cs[0])] : seq_nt16_str[bam_seqi(bam_get_seq(b), i+1)];
         // get current base
-        cur_b = bam_nt16_rev_table[bam1_seqi(bam1_seq(b), i)];
+        cur_b = seq_nt16_str[bam_seqi(bam_get_seq(b), i)];
     }
     else {
         cs_i=i+1;
         // get current color
         cur_color = cs[cs_i];
         // get previous base
-        prev_b = (0 == i) ? cs[0] : bam_nt16_rev_table[bam1_seqi(bam1_seq(b), i-1)];
+        prev_b = (0 == i) ? cs[0] : seq_nt16_str[bam_seqi(bam_get_seq(b), i-1)];
         // get current base
-        cur_b = bam_nt16_rev_table[bam1_seqi(bam1_seq(b), i)];
+        cur_b = seq_nt16_str[bam_seqi(bam_get_seq(b), i)];
     }
 
     // corrected color


### PR DESCRIPTION
Contrary to my assumption in #1184, it turns out that there are still a few functions that are actually used in the samtools executable that are still written in terms of the legacy _bam.h_ API. These ones are used for somewhat legacy purposes, but it seems easiest to keep them and convert them to use HTSlib directly:

* bam_remove_B(), used in sam_view.c. (Of the other functions in bam.c, only bam_get_library() is used in samtools.)

* bam_aux_drop_other(), used in bam_md.c to implement the undocumented `calmd -d` option. This function's functionality may be a candidate for adding via a new HTSlib API function, at which point samtools's `bam_aux_drop_other` would disappear.

* bam_color.c functions, used in bam_tview.c. As there are no legacy functions also defined in bam_color.c, this PR completely converts _bam_color.c_, changing its #includes and Makefile dependencies to use HTSlib headers directly.

As I have a sed script that does most of this conversion, here is a PR :smile: