### PR TITLE
Handle records with no sequence in calmd + add error checks

### DIFF
--- a/bam_md.c
+++ b/bam_md.c
@@ -30,6 +30,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <string.h>
 #include <ctype.h>
 #include <limits.h>
+#include <errno.h>
 #include "htslib/faidx.h"
 #include "htslib/sam.h"
 #include "htslib/kstring.h"
@@ -46,7 +47,7 @@ DEALINGS IN THE SOFTWARE.  */
 
 int bam_aux_drop_other(bam1_t *b, uint8_t *s);
 
-void bam_fillmd1_core(bam1_t *b, char *ref, hts_pos_t ref_len, int flag, int max_nm, int quiet_mode)
+int bam_fillmd1_core(bam1_t *b, char *ref, hts_pos_t ref_len, int flag, int max_nm, int quiet_mode)
 {
     uint8_t *seq = bam_get_seq(b);
     uint32_t *cigar = bam_get_cigar(b);
@@ -55,29 +56,34 @@ void bam_fillmd1_core(bam1_t *b, char *ref, hts_pos_t ref_len, int flag, int max
     hts_pos_t rpos;
     kstring_t str = KS_INITIALIZE;
     int32_t old_nm_i = -1, nm = 0;
+    uint32_t err = 0;
 
     for (i = qpos = 0, rpos = c->pos; i < c->n_cigar; ++i) {
         int j, oplen = cigar[i]>>4, op = cigar[i]&0xf;
         if (op == BAM_CMATCH || op == BAM_CEQUAL || op == BAM_CDIFF) {
             for (j = 0; j < oplen; ++j) {
                 int c1, c2, z = qpos + j;
-                if (rpos+j >= ref_len || ref[rpos+j] == '\0') break; // out of bounds
-                c1 = bam_seqi(seq, z), c2 = seq_nt16_table[(int)ref[rpos+j]];
+                if (rpos+j >= ref_len || z >= c->l_qseq || ref[rpos+j] == '\0')
+                    break; // out of bounds
+                c1 = bam_seqi(seq, z);
+                c2 = seq_nt16_table[(uint8_t)ref[rpos+j]];
                 if ((c1 == c2 && c1 != 15 && c2 != 15) || c1 == 0) { // a match
                     if (flag&USE_EQUAL) seq[z/2] &= (z&1)? 0xf0 : 0x0f;
                     ++matched;
                 } else {
-                    kputw(matched, &str); kputc(toupper(ref[rpos+j]), &str);
+                    err |= kputw(matched, &str) < 0;
+                    err |= kputc(toupper(ref[rpos+j]), &str) < 0;
                     matched = 0; ++nm;
                 }
             }
             if (j < oplen) break;
             rpos += oplen; qpos += oplen;
         } else if (op == BAM_CDEL) {
-            kputw(matched, &str); kputc('^', &str);
+            err |= kputw(matched, &str) < 0;
+            err |= kputc('^', &str) < 0;
             for (j = 0; j < oplen; ++j) {
                 if (rpos+j >= ref_len || ref[rpos+j] == '\0') break;
-                kputc(toupper(ref[rpos+j]), &str);
+                err |= kputc(toupper(ref[rpos+j]), &str) < 0;
             }
             matched = 0;
             rpos += j; nm += j;
@@ -89,7 +95,11 @@ void bam_fillmd1_core(bam1_t *b, char *ref, hts_pos_t ref_len, int flag, int max
             rpos += oplen;
         }
     }
-    kputw(matched, &str);
+    err |= kputw(matched, &str) < 0;
+    if (err) {
+        print_error_errno("calmd", "Couldn't build new MD string");
+        goto fail;
+    }
     // apply max_nm
     if (max_nm > 0 && nm >= max_nm) {
         for (i = qpos = 0, rpos = c->pos; i < c->n_cigar; ++i) {
@@ -97,8 +107,10 @@ void bam_fillmd1_core(bam1_t *b, char *ref, hts_pos_t ref_len, int flag, int max
             if (op == BAM_CMATCH || op == BAM_CEQUAL || op == BAM_CDIFF) {
                 for (j = 0; j < oplen; ++j) {
                     int c1, c2, z = qpos + j;
-                    if (rpos+j >= ref_len || ref[rpos+j] == '\0') break; // out of bounds
-                    c1 = bam_seqi(seq, z), c2 = seq_nt16_table[(int)ref[rpos+j]];
+                    if (rpos+j >= ref_len || z >= c->l_qseq || ref[rpos+j] == '\0')
+                        break; // out of bounds
+                    c1 = bam_seqi(seq, z);
+                    c2 = seq_nt16_table[(uint8_t)ref[rpos+j]];
                     if ((c1 == c2 && c1 != 15 && c2 != 15) || c1 == 0) { // a match
                         seq[z/2] |= (z&1)? 0x0f : 0xf0;
                         bam_get_qual(b)[z] = 0;
@@ -114,20 +126,26 @@ void bam_fillmd1_core(bam1_t *b, char *ref, hts_pos_t ref_len, int flag, int max
     if ((flag & UPDATE_NM) && !(c->flag & BAM_FUNMAP)) {
         uint8_t *old_nm = bam_aux_get(b, "NM");
         if (old_nm) old_nm_i = bam_aux2i(old_nm);
-        if (!old_nm) bam_aux_append(b, "NM", 'i', 4, (uint8_t*)&nm);
+        if (!old_nm) {
+            if (bam_aux_append(b, "NM", 'i', 4, (uint8_t*)&nm) < 0)
+                goto aux_fail;
+        }
         else if (nm != old_nm_i) {
             if (!quiet_mode) {
                 fprintf(stderr, "[bam_fillmd1] different NM for read '%s': %d -> %d\n", bam_get_qname(b), old_nm_i, nm);
             }
-            bam_aux_del(b, old_nm);
-            bam_aux_append(b, "NM", 'i', 4, (uint8_t*)&nm);
+            if (bam_aux_del(b, old_nm) < 0) goto aux_fail;
+            if (bam_aux_append(b, "NM", 'i', 4, (uint8_t*)&nm) < 0)
+                goto aux_fail;
         }
     }
     // update MD
     if ((flag & UPDATE_MD) && !(c->flag & BAM_FUNMAP)) {
         uint8_t *old_md = bam_aux_get(b, "MD");
-        if (!old_md) bam_aux_append(b, "MD", 'Z', str.l + 1, (uint8_t*)str.s);
-        else {
+        if (!old_md) {
+            if (bam_aux_append(b, "MD", 'Z', str.l + 1, (uint8_t*)str.s) < 0)
+                goto aux_fail;
+        } else {
             int is_diff = 0;
             if (strlen((char*)old_md+1) == str.l) {
                 for (i = 0; i < str.l; ++i)
@@ -139,8 +157,9 @@ void bam_fillmd1_core(bam1_t *b, char *ref, hts_pos_t ref_len, int flag, int max
                 if (!quiet_mode) {
                     fprintf(stderr, "[bam_fillmd1] different MD for read '%s': '%s' -> '%s'\n", bam_get_qname(b), old_md+1, str.s);
                 }
-                bam_aux_del(b, old_md);
-                bam_aux_append(b, "MD", 'Z', str.l + 1, (uint8_t*)str.s);
+                if (bam_aux_del(b, old_md) < 0) goto aux_fail;
+                if (bam_aux_append(b, "MD", 'Z', str.l + 1, (uint8_t*)str.s) < 0)
+                    goto aux_fail;
             }
         }
     }
@@ -158,11 +177,24 @@ void bam_fillmd1_core(bam1_t *b, char *ref, hts_pos_t ref_len, int flag, int max
     }
 
     free(str.s);
+    return 0;
+
+ aux_fail:
+    if (errno == ENOMEM) {
+        print_error("calmd", "Couldn't add aux tag (too long)");
+    } else if (errno == EINVAL) {
+        print_error("calmd", "Corrupt aux data");
+    } else {
+        print_error_errno("calmd", "Couldn't add aux tag");
+    }
+ fail:
+    free(str.s);
+    return -1;
 }
 
-void bam_fillmd1(bam1_t *b, char *ref, int flag, int quiet_mode)
+int bam_fillmd1(bam1_t *b, char *ref, int flag, int quiet_mode)
 {
-    bam_fillmd1_core(b, ref, INT_MAX, flag, 0, quiet_mode);
+    return bam_fillmd1_core(b, ref, INT_MAX, flag, 0, quiet_mode);
 }
 
 int calmd_usage() {
@@ -301,12 +333,20 @@ int bam_fillmd(int argc, char *argv[])
                     if (is_realn || capQ > 10) goto fail; // Would otherwise crash
                 }
             }
-            if (is_realn) sam_prob_realn(b, ref, len, baq_flag);
+            if (is_realn) {
+                if (sam_prob_realn(b, ref, len, baq_flag) < -3) {
+                    print_error_errno("calmd", "BAQ alignment failed");
+                    goto fail;
+                }
+            }
             if (capQ > 10) {
                 int q = sam_cap_mapq(b, ref, len, capQ);
                 if (b->core.qual > q) b->core.qual = q;
             }
-            if (ref) bam_fillmd1_core(b, ref, len, flt_flag, max_nm, quiet_mode);
+            if (ref) {
+                if (bam_fillmd1_core(b, ref, len, flt_flag, max_nm, quiet_mode) < 0)
+                    goto fail;
+            }
         }
         if (sam_write1(fpout, header, b) < 0) {
             print_error_errno("calmd", "failed to write to output file");

--- a/doc/samtools-calmd.1
+++ b/doc/samtools-calmd.1
@@ -59,6 +59,15 @@ pointless as CRAM recalculates MD and NM tags on the fly.  The one
 exception to this case is where both input and output CRAM files
 have been / are being created with the \fIno_ref\fR option.
 
+Note that some aligners do not include sequence or confidence values
+in secondary and supplementary alignment records.
+Where this happens in SAM files, a \(lq*\(rq character will be
+seen in the \fBSEQ\fR and \fBQUAL\fR columns.
+These records will be skipped, as it is not possible to recalculate
+the MD and NM tags without access to the query sequence.
+.B samtools calmd
+will emit a warning if any records have been skipped for this reason.
+
 .SH OPTIONS
 .TP 8
 .B -A


### PR DESCRIPTION
* Replace some one-letter variable names in `bam_fillmd1_core()` to make it easier to understand
* Move a kstring to the stack to get rid of a `calloc()`
* Add lots of error checking to `bam_fillmd1_core()` and ensure it doesn't read or write beyond the end of the sequence in the alignment record.
* Make `bam_fillmd1_core()` skip over alignment records where the sequence has not been stored and make it report when this happens.

Fixes #1229