### PR TITLE
Minor documentation formatting fixes

### DIFF
--- a/doc/samtools-stats.1
+++ b/doc/samtools-stats.1
@@ -58,33 +58,33 @@ detailed descriptions.
 
 .TS
 lb l .
-CHK     Checksum
-SN      Summary numbers
-FFQ     First fragment qualities
-LFQ     Last fragment qualities
-GCF     GC content of first fragments
-GCL     GC content of last fragments
-GCC     ACGT content per cycle
-FBC     ACGT content per cycle for first fragments only
-FTC     ACGT raw counters for first fragments
-LBC     ACGT content per cycle for last fragments only
-LTC     ACGT raw counters for last fragments
-BCC     ACGT content per cycle for BC barcode
-CRC     ACGT content per cycle for CR barcode
-OXC     ACGT content per cycle for OX barcode
-RXC     ACGT content per cycle for RX barcode
-QTQ     Quality distribution for BC barcode
-CYQ     Quality distribution for CR barcode
-BZQ     Quality distribution for OX barcode
-QXQ     Quality distribution for RX barcode
-IS      Insert sizes
-RL      Read lengths
-FRL     Read lengths for first fragments only
-LRL     Read lengths for last fragments only
-ID      Indel size distribution
-IC      Indels per cycle
-COV     Coverage (depth) distribution
-GCD     GC-depth
+CHK	Checksum
+SN	Summary numbers
+FFQ	First fragment qualities
+LFQ	Last fragment qualities
+GCF	GC content of first fragments
+GCL	GC content of last fragments
+GCC	ACGT content per cycle
+FBC	ACGT content per cycle for first fragments only
+FTC	ACGT raw counters for first fragments
+LBC	ACGT content per cycle for last fragments only
+LTC	ACGT raw counters for last fragments
+BCC	ACGT content per cycle for BC barcode
+CRC	ACGT content per cycle for CR barcode
+OXC	ACGT content per cycle for OX barcode
+RXC	ACGT content per cycle for RX barcode
+QTQ	Quality distribution for BC barcode
+CYQ	Quality distribution for CR barcode
+BZQ	Quality distribution for OX barcode
+QXQ	Quality distribution for RX barcode
+IS	Insert sizes
+RL	Read lengths
+FRL	Read lengths for first fragments only
+LRL	Read lengths for last fragments only
+ID	Indel size distribution
+IC	Indels per cycle
+COV	Coverage (depth) distribution
+GCD	GC-depth
 .TE
 
 Not all sections will be reported as some depend on the data being

--- a/doc/samtools.1
+++ b/doc/samtools.1
@@ -134,9 +134,9 @@ explicitly indicate where the data and index files reside.
 .SH COMMANDS
 
 Each command has its own man page which can be viewed using
-e.g. \fBman samtools-view\fR or with a recent GNU man using \fBman
-samtools view\fR.  Below we have a brief summary of syntax and
-sub-command description.
+e.g. \fBman samtools-view\fR or with a recent GNU man using
+\fBman samtools view\fR.  Below we have a brief summary of syntax
+and sub-command description.
 
 Options common to all sub-commands are documented below in the GLOBAL
 COMMAND OPTIONS section.


### PR DESCRIPTION
Use actual tab characters to delimit .TS/.TE table rows. (All the other tables in _samtools/doc/*.1_ are already using tabs.)

To improve the formatting on _htslib.org/doc_: man2fhtml converts to HTML one line at a time, so works best when sequences of `\fB...\fR` font escapes are kept within a single line. (It would be possible for man2fhtml to carry the font state from line to line and hopefully not introduce other problems, but Don't Do That is easier for now!)