### PR TITLE
[split] Add -d TAG option

### DIFF
--- a/bam_addrprg.c
+++ b/bam_addrprg.c
@@ -410,10 +410,11 @@ static bool readgroupise(parsed_opts_t *opts, state_t* state, char *arg_list)
         print_error_errno("addreplacerg", "[%s] Could not write header to output file", __func__);
         return false;
     }
-    char *idx_fn = NULL;
     if (opts->ga.write_index) {
-        if (!(idx_fn = auto_index(state->output_file, opts->output_name, state->output_header)))
+        if (auto_index(state->output_file, opts->output_name, state->output_header) < 0) {
+            print_error_errno("addreplacerg", "[%s] Auto-indexing failed", __func__);
             return false;
+        }
     }
 
     bam1_t* file_read = bam_init1();
@@ -424,25 +425,21 @@ static bool readgroupise(parsed_opts_t *opts, state_t* state, char *arg_list)
         if (sam_write1(state->output_file, state->output_header, file_read) < 0) {
             print_error_errno("addreplacerg", "[%s] Could not write read to output file", __func__);
             bam_destroy1(file_read);
-            free(idx_fn);
             return false;
         }
     }
     bam_destroy1(file_read);
     if (ret != -1) {
         print_error_errno("addreplacerg", "[%s] Error reading from input file", __func__);
-        free(idx_fn);
         return false;
     } else {
 
         if (opts->ga.write_index) {
             if (sam_idx_save(state->output_file) < 0) {
                 print_error_errno("addreplacerg", "[%s] Writing index failed", __func__);
-                free(idx_fn);
                 return false;
             }
         }
-        free(idx_fn);
         return true;
     }
 }

