### PR TITLE
Avoid calling fclose() on stdout

### DIFF
--- a/bam2depth.c
+++ b/bam2depth.c
@@ -368,11 +368,12 @@ int main_depth(int argc, char *argv[])
     }
 
 depth_end:
-    if (fclose(file_out) != 0) {
+    if (((file_out != stdout)? fclose(file_out) : fflush(file_out)) != 0) {
         if (status == EXIT_SUCCESS) {
-            print_error_errno("depth", "error on closing \"%s\"",
-                              (output_file && strcmp(output_file, "-") != 0
-                               ? output_file : "stdout"));
+            if (file_out != stdout)
+                print_error_errno("depth", "error on closing \"%s\"", output_file);
+            else
+                print_error_errno("depth", "error on flushing standard output");
             status = EXIT_FAILURE;
         }
     }


### PR DESCRIPTION
Stops `samtools depth` from closing `stdout`, which was the cause of [these Pysam build failures on Linux](https://travis-ci.org/jmarshall/pysam/builds/660188509). Leaving `stdout` open facilitates wrappers such as pysam that call samtools's `main()` and/or `main_depth()` as subroutines.

Other samtools subcommands I looked at that call `fclose()` call it only when output has indeed been redirected and a file explicitly `fopen()ed`.

(It would be mostly possible to detect this in pysam's wrapper function and not crash, but only mostly and at the cost of instead leaking the `FILE *` in cases where the underlying fd for stdout has been `close()ed`, e.g. bam2fq and reheader.)