### PR TITLE
Make more functions static.

### DIFF
--- a/bam_cat.c
+++ b/bam_cat.c
@@ -196,7 +196,7 @@ fail:
  * huffman code.  In this situation we can change the meta-data in the
  * compression header to renumber an RG value..
  */
-int cram_cat(int nfn, char * const *fn, const sam_hdr_t *h, const char* outcram, sam_global_args *ga, char *arg_list, int no_pg)
+static int cram_cat(int nfn, char * const *fn, const sam_hdr_t *h, const char* outcram, sam_global_args *ga, char *arg_list, int no_pg)
 {
     samFile *out;
     cram_fd *out_c;
@@ -338,7 +338,7 @@ int cram_cat(int nfn, char * const *fn, const sam_hdr_t *h, const char* outcram,
 
 #define BGZF_EMPTY_BLOCK_SIZE 28
 
-int bam_cat(int nfn, char * const *fn, sam_hdr_t *h, const char* outbam, char *arg_list, int no_pg)
+static int bam_cat(int nfn, char * const *fn, sam_hdr_t *h, const char* outbam, char *arg_list, int no_pg)
 {
     BGZF *fp, *in = NULL;
     uint8_t *buf = NULL;

--- a/bam_fastq.c
+++ b/bam_fastq.c
@@ -49,7 +49,7 @@ KLIST_INIT(ktaglist, char*, taglist_free)
 #define DEFAULT_QUALITY_TAG "QT"
 #define INDEX_SEPARATOR "+"
 
-int8_t seq_comp_table[16] = { 0, 8, 4, 12, 2, 10, 6, 14, 1, 9, 5, 13, 3, 11, 7, 15 };
+static int8_t seq_comp_table[16] = { 0, 8, 4, 12, 2, 10, 6, 14, 1, 9, 5, 13, 3, 11, 7, 15 };
 static const char *copied_tags[] = { "RG", "BC", "QT", NULL };
 
 static void bam2fq_usage(FILE *to, const char *command)

--- a/bam_index.c
+++ b/bam_index.c
@@ -114,7 +114,7 @@ int bam_index(int argc, char *argv[])
  * Returns 0 on success,
  *        -1 on failure.
  */
-int slow_idxstats(samFile *fp, sam_hdr_t *header) {
+static int slow_idxstats(samFile *fp, sam_hdr_t *header) {
     int ret, last_tid = -2;
     bam1_t *b = bam_init1();
 

--- a/bam_mate.c
+++ b/bam_mate.c
@@ -401,7 +401,7 @@ static int bam_mating_core(samFile *in, samFile *out, int remove_reads, int prop
     return 1;
 }
 
-void usage(FILE* where)
+static void usage(FILE* where)
 {
     fprintf(where,
 "Usage: samtools fixmate <in.nameSrt.bam> <out.nameSrt.bam>\n"

--- a/bam_md.c
+++ b/bam_md.c
@@ -46,7 +46,7 @@ DEALINGS IN THE SOFTWARE.  */
 
 int bam_aux_drop_other(bam1_t *b, uint8_t *s);
 
-void bam_fillmd1_core(bam1_t *b, char *ref, hts_pos_t ref_len, int flag, int max_nm, int quiet_mode)
+static void bam_fillmd1_core(bam1_t *b, char *ref, hts_pos_t ref_len, int flag, int max_nm, int quiet_mode)
 {
     uint8_t *seq = bam_get_seq(b);
     uint32_t *cigar = bam_get_cigar(b);
@@ -166,7 +166,7 @@ void bam_fillmd1(bam1_t *b, char *ref, int flag, int quiet_mode)
     bam_fillmd1_core(b, ref, INT_MAX, flag, 0, quiet_mode);
 }
 
-int calmd_usage() {
+static int calmd_usage() {
     fprintf(stderr,
 "Usage: samtools calmd [-eubrAESQ] <aln.bam> <ref.fasta>\n"
 "Options:\n"

--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -1050,7 +1050,7 @@ int read_file_list(const char *file_list,int *n,char **argv[])
 }
 #undef MAX_PATH_LEN
 
-int parse_format_flag(const char *str)
+static int parse_format_flag(const char *str)
 {
     int i, flag = 0, n_tags;
     char **tags = hts_readlist(str, 0, &n_tags);

--- a/bam_reheader.c
+++ b/bam_reheader.c
@@ -43,8 +43,8 @@ DEALINGS IN THE SOFTWARE.  */
  * Reads a file and outputs a new BAM file to fd with 'h' replaced as
  * the header.    No checks are made to the validity.
  */
-int bam_reheader(BGZF *in, sam_hdr_t *h, int fd,
-                 const char *arg_list, int no_pg, int skip_header)
+static int bam_reheader(BGZF *in, sam_hdr_t *h, int fd,
+                        const char *arg_list, int no_pg, int skip_header)
 {
     BGZF *fp = NULL;
     ssize_t len;
@@ -118,7 +118,7 @@ int bam_reheader(BGZF *in, sam_hdr_t *h, int fd,
  *
  * FIXME: error checking
  */
-int cram_reheader(cram_fd *in, sam_hdr_t *h, const char *arg_list, int no_pg)
+static int cram_reheader(cram_fd *in, sam_hdr_t *h, const char *arg_list, int no_pg)
 {
     htsFile *h_out = hts_open("-", "wc");
     cram_fd *out = h_out->fp.cram;
@@ -182,8 +182,8 @@ int cram_reheader(cram_fd *in, sam_hdr_t *h, const char *arg_list, int no_pg)
  *        -1 on general failure;
  *        -2 on failure due to insufficient size
  */
-int cram_reheader_inplace2(cram_fd *fd, sam_hdr_t *h, const char *arg_list,
-                          int no_pg)
+static int cram_reheader_inplace2(cram_fd *fd, sam_hdr_t *h, const char *arg_list,
+                                  int no_pg)
 {
     cram_container *c = NULL;
     cram_block *b = NULL;
@@ -279,8 +279,8 @@ int cram_reheader_inplace2(cram_fd *fd, sam_hdr_t *h, const char *arg_list,
  *        -1 on general failure;
  *        -2 on failure due to insufficient size
  */
-int cram_reheader_inplace3(cram_fd *fd, sam_hdr_t *h, const char *arg_list,
-                          int no_pg)
+static int cram_reheader_inplace3(cram_fd *fd, sam_hdr_t *h, const char *arg_list,
+                                  int no_pg)
 {
     cram_container *c = NULL;
     cram_block *b = NULL;
@@ -417,8 +417,8 @@ int cram_reheader_inplace3(cram_fd *fd, sam_hdr_t *h, const char *arg_list,
     return ret;
 }
 
-int cram_reheader_inplace(cram_fd *fd, sam_hdr_t *h, const char *arg_list,
-                         int no_pg)
+static int cram_reheader_inplace(cram_fd *fd, sam_hdr_t *h, const char *arg_list,
+                                 int no_pg)
 {
     switch (cram_major_vers(fd)) {
     case 2: return cram_reheader_inplace2(fd, h, arg_list, no_pg);

--- a/bam_rmdup.c
+++ b/bam_rmdup.c
@@ -127,7 +127,7 @@ static inline int sum_qual(const bam1_t *b)
     return q;
 }
 
-int bam_rmdup_core(samFile *in, sam_hdr_t *hdr, samFile *out)
+static int bam_rmdup_core(samFile *in, sam_hdr_t *hdr, samFile *out)
 {
     bam1_t *b = NULL;
     int last_tid = -1, last_pos = -1, r;

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -884,7 +884,7 @@ static void bam_translate(bam1_t* b, trans_tbl_t* tbl)
     }
 }
 
-int* rtrans_build(int n, int n_targets, trans_tbl_t* translation_tbl)
+static int* rtrans_build(int n, int n_targets, trans_tbl_t* translation_tbl)
 {
     // Create reverse translation table for tids
     int* rtrans = (int*)malloc(sizeof(int32_t)*n*n_targets);
@@ -984,11 +984,11 @@ static hts_reglist_t *duplicate_reglist(const hts_reglist_t *rl, int rn) {
   @discussion Padding information may NOT correctly maintained. This
   function is NOT thread safe.
  */
-int bam_merge_core2(int by_qname, char* sort_tag, const char *out, const char *mode,
-                    const char *headers, int n, char * const *fn, char * const *fn_idx,
-                    const char *fn_bed, int flag, const char *reg, int n_threads,
-                    const char *cmd, const htsFormat *in_fmt, const htsFormat *out_fmt,
-                    int write_index, char *arg_list, int no_pg)
+static int bam_merge_core2(int by_qname, char* sort_tag, const char *out, const char *mode,
+                           const char *headers, int n, char * const *fn, char * const *fn_idx,
+                           const char *fn_bed, int flag, const char *reg, int n_threads,
+                           const char *cmd, const htsFormat *in_fmt, const htsFormat *out_fmt,
+                           int write_index, char *arg_list, int no_pg)
 {
     samFile *fpout, **fp = NULL;
     heap1_t *heap = NULL;
@@ -1371,16 +1371,6 @@ int bam_merge_core2(int by_qname, char* sort_tag, const char *out, const char *m
     free(rtrans);
     free(out_idx_fn);
     return -1;
-}
-
-// Unused here but may be used by legacy samtools-using third-party code
-int bam_merge_core(int by_qname, const char *out, const char *headers, int n, char * const *fn, int flag, const char *reg)
-{
-    char mode[12];
-    strcpy(mode, "wb");
-    if (flag & MERGE_UNCOMP) strcat(mode, "0");
-    else if (flag & MERGE_LEVEL1) strcat(mode, "1");
-    return bam_merge_core2(by_qname, NULL, out, mode, headers, n, fn, NULL, NULL, flag, reg, 0, "merge", NULL, NULL, 0, NULL, 1);
 }
 
 static void merge_usage(FILE *to)
@@ -1786,7 +1776,7 @@ static inline int bam1_cmp_core(const bam1_tag a, const bam1_tag b)
     }
 }
 
-uint8_t normalize_type(const uint8_t* aux) {
+static uint8_t normalize_type(const uint8_t* aux) {
     if (*aux == 'c' || *aux == 'C' || *aux == 's' || *aux == 'S' || *aux == 'i' || *aux == 'I') {
         return 'c';
     } else if (*aux == 'f' || *aux == 'd') {
@@ -2133,11 +2123,11 @@ static int sort_blocks(int n_files, size_t k, bam1_tag *buf, const char *prefix,
   and then merge them by calling bam_merge_simple(). This function is
   NOT thread safe.
  */
-int bam_sort_core_ext(int is_by_qname, char* sort_by_tag, const char *fn, const char *prefix,
-                      const char *fnout, const char *modeout,
-                      size_t _max_mem, int n_threads,
-                      const htsFormat *in_fmt, const htsFormat *out_fmt,
-                      char *arg_list, int no_pg, int write_index)
+static int bam_sort_core_ext(int is_by_qname, char* sort_by_tag, const char *fn, const char *prefix,
+                             const char *fnout, const char *modeout,
+                             size_t _max_mem, int n_threads,
+                             const htsFormat *in_fmt, const htsFormat *out_fmt,
+                             char *arg_list, int no_pg, int write_index)
 {
     int ret = -1, res, i, n_files = 0;
     size_t max_k, k, max_mem, bam_mem_offset;
@@ -2319,18 +2309,6 @@ int bam_sort_core_ext(int is_by_qname, char* sort_by_tag, const char *fn, const 
     free(in_mem);
     sam_hdr_destroy(header);
     if (fp) sam_close(fp);
-    return ret;
-}
-
-// Unused here but may be used by legacy samtools-using third-party code
-int bam_sort_core(int is_by_qname, const char *fn, const char *prefix, size_t max_mem)
-{
-    int ret;
-    char *fnout = calloc(strlen(prefix) + 4 + 1, 1);
-    if (!fnout) return -1;
-    sprintf(fnout, "%s.bam", prefix);
-    ret = bam_sort_core_ext(is_by_qname, NULL, fn, prefix, fnout, "wb", max_mem, 0, NULL, NULL, NULL, 1, 0);
-    free(fnout);
     return ret;
 }
 

--- a/bam_stat.c
+++ b/bam_stat.c
@@ -69,7 +69,7 @@ typedef struct {
         if ((c)->flag & BAM_FDUP) ++(s)->n_dup[w];                      \
     } while (0)
 
-bam_flagstat_t *bam_flagstat_core(samFile *fp, sam_hdr_t *h)
+static bam_flagstat_t *bam_flagstat_core(samFile *fp, sam_hdr_t *h)
 {
     bam_flagstat_t *s;
     bam1_t *b;

--- a/bam_tview.c
+++ b/bam_tview.c
@@ -34,6 +34,8 @@ DEALINGS IN THE SOFTWARE.  */
 #include "samtools.h"
 #include "sam_opts.h"
 
+static int tv_pl_func(uint32_t tid, hts_pos_t pos, int n, const bam_pileup1_t *pl, void *data);
+
 // Threshold where spacing of numbers on the scale line changes from 10 to 20
 // to stop them running into each other.
 #define TEN_DIGITS 1000000000
@@ -170,7 +172,7 @@ void base_tv_destroy(tview_t* tv)
 }
 
 
-int tv_pl_func(uint32_t tid, hts_pos_t pos, int n, const bam_pileup1_t *pl, void *data)
+static int tv_pl_func(uint32_t tid, hts_pos_t pos, int n, const bam_pileup1_t *pl, void *data)
 {
     tview_t *tv = (tview_t*)data;
     hts_pos_t cp;

--- a/bam_tview.h
+++ b/bam_tview.h
@@ -89,7 +89,6 @@ char bam_aux_getCQi(bam1_t *b, int i);
 #define TV_BASE_NUCL 0
 #define TV_BASE_COLOR_SPACE 1
 
-int tv_pl_func(uint32_t tid, hts_pos_t pos, int n, const bam_pileup1_t *pl, void *data);
 // Added fn_idx to arguments as index file
 int base_tv_init(tview_t*,const char *fn, const char *fn_fa, const char *fn_idx,
                  const char *samples, const htsFormat *fmt);

--- a/bamshuf.c
+++ b/bamshuf.c
@@ -546,7 +546,7 @@ static int usage(FILE *fp, int n_files, int reads_store) {
     return 1;
 }
 
-char * generate_prefix() {
+static char *generate_prefix() {
     char *prefix;
     unsigned int pid = getpid();
 #ifdef _WIN32

--- a/coverage.c
+++ b/coverage.c
@@ -205,7 +205,7 @@ static int read_bam(void *data, bam1_t *b) {
     return ret;
 }
 
-void print_tabular_line(FILE *file_out, const sam_hdr_t *h, const stats_aux_t *stats) {
+static void print_tabular_line(FILE *file_out, const sam_hdr_t *h, const stats_aux_t *stats) {
     fputs(sam_hdr_tid2name(h, stats->tid), file_out);
     double region_len = (double) stats->end - stats->beg;
     fprintf(file_out, "\t%"PRId64"\t%"PRId64"\t%u\t%llu\t%g\t%g\t%.3g\t%.3g\n",
@@ -220,8 +220,8 @@ void print_tabular_line(FILE *file_out, const sam_hdr_t *h, const stats_aux_t *s
            );
 }
 
-void print_hist(FILE *file_out, const sam_hdr_t *h, const stats_aux_t *stats, const uint32_t *hist,
-        const int hist_size, const bool full_utf) {
+static void print_hist(FILE *file_out, const sam_hdr_t *h, const stats_aux_t *stats,
+                       const uint32_t *hist, const int hist_size, const bool full_utf) {
     int i, col;
     bool show_percentiles = false;
     const int n_rows = 10;

--- a/faidx.c
+++ b/faidx.c
@@ -232,7 +232,7 @@ static int usage(FILE *fp, enum fai_format_options format, int exit_status)
     return exit_status;
 }
 
-int faidx_core(int argc, char *argv[], enum fai_format_options format)
+static int faidx_core(int argc, char *argv[], enum fai_format_options format)
 {
     int c, ignore_error = 0, rev = 0;
     int line_len = DEFAULT_FASTA_LINE_LEN ;/* fasta line len */

--- a/padding.c
+++ b/padding.c
@@ -189,7 +189,7 @@ static inline int * update_posmap(int *posmap, kstring_t ref)
     return posmap;
 }
 
-int bam_pad2unpad(samFile *in, samFile *out,  sam_hdr_t *h, faidx_t *fai)
+static int bam_pad2unpad(samFile *in, samFile *out,  sam_hdr_t *h, faidx_t *fai)
 {
     bam1_t *b = 0;
     kstring_t r, q;


### PR DESCRIPTION
Current policy is now all functions must be static, even in the executable.

The only ones left non-static are when used in other .c files or when
part of $(LOBJS) and hence part of libbam.a (although in time those
too will change).

(Note this has meant complete removal of some functions, along with
their warnings that they may be used by third party applications,
albeit presumably by dint of complete hackery and manually copying
over .c files into their own projects.)