--- a/bam_markdup.c
+++ b/bam_markdup.c
@@ -1150,7 +1150,6 @@ static int bam_mark_duplicates(md_param_t *param) {
     long np_duplicate, np_opt_duplicate;
     long opt_warnings = 0;
     tmp_file_t temp;
-    char *idx_fn = NULL;
     int exclude = 0;
 
     if (!pair_hash || !single_hash || !read_buffer || !dup_hash) {
@@ -1185,8 +1184,10 @@ static int bam_mark_duplicates(md_param_t *param) {
         goto fail;
     }
     if (param->write_index) {
-        if (!(idx_fn = auto_index(param->out, param->out_fn, header)))
+        if (auto_index(param->out, param->out_fn, header) < 0) {
+            fprintf(stderr, "[markdup] error auto-indexing.\n");
             goto fail;
+        }
     }
 
     // used for coordinate order checks

--- a/bam_split.c
+++ b/bam_split.c
@@ -634,7 +634,7 @@ static bool split(state_t* state, parsed_opts_t *opts, char *arg_list)
                 int i = prep_sam_file(opts, state, bam_aux2Z(tag), arg_list);
                 if (i >= 0) {
                     samFile *sf = kh_val(state->tf_hash, (khint_t)i);
-                    if (sam_write1(sf, hts_get_hdr(sf), file_read) < 0) {
+                    if (sam_write1(sf, NULL, file_read) < 0) {
                         print_error_errno("split", "Could not write to \"%s\"", hts_get_fn(sf));
                         goto error;
                     }

--- a/doc/samtools-split.1
+++ b/doc/samtools-split.1
@@ -59,7 +59,7 @@ records without an RG tag.
 .SH OPTIONS
 .TP 14
 .BI "-u " FILE1
-.RI "Put reads with no RG tag or an unrecognised RG tag into " FILE1
+.RI "Put reads with no tag or an unrecognised tag into " FILE1
 .TP
 .BI "-h " FILE2
 .RI "Use the header from " FILE2 " when writing the file given in the " -u
@@ -72,6 +72,12 @@ references must be in the same order and have the same lengths.
 .BI "-f " STRING
 Output filename format string (see below)
 ["%*_%#.%."]
+.TP
+.BI "-d " TAG
+Split reads by TAG value into distinct files. Only the TAG key must be 
+supplied with the option. The value of the TAG has to be a string (i.e.
+.B key:Z:value
+)
 .TP
 .B -v
 Verbose output

--- a/padding.c
+++ b/padding.c
@@ -447,7 +447,7 @@ int main_pad2unpad(int argc, char *argv[])
     sam_hdr_t *h = 0, *h_fix = 0;
     faidx_t *fai = 0;
     int c, compress_level = -1, is_long_help = 0, no_pg = 0;
-    char in_mode[5], out_mode[6], *fn_out = 0, *fn_fai = 0, *fn_out_idx = NULL;
+    char in_mode[5], out_mode[6], *fn_out = 0, *fn_fai = 0;
     int ret=0;
     char *arg_list = NULL;
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
@@ -560,7 +560,7 @@ int main_pad2unpad(int argc, char *argv[])
         goto depad_end;
     }
     if (ga.write_index) {
-        if (!(fn_out_idx = auto_index(out, fn_out, h_fix))) {
+        if (auto_index(out, fn_out, h_fix) < 0) {
             ret = 1;
             goto depad_end;
         }
@@ -588,8 +588,6 @@ depad_end:
         ret = 1;
     }
     free(fn_fai); free(fn_out);
-    if (fn_out_idx)
-        free(fn_out_idx);
     sam_global_args_free(&ga);
     return ret;
 }

--- a/sam_view.c
+++ b/sam_view.c
@@ -267,7 +267,7 @@ int main_samview(int argc, char *argv[])
     sam_hdr_t *header = NULL;
     char out_mode[5], out_un_mode[5], *out_format = "";
     char *fn_in = 0, *fn_idx_in = 0, *fn_out = 0, *fn_fai = 0, *q, *fn_un_out = 0;
-    char *fn_out_idx = NULL, *fn_un_out_idx = NULL, *arg_list = NULL;
+    char *arg_list = NULL;
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
     htsThreadPool p = {NULL, 0};
     int filter_state = ALL, filter_op = 0;
@@ -550,7 +550,7 @@ int main_samview(int argc, char *argv[])
             }
         }
         if (ga.write_index) {
-            if (!(fn_out_idx = auto_index(out, fn_out, header))) {
+            if (auto_index(out, fn_out, header) < 0) {
                 ret = 1;
                 goto view_end;
             }
@@ -579,7 +579,7 @@ int main_samview(int argc, char *argv[])
                 }
             }
             if (ga.write_index) {
-                if (!(fn_un_out_idx = auto_index(un_out, fn_un_out, header))) {
+                if (auto_index(un_out, fn_un_out, header) < 0) {
                     ret = 1;
                     goto view_end;
                 }
@@ -789,10 +789,6 @@ view_end:
     if (p.pool)
         hts_tpool_destroy(p.pool);
 
-    if (fn_out_idx)
-        free(fn_out_idx);
-    if (fn_un_out_idx)
-        free(fn_un_out_idx);
     free(arg_list);
 
     return ret;

--- a/samtools.h
+++ b/samtools.h
@@ -41,12 +41,9 @@ void check_sam_close(const char *subcmd, samFile *fp, const char *fname, const c
  * Utility function to add an index to a file we've opened for write.
  * NB: Call this after writing the header and before writing sequences.
  *
- * The returned index filename should be freed by the caller, but only
- * after sam_idx_save has been called.
- *
- * Returns index filename on success,
- *         NULL on failure.
+ * Returns  0 on success,
+ *         -1 on failure.
  */
-char *auto_index(htsFile *fp, const char *fn, bam_hdr_t *header);
+int auto_index(htsFile *fp, const char *fn, bam_hdr_t *header);
 
 #endif


### PR DESCRIPTION
Adds a new option to `samtools split` command, which allows the user to split reads into distinct files by a custom read tag (with a string type value). E.g. `samtools split -d hc align.sam`, where some of the reads in `align.sam` have a tag in the format `hc:Z:<string value>`.
Options `-u` is also available with `-d`.

Change the return type of `auto_index` method from `char*` to `int`, since a separate pointer to the index file name is no longer needed. 

Depends on https://github.com/samtools/htslib/pull/1055

