### PR TITLE
[bedcov] Reset skip counter for each file

### DIFF
--- a/bedcov.c
+++ b/bedcov.c
@@ -180,12 +180,14 @@ int main_bedcov(int argc, char *argv[])
         memset(cnt, 0, 8 * n);
         while (bam_mplp_auto(mplp, &tid, &pos, n_plp, plp) > 0)
             if (pos >= beg && pos < end) {
-                for (i = 0, m = 0; i < n; ++i) {
-                    if (skip_DN)
+                for (i = 0; i < n; ++i) {
+                    m = 0;
+                    if (skip_DN) {
                         for (j = 0; j < n_plp[i]; ++j) {
                             const bam_pileup1_t *pi = plp[i] + j;
                             if (pi->is_del || pi->is_refskip) ++m;
                         }
+                    }
                     cnt[i] += n_plp[i] - m;
                 }
             }


### PR DESCRIPTION
When running `bedcov` on multiple files, the counter for positions that have to be skipped should be reset for each file.