### PR TITLE
More ampliconstats improvements.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ sam_view.o: sam_view.c config.h $(htslib_sam_h) $(htslib_faidx_h) $(htslib_khash
 sample.o: sample.c config.h $(sample_h) $(htslib_khash_h)
 stats_isize.o: stats_isize.c config.h $(stats_isize_h) $(htslib_khash_h)
 stats.o: stats.c config.h $(htslib_faidx_h) $(htslib_sam_h) $(htslib_hts_h) $(htslib_hts_defs_h) $(htslib_khash_str2int_h) $(samtools_h) $(htslib_khash_h) $(htslib_kstring_h) $(stats_isize_h) $(sam_opts_h) $(bedidx_h)
-amplicon_stats.o: amplicon_stats.c config.h $(htslib_sam_h) $(samtools_h) $(sam_opts_h) bam_ampliconclip.h
+amplicon_stats.o: amplicon_stats.c config.h $(htslib_sam_h) $(htslib_khash_h) $(samtools_h) $(sam_opts_h) bam_ampliconclip.h
 bam_markdup.o: bam_markdup.c config.h $(htslib_thread_pool_h) $(htslib_sam_h) $(sam_opts_h) $(samtools_h) $(htslib_khash_h) $(htslib_klist_h) $(htslib_kstring_h) $(tmp_file_h)
 tmp_file.o: tmp_file.c config.h $(tmp_file_h) $(htslib_sam_h)
 bam_ampliconclip.o: bam_ampliconclip.c config.h $(htslib_thread_pool_h) $(sam_opts_h) $(htslib_hts_h) $(htslib_hfile_h) $(htslib_kstring_h) $(htslib_sam_h) $(samtools_h) bam_ampliconclip.h

--- a/amplicon_stats.c
+++ b/amplicon_stats.c
@@ -632,7 +632,8 @@ void dump_stats(char type, char *name, astats_t *stats, astats_args_t *args,
         fprintf(ofp, "CREADS\tSTDDEV");
         for (i = 0; i < namp; i++) {
             double n1 = stats->nreads[i];
-            fprintf(ofp, "\t%.1f", sqrt(stats->nreads2[i]/nfile - (n1/nfile)*(n1/nfile)));
+            fprintf(ofp, "\t%.1f", sqrt(stats->nreads2[i]/(double)nfile
+                                        - (n1/nfile)*(n1/nfile)));
         }
         fprintf(ofp, "\n");
     }

--- a/amplicon_stats.c
+++ b/amplicon_stats.c
@@ -847,7 +847,7 @@ int main_ampliconstats(int argc, char **argv) {
     astats_args_t args = {
         .ga = SAM_GLOBAL_ARGS_INIT,
         .flag_require = 0,
-        .flag_filter = 0x10F04,
+        .flag_filter = 0x10B04,
         .sites = {NULL, 0, 0},
         .max_delta = 30, // large enough to cope with alt primers
         .min_depth = {1},

--- a/amplicon_stats.c
+++ b/amplicon_stats.c
@@ -953,18 +953,18 @@ static int usage(astats_args_t *args, FILE *fp, int exit_status) {
 "\n"
 "Options:\n");
     fprintf(fp, "  -f, --required-flag STR|INT\n"
-            "               Only include reads with all  of the FLAGs in present [0x%X]\n",args->flag_require);
+            "               Only include reads with all of the FLAGs present [0x%X]\n",args->flag_require);
     fprintf(fp, "  -F, --filter-flag STR|INT\n"
-            "               Only include reads with none of the FLAGs in present [0x%X]\n",args->flag_filter & 0xffff);
+            "               Only include reads with none of the FLAGs present [0x%X]\n",args->flag_filter & 0xffff);
     fprintf(fp, "  -a, --max-amplicons INT\n"
             "               Change the maximum number of amplicons permitted [%d]\n", MAX_AMP);
     fprintf(fp, "  -l, --max-amplicon-length INT\n"
-            "               Change the maximum length of an individual ampicon [%d]\n", MAX_AMP_LEN);
+            "               Change the maximum length of an individual amplicon [%d]\n", MAX_AMP_LEN);
     fprintf(fp, "  -d, --min-depth INT[,INT]...\n"
             "               Minimum base depth(s) to consider position covered [%d]\n", args->min_depth[0]);
     fprintf(fp, "  -m, --pos-margin INT\n"
-            "               Margin of error for matching primer positions [%d]n", args->max_delta);
-    fprintf(fp, "  -o, FILE\n"
+            "               Margin of error for matching primer positions [%d]\n", args->max_delta);
+    fprintf(fp, "  -o, --output FILE\n"
             "               Specify output file [stdout if unset]\n");
     fprintf(fp, "  -s, --use-sample-name\n"
             "               Use the sample name from the first @RG header line\n");
@@ -1000,6 +1000,7 @@ int main_ampliconstats(int argc, char **argv) {
         {"flag-require", required_argument, NULL, 'f'},
         {"flag-filter", required_argument, NULL, 'F'},
         {"min-depth", required_argument, NULL, 'd'},
+        {"output", required_argument, NULL, 'o'},
         {"pos-margin", required_argument, NULL, 'm'},
         {"use-sample-name", no_argument, NULL, 's'},
         {"max-amplicons", required_argument, NULL, 'a'},

--- a/doc/samtools-ampliconstats.1
+++ b/doc/samtools-ampliconstats.1
@@ -78,19 +78,20 @@ detailed descriptions.
 .TS
 lb l .
 SS	Amplicon and file counts.  Always comes first
+AMPLICON	Amplicon primer locations
 FSS	File specific: summary stats
 FRPERC	File specific: read percentage distributoin between amplicons
 FDEPTH	File specific: average read depth per amplicon
 FREADS	File specific: numbers of reads per amplicon
 FPCOV	File specific: percent coverage per amplicon
-FTLEN	File specific: template length distribution per amplicon
+FTCOORD	File specific: template start,end coordinate frequencies per amplicon
 FAMP	File specific: amplicon correct / double / treble length counts
 CSS	Combined  summary stats
 CRPERC	Combined: read percentage distributoin between amplicons
 CDEPTH	Combined: average read depth per amplicon
 CREADS	Combined: numbers of reads per amplicon
 CPCOV	Combined: percent coverage per amplicon
-CTLEN	Combined: template length distribution per amplicon
+CTCOORD	Combined: template coordinates per amplicon
 CAMP	Combined: amplicon correct / double / treble length counts
 .TE
 
@@ -105,6 +106,21 @@ The combined sections (C*) follow the same format as the file specific
 sections, with a different key.  For simplicity of parsing they also
 have a filename column which is filled out with "COMBINED".  These
 rows contain stats aggregated across all input files.
+
+.SH SS / AMPLICON
+
+This section is once per file and includes summary information to be
+utilised for scaling of plots, for example the total number of
+amplicons and files present, tool version number, and command line
+arguments.
+
+The AMPLICON section is a reformatting of the input BED file.  Each
+line consists of the amplicon number and the \fIstart\fR-\fIend\fR
+coordinates of the left and right primers.  Where multiple primers are
+available these are comma separated, for example \fB10-30,15-40\fR in
+the left primer column indicates two primers have been multiplex
+together covering genome coords 10-30 inclusive and 14-40 inclusively.
+
 
 .SH CSS SECTION
 
@@ -171,25 +187,31 @@ The minimum depth necessary to constitute a position as being
 "covered" is specifiable using the -d option.
 
 
-.SH FTLEN / CTLEN / FAMP / CAMP SECTION
+.SH FTCOORD / CTCOORD / FAMP / CAMP SECTION
 
 It is possible for an amplicon to be produced using incorrect primers,
 giving rise to extra-long amplicons (typically double or treble
 length).
 
-The FTLEN field holds a distribution of observed TLEN fields from the
-input data, up to a maximum value.  Each row consists of the file
-name, the amplicon number in question, and tab separated counts of
-that length.  Amplicon number zero is used as a summation across all
-amplicons for this sample.
+The FTCOORD field holds a distribution of observed template
+coordsinates from the input data.  Each row consists of the file name,
+the amplicon number in question, and tab separated tuples of start,
+end and frequency (whose values are separated by commas).  Each
+template is only counted for one amplicon, so if the read-pairs span
+amplicons the count will show up in the left-most amplicon covered.
 
-If the desired amplicons are of variable length then we can instead
-count the number of reads that map to the expected ends of this
-amplicon, map to this amplicon plus the neighbouring amplicon, or map
-to this amplicon and another further away amplicon (usually meaning
-at least treble size).  As FTLEN the format of this data is one
-amplicon per row followed by the counts of correct, skip-1 and skip-2+
-primers.
+Th COORD data may indicate which primers are being utilised if there
+are alternates available for a given amplicon.
+
+The FAMP / CAMP section is a simple count per amplicon of the number
+of templates coming from this amplicon.  Templates are counted once
+per amplicon, but and like the FTCOORD field if a read-pair spans
+amplicons it is only counted in the left-most amplicon.  Each line
+consists of the file name, amplicon number and 3 counts for the number
+of templates with both ends within this amplicon, the number of
+templates with the rightmost end in another amplicon, and the number
+of templates where the other end has failed to be assigned to an
+amplicon.
 
 .SH OPTIONS
 .TP 8

--- a/doc/samtools-ampliconstats.1
+++ b/doc/samtools-ampliconstats.1
@@ -196,9 +196,10 @@ length).
 The FTCOORD field holds a distribution of observed template
 coordsinates from the input data.  Each row consists of the file name,
 the amplicon number in question, and tab separated tuples of start,
-end and frequency (whose values are separated by commas).  Each
-template is only counted for one amplicon, so if the read-pairs span
-amplicons the count will show up in the left-most amplicon covered.
+end, frequency and status (0 for OK, 1 for skipping amplicon, 2 for
+unknown location).  Each template is only counted for one amplicon, so
+if the read-pairs span amplicons the count will show up in the
+left-most amplicon covered.
 
 Th COORD data may indicate which primers are being utilised if there
 are alternates available for a given amplicon.
@@ -241,9 +242,18 @@ listed by the "samtools flags" subcommand.
 Specify the maximum number of amplicons permitted.
 
 .TP
+.BI "-c, --tcoord-min-count " INT
+In the FTCOORD and CTCOORD lines, only record template start,end
+coordinate combination if they occur at least \fIINT\fR times.
+
+.TP
 .BI "-d, --min-depth " INT
 Specifies the minimum base depth to consider a reference position to
 be covered, for purposes of the FRPERC and CRPERC sections.
+
+.TP
+.BI "-l, --max-amplicon-length " INT
+Specifies the maximum length of any individual amplicon.
 
 .TP
 .BI "-m, --pos-margin " INT
@@ -264,8 +274,8 @@ Instead of using the basename component of the input path names, use
 the SM field from the first @RG header line.
 
 .TP
-.B "-t, --tlen-adjust " INT
-Adjust the TLEN field by +/- INT to compensate for primer clipping.
+.BI "-t, --tlen-adjust " INT
+Adjust the TLEN field by +/- \fIINT\fR to compensate for primer clipping.
 This defaults to zero, but if the primers have been clipped and the
 TLEN field has not been updated using samtools fixmate then the
 template length will be wrong by the sum of the forward and reverse

--- a/misc/plot-ampliconstats
+++ b/misc/plot-ampliconstats
@@ -294,13 +294,33 @@ my %fh_cover_count;
 my %fh_cover_page;
 my %fh_cover_nfile;
 
+my @amp_start; # coords for amplicons
+my @amp_end;
+
 #-----------------------------------------------------------------------------
 # Parse stats file, writing to a number of outputs simultaneously
 my %file;
 my $fh;
+my @combined_coord;
 while (<>) {
     chomp($_);
     my @F = split("\t", $_);
+
+    # Amplicon coordinates
+    if (/^AMPLICON/) {
+	my $min_left=1e9;
+	foreach (split(",",$F[2])) {
+	    /\d+-(\d+)/;
+	    $min_left=$1 if ($min_left > $1);
+	}
+	my $max_right=0;
+	foreach (split(",",$F[3])) {
+	    /(\d+)-\d+/;
+	    $max_right=$1 if ($max_right < $1);
+	}
+	$amp_start[$F[1]]=$min_left;
+	$amp_end[$F[1]]=$max_right;
+    }
 
     # Heatmaps showing all files & all amplicons
     local $"="\t";
@@ -640,6 +660,19 @@ END
     if (/^FAMP\s\S+\s[1-9]*/) {
         push(@{$file{$F[1]}{$F[0]}}, 100*($F[4]+$F[5])/($F[3]+$F[4]+$F[5]+$opts{amp_add}));
     }
+    if (/^FTCOORD/) {
+	local $"="\t$F[2]\n";
+	$_="@F[3..$#F]";
+	s/,/\t/g;
+	push(@{$file{$F[1]}{$F[0]}}, "$_\t$F[2]") if ($_ ne "");
+    }
+
+    if (/^CTCOORD/) {
+	local $"="\t$F[2]\n";
+	$_="@F[3..$#F]";
+	s/,/\t/g;
+	push(@combined_coord, "$_\t$F[2]") if ($_ ne "");
+    }
 }
 
 #-----------------------------------------------------------------------------
@@ -705,6 +738,105 @@ foreach my $f (sort keys %file) {
     $ff =~ s/[\\;#\$\{\}]/./g;  # safe filename component
     my $fg = $f;                # printable in gnuplot
     $fg =~ s/_/\\\\_/g;
+
+    #--- Template coordinates: FILE
+    goto skip_coord if !exists($file{$f}{FTCOORD});
+    my $fn = "$prefix-$ff-tcoord";  # filename prefix
+    open(my $fh, ">", "$fn.gp") || die "$fn.gp";
+
+    print $fh <<"END";
+set title "$fg: Template coordinate frequencies"
+unset key
+set xlabel "position"
+set xrange [*:*]
+set ylabel "frequency"
+set yrange [*:*]
+set logscale y
+set mytics 10
+set title font "helvetica,20"
+set xtics out nomirror
+set mxtics 5
+set x2tics font "helvectica,6" offset 0,-0.6 scale -0.4 centre nomirror
+
+set terminal png size $opts{size} truecolor
+set output "$fn.png"
+set linetype 1 lc "blue"
+set linetype 2 lc "red"
+set linetype 3 lc "black
+seed=rand(-1)
+END
+
+    my @x2tics = ();
+    for (my $i=1;$i<=$namp;$i++) {
+	my $col = ($i%2)?"blue":"green";
+	print $fh "set obj rect from $amp_start[$i], graph 0 to $amp_end[$i], graph 1 fillcolor rgb '$col' fillstyle transparent solid 0.1 noborder\n";
+	if ($i%2 == 0) {
+	    my $ts = $i>=2    ? $amp_end[$i-1]   : $amp_start[$i];
+	    my $te = $i<$namp ? $amp_start[$i+1] : $amp_end[$i];
+	    my $tpos = ($ts+$te)/2;
+	    push(@x2tics, "\"$i\" " . ($amp_start[$i]+$amp_end[$i])/2);
+	}
+    }
+    print $fh "set x2tics (" . join(", ", @x2tics) . ")\n";
+
+    print $fh <<"END";
+plot "-" using 1:(\$3+rand(0)):(\$2-\$1):(0):(int(\$4)?\$4+1:(int(\$5) % 2)) with vector nohead lw 3 lc var
+END
+    local $"="\n";
+    print $fh "@{$file{$f}{FTCOORD}}\nend\n";
+
+    close($fh);
+    system("gnuplot $fn.gp") && die $!;
+  skip_coord:
+
+    #--- Template coordinates: COMBINED
+    my $fn = "$prefix-combined-tcoord";  # filename prefix
+    open(my $fh, ">", "$fn.gp") || die "$fn.gp";
+
+    print $fh <<"END";
+set title "Template coordinate frequencies, all files"
+unset key
+set xlabel "position"
+set xrange [*:*]
+set ylabel "frequency"
+set yrange [*:*]
+set logscale y
+set mytics 10
+set title font "helvetica,20"
+set xtics out nomirror
+set mxtics 5
+set x2tics font "helvectica,6" offset 0,-0.6 scale -0.4 centre nomirror
+
+set terminal png size $opts{size} truecolor
+set output "$fn.png"
+set linetype 1 lc "blue"
+set linetype 2 lc "red"
+set linetype 3 lc "black
+seed=rand(-1)
+END
+
+    my @x2tics = ();
+    for (my $i=1;$i<=$namp;$i++) {
+	my $col = ($i%2)?"blue":"green";
+	print $fh "set obj rect from $amp_start[$i], graph 0 to $amp_end[$i], graph 1 fillcolor rgb '$col' fillstyle transparent solid 0.1 noborder\n";
+	if ($i%2 == 0) {
+	    my $ts = $i>=2    ? $amp_end[$i-1]   : $amp_start[$i];
+	    my $te = $i<$namp ? $amp_start[$i+1] : $amp_end[$i];
+	    my $tpos = ($ts+$te)/2;
+	    push(@x2tics, "\"$i\" " . ($amp_start[$i]+$amp_end[$i])/2);
+	}
+    }
+    print $fh "set x2tics (" . join(", ", @x2tics) . ")\n";
+
+    print $fh <<"END";
+plot "-" using 1:(\$3+rand(0)):(\$2-\$1):(0):(int(\$4)?\$4+1:(int(\$5) % 2)) with vector nohead lw 3 lc var
+END
+    local $"="\n";
+    print $fh "@combined_coord\nend\n";
+
+    close($fh);
+    system("gnuplot $fn.gp") && die $!;
+
 
     #--- Read count / depth
     my $fn = "$prefix-$ff-reads";  # filename prefix

--- a/misc/plot-ampliconstats
+++ b/misc/plot-ampliconstats
@@ -790,10 +790,11 @@ END
   skip_coord:
 
     #--- Template coordinates: COMBINED
-    my $fn = "$prefix-combined-tcoord";  # filename prefix
-    open(my $fh, ">", "$fn.gp") || die "$fn.gp";
+    if (scalar(@combined_coord) > 0) {
+	my $fn = "$prefix-combined-tcoord";  # filename prefix
+	open(my $fh, ">", "$fn.gp") || die "$fn.gp";
 
-    print $fh <<"END";
+	print $fh <<"END";
 set title "Template coordinate frequencies, all files"
 unset key
 set xlabel "position"
@@ -815,28 +816,28 @@ set linetype 3 lc "black
 seed=rand(-1)
 END
 
-    my @x2tics = ();
-    for (my $i=1;$i<=$namp;$i++) {
-	my $col = ($i%2)?"blue":"green";
-	print $fh "set obj rect from $amp_start[$i], graph 0 to $amp_end[$i], graph 1 fillcolor rgb '$col' fillstyle transparent solid 0.1 noborder\n";
-	if ($i%2 == 0) {
-	    my $ts = $i>=2    ? $amp_end[$i-1]   : $amp_start[$i];
-	    my $te = $i<$namp ? $amp_start[$i+1] : $amp_end[$i];
-	    my $tpos = ($ts+$te)/2;
-	    push(@x2tics, "\"$i\" " . ($amp_start[$i]+$amp_end[$i])/2);
+	my @x2tics = ();
+	for (my $i=1;$i<=$namp;$i++) {
+	    my $col = ($i%2)?"blue":"green";
+	    print $fh "set obj rect from $amp_start[$i], graph 0 to $amp_end[$i], graph 1 fillcolor rgb '$col' fillstyle transparent solid 0.1 noborder\n";
+	    if ($i%2 == 0) {
+		my $ts = $i>=2    ? $amp_end[$i-1]   : $amp_start[$i];
+		my $te = $i<$namp ? $amp_start[$i+1] : $amp_end[$i];
+		my $tpos = ($ts+$te)/2;
+		push(@x2tics, "\"$i\" " . ($amp_start[$i]+$amp_end[$i])/2);
+	    }
 	}
-    }
-    print $fh "set x2tics (" . join(", ", @x2tics) . ")\n";
+	print $fh "set x2tics (" . join(", ", @x2tics) . ")\n";
 
-    print $fh <<"END";
+	print $fh <<"END";
 plot "-" using 1:(\$3+rand(0)):(\$2-\$1):(0):(int(\$4)?\$4+1:(int(\$5) % 2)) with vector nohead lw 3 lc var
 END
-    local $"="\n";
-    print $fh "@combined_coord\nend\n";
+	local $"="\n";
+	print $fh "@combined_coord\nend\n";
 
-    close($fh);
-    system("gnuplot $fn.gp") && die $!;
-
+	close($fh);
+	system("gnuplot $fn.gp") && die $!;
+  }
 
     #--- Read count / depth
     my $fn = "$prefix-$ff-reads";  # filename prefix

--- a/misc/plot-ampliconstats
+++ b/misc/plot-ampliconstats
@@ -26,6 +26,8 @@
 
 use strict;
 use Getopt::Long;
+use List::Util qw(max);
+use POSIX qw(ceil);
 
 my $version = "1.0";
 
@@ -51,6 +53,12 @@ $opts{amp_add}   = 100        unless $opts{amp_add};
 $opts{orient}    = "h"        unless $opts{orient};
 $opts{max_depth} = 1e6        unless $opts{max_depth};
 
+# We auto-scale max depth normally.
+# However the vertical oriented combined plot needs to know max_depth upfront
+# as xscale [1:*] doesn't work in that context.  For that we use
+# opts{max_depth}.  It's a fudge.  Sorry.
+my $max_depth = 0;
+
 my $usage = <<END;
 plot-ampliconstats version $version
 
@@ -64,7 +72,7 @@ Options:
     -page N      Maximum number of samples per page in heatmaps
     -amp_add X   Small sample fudge: NErr/(NAll+X) in amplicon count plots
     -orient h/v  Orientation for plots, defaults to h (horizontal)
-    -max_depth N Set maximum scale for vertical plots with logscale x
+    -max_depth N Set maximum scale for combined vertical plots with logscale x
 
 If FILE is not specified, reads from stdin.
 END
@@ -652,6 +660,11 @@ END
         }
     }
 
+    if (/^(FREADS|FDEPTH)/) {
+	my $max = max(@F[2..$#F]);
+	$max_depth = $max if $max_depth < $max;
+    }
+
     # Per file graphs; accumulate multiple stats here and dump out at end
     if (/^(FREADS|FDEPTH|FPCOV|FRPERC)/) {
         $file{$F[1]}{$F[0]} = \@F;
@@ -733,6 +746,8 @@ system("gnuplot $prefix-combined-amp.gp") && die $!;
 
 #-----------------------------------------------------------------------------
 # Also produce per file graphs
+$max_depth = 10**ceil(log($max_depth)/log(10)); # round up to power of 10
+
 foreach my $f (sort keys %file) {
     my $ff = $f;
     $ff =~ s/[\\;#\$\{\}]/./g;  # safe filename component
@@ -837,7 +852,7 @@ END
 
 	close($fh);
 	system("gnuplot $fn.gp") && die $!;
-  }
+    }
 
     #--- Read count / depth
     my $fn = "$prefix-$ff-reads";  # filename prefix
@@ -851,6 +866,7 @@ set xlabel "amplicon"
 set xrange [0:$namp+1]
 set ylabel "no. reads"
 set logscale y
+set yrange [1:$max_depth]
 set title font "helvetica,20"
 set xtics 5 font "helvectica,$xfont" scale -2,-1
 set mxtics 5
@@ -866,7 +882,7 @@ set key below
 set ylabel "amplicon"
 set yrange [0:$namp+1]
 set xlabel "no. reads"
-set xrange [1:$opts{max_depth}]
+set xrange [1:$max_depth]
 set grid; # xtics noytics
 set logscale x
 set xtics font "helvectica,$yfont"
@@ -875,8 +891,8 @@ set ytics 5 font "helvectica,$xfont" scale -2,-1
 set mytics 5
 set terminal png size $opts{size3}
 set output "$fn.png"
-plot "-" using (0):(column(0)+1):(\$1 > 0.001 ? (\$1 < $opts{max_depth} ? \$1 : $opts{max_depth}) : 0.001):(0) with vector nohead lw $impw1 title "#reads", \\
-     "-" using (0):(column(0)+1):(\$1 > 0.001 ? (\$1 < $opts{max_depth} ? \$1 : $opts{max_depth}) : 0.001):(0) with vector nohead lw $impw2 lt 3 title "depth",
+plot "-" using (0):(column(0)+1):(\$1 > 0.001 ? (\$1 < $max_depth ? \$1 : $max_depth) : 0.001):(0) with vector nohead lw $impw1 title "#reads", \\
+     "-" using (0):(column(0)+1):(\$1 > 0.001 ? (\$1 < $max_depth ? \$1 : $max_depth) : 0.001):(0) with vector nohead lw $impw2 lt 3 title "depth",
 END
     }
 

--- a/misc/plot-ampliconstats
+++ b/misc/plot-ampliconstats
@@ -42,8 +42,7 @@ my $res = GetOptions("size=s"      => \$opts{size},
                      "help"        => \$opts{help},
                      "page=i"      => \$opts{page},
                      "amp_add=i"   => \$opts{amp_add},
-                     "orient=s"    => \$opts{orient},
-                     "max_depth=i" => \$opts{max_depth});
+                     "orient=s"    => \$opts{orient});
 
 $opts{size}      = "1000,800" unless $opts{size};
 $opts{size2}     = "1000,400" unless $opts{size2};
@@ -51,12 +50,7 @@ $opts{size3}     = "400,847"  unless $opts{size3};
 $opts{page}      = 96         unless $opts{page};
 $opts{amp_add}   = 100        unless $opts{amp_add};
 $opts{orient}    = "h"        unless $opts{orient};
-$opts{max_depth} = 1e6        unless $opts{max_depth};
 
-# We auto-scale max depth normally.
-# However the vertical oriented combined plot needs to know max_depth upfront
-# as xscale [1:*] doesn't work in that context.  For that we use
-# opts{max_depth}.  It's a fudge.  Sorry.
 my $max_depth = 0;
 
 my $usage = <<END;
@@ -72,7 +66,6 @@ Options:
     -page N      Maximum number of samples per page in heatmaps
     -amp_add X   Small sample fudge: NErr/(NAll+X) in amplicon count plots
     -orient h/v  Orientation for plots, defaults to h (horizontal)
-    -max_depth N Set maximum scale for combined vertical plots with logscale x
 
 If FILE is not specified, reads from stdin.
 END
@@ -125,85 +118,9 @@ my $impw2 = ($namp >= 100) ? 2 : 4;
 #--- Combined
 open(my $ch_depth, ">", $prefix."-combined-depth.gp") ||
     die "$prefix-combined-depth.gp";
-if ($opts{orient} eq "h") {
-    print $ch_depth <<"END";
-set title "average depth per amplicon, all files"
-set xlabel "amplicon"
-set xrange [:$namp+1]
-set ylabel "depth"
-set logscale y
-set key below
-set title font "helvetica,20"
-set xtics 5 font "helvetica,$xfont" scale -2,-1
-set mxtics 5
-set terminal png size $opts{size2}
-set output "$prefix-combined-depth.png"
-plot "-" using (column(0)+1):(\$1 > 0.001 ? \$1 : 0.001) with impulses lw $impw1 title "mean", \\
-     "-" using (column(0)+1):(\$1 > 0.001 ? \$1 : 0.001) with impulses lw $impw2 lt 3 title "s.d."
-END
-} else {
-    print $ch_depth <<"END";
-set title "avg depth / amp, all files"
-set ylabel "amplicon"
-set yrange [0:$namp+1]
-set xlabel "depth"
-set xrange [0:$opts{max_depth}]
-set grid; # xtics noytics
-set logscale x
-set format x "%.g"
-set xtics font "helvectica,$yfont"
-set key below
-set title font "helvetica,20"
-set ytics 5 font "helvetica,$xfont" scale -2,-1
-set mytics 5
-set terminal png size $opts{size3}
-set output "$prefix-combined-depth.png"
-plot "-" using (0):(column(0)+1):(\$1 > 0.001 ? (\$1 < $opts{max_depth} ? \$1 : $opts{max_depth}) : 0.001):(0) with vector nohead lw $impw1 title "mean", \\
-     "-" using (0):(column(0)+1):(\$1 > 0.001 ? (\$1 < $opts{max_depth} ? \$1 : $opts{max_depth}) : 0.001):(0) with vector nohead lw $impw2 lt 3 title "s.d."
-END
-}
 
 open(my $ch_reads, ">", $prefix."-combined-reads.gp") ||
     die "$prefix-combined-reads.gp";
-if ($opts{orient} eq "h") {
-    print $ch_reads <<"END";
-set title "average number of reads per amplicon, all files"
-unset key
-set xlabel "amplicon"
-set xrange [0:$namp+1]
-set ylabel "no. reads"
-set logscale y
-set key below
-set title font "helvetica,20"
-set xtics 5 font "helvetica,$xfont" scale -2,-1
-set mxtics 5
-set terminal png size $opts{size2}
-set output "$prefix-combined-reads.png"
-plot "-" using (column(0)+1):(\$1 > 0.001 ? \$1 : 0.001) with impulses lw $impw1 title "mean", \\
-     "-" using (column(0)+1):(\$1 > 0.001 ? \$1 : 0.001) with impulses lw $impw2 lt 3 title "s.d."
-END
-} else {
-    print $ch_reads <<"END";
-set title "no. of reads, all files"
-unset key
-set ylabel "amplicon"
-set yrange [0:$namp+1]
-set xlabel "no. reads"
-set xrange [0:$opts{max_depth}]
-set grid; # xtics noytics
-set logscale x
-set format x "%.g"
-set xtics font "helvectica,$yfont"
-set key below
-set title font "helvetica,20"
-set ytics 5 font "helvectica,$xfont" scale -2,-1
-set mytics 5
-set terminal png size $opts{size3}
-set output "$prefix-combined-reads.png"
-plot "-" using (0):(column(0)+1):(\$1 > 0.001 ? (\$1 < $opts{max_depth} ? \$1 : $opts{max_depth} ): 0.001):(0) with vector nohead lw $impw1 title "mean", \\
-     "-" using (0):(column(0)+1):(\$1 > 0.001 ? (\$1 < $opts{max_depth} ? \$1 : $opts{max_depth} ): 0.001):(0) with vector nohead lw $impw2 lt 3 title "s.d."
-END
-}
 
 open(my $ch_rperc, ">", $prefix."-combined-read-perc.gp") ||
     die "$prefix-combined-read-perc.gp";
@@ -603,8 +520,10 @@ END
 
     # Graphs with merged file data (mean and SD) for all amplicons
     local $"="\n";
-    print $ch_reads "@F[2..$#F]\nend\n" if (/^CDEPTH.*(MEAN|STDDEV)/);
-    print $ch_depth "@F[2..$#F]\nend\n" if (/^CDEPTH.*(MEAN|STDDEV)/);
+    print $ch_reads "\$mean << EOD\n@F[2..$#F]\nEOD\n\n" if (/^CDEPTH.*MEAN/);
+    print $ch_reads "\$sd << EOD\n@F[2..$#F]\nEOD\n\n" if (/^CDEPTH.*STDDEV/);
+    print $ch_depth "\$mean << EOD\n@F[2..$#F]\nEOD\n\n" if (/^CDEPTH.*MEAN/);
+    print $ch_depth "\$sd << EOD\n@F[2..$#F]\nEOD\n\n" if (/^CDEPTH.*STDDEV/);
     print $ch_rperc "@F[2..$#F]\nend\n" if (/^CRPERC.*(MEAN|STDDEV)/);
     print $ch_amp   100*($F[4]+$F[5])/($F[3]+$F[4]+$F[5]+$opts{amp_add}),"\n"
         if (/^CAMP\tCOMBINED\t[1-9]/);
@@ -730,9 +649,103 @@ foreach (keys %fh_cover) {
 }
 
 #--- Combined
+$max_depth = 10**ceil(log($max_depth)/log(10)); # round up to power of 10
+
+# combined-reads
+if ($opts{orient} eq "h") {
+    print $ch_reads <<"END";
+set title "average number of reads per amplicon, all files"
+unset key
+set xlabel "amplicon"
+set xrange [0:$namp+1]
+set ylabel "no. reads"
+set logscale y
+set key below
+set title font "helvetica,20"
+set xtics 5 font "helvetica,$xfont" scale -2,-1
+set mxtics 5
+set terminal png size $opts{size2}
+set output "$prefix-combined-reads.png"
+plot \$mean using (column(0)+1):(\$1 > 0.001 ? \$1 : 0.001) with impulses lw $impw1 title "mean", \\
+     \$sd using (column(0)+1):(\$1 > 0.001 ? \$1 : 0.001) with impulses lw $impw2 lt 3 title "s.d."
+END
+} else {
+    print $ch_reads <<"END";
+# Compute max X value
+stats \$mean nooutput
+max_range = STATS_max
+stats \$sd nooutput
+max_range = max_range > STATS_max ? max_range : STATS_max
+max_range = 10**ceil(log10(max_range+0.01))
+
+set title "no. of reads, all files"
+unset key
+set ylabel "amplicon"
+set yrange [0:$namp+1]
+set xlabel "no. reads"
+set xrange [0:max_range]
+set grid; # xtics noytics
+set logscale x
+set format x "%.g"
+set xtics font "helvectica,$yfont"
+set key below
+set title font "helvetica,20"
+set ytics 5 font "helvectica,$xfont" scale -2,-1
+set mytics 5
+set terminal png size $opts{size3}
+set output "$prefix-combined-reads.png"
+plot "\$mean" using (0):(column(0)+1):(\$1 > 0.001 ? (\$1 < max_range ? \$1 : max_range ): 0.001):(0) with vector nohead lw $impw1 title "mean", \\
+     "\$sd" using (0):(column(0)+1):(\$1 > 0.001 ? (\$1 < max_range ? \$1 : max_range ): 0.001):(0) with vector nohead lw $impw2 lt 3 title "s.d."
+END
+}
 close($ch_reads);
 system("gnuplot $prefix-combined-reads.gp") && die $!;
 
+# combind-depth
+if ($opts{orient} eq "h") {
+    print $ch_depth <<"END";
+set title "average depth per amplicon, all files"
+set xlabel "amplicon"
+set xrange [:$namp+1]
+set ylabel "depth"
+set logscale y
+set key below
+set title font "helvetica,20"
+set xtics 5 font "helvetica,$xfont" scale -2,-1
+set mxtics 5
+set terminal png size $opts{size2}
+set output "$prefix-combined-depth.png"
+plot "\$mean" using (column(0)+1):(\$1 > 0.001 ? \$1 : 0.001) with impulses lw $impw1 title "mean", \\
+     "\$sd" using (column(0)+1):(\$1 > 0.001 ? \$1 : 0.001) with impulses lw $impw2 lt 3 title "s.d."
+END
+} else {
+    print $ch_depth <<"END";
+# Compute max X value
+stats \$mean nooutput
+max_range = STATS_max
+stats \$sd nooutput
+max_range = max_range > STATS_max ? max_range : STATS_max
+max_range = 10**ceil(log10(max_range+0.01))
+
+set title "avg depth / amp, all files"
+set ylabel "amplicon"
+set yrange [0:$namp+1]
+set xlabel "depth"
+set xrange [0:max_range]
+set grid; # xtics noytics
+set logscale x
+set format x "%.g"
+set xtics font "helvectica,$yfont"
+set key below
+set title font "helvetica,20"
+set ytics 5 font "helvetica,$xfont" scale -2,-1
+set mytics 5
+set terminal png size $opts{size3}
+set output "$prefix-combined-depth.png"
+plot "\$mean" using (0):(column(0)+1):(\$1 > 0.001 ? (\$1 < max_range ? \$1 : max_range) : 0.001):(0) with vector nohead lw $impw1 title "mean", \\
+     "\$sd" using (0):(column(0)+1):(\$1 > 0.001 ? (\$1 < max_range ? \$1 : max_range) : 0.001):(0) with vector nohead lw $impw2 lt 3 title "s.d."
+END
+}
 close($ch_depth);
 system("gnuplot $prefix-combined-depth.gp") && die $!;
 
@@ -746,8 +759,6 @@ system("gnuplot $prefix-combined-amp.gp") && die $!;
 
 #-----------------------------------------------------------------------------
 # Also produce per file graphs
-$max_depth = 10**ceil(log($max_depth)/log(10)); # round up to power of 10
-
 foreach my $f (sort keys %file) {
     my $ff = $f;
     $ff =~ s/[\\;#\$\{\}]/./g;  # safe filename component

--- a/test/ampliconstats/stats.expected.txt
+++ b/test/ampliconstats/stats.expected.txt
@@ -1,0 +1,192 @@
+# Summary statistics, used for scaling the plots.
+SS	Number of amplicons:	2
+SS	Number of files:	4
+SS	End of summary
+# Amplicon locations from BED file.
+# LEFT/RIGHT are <start>-<end> format and comma-separated for alt-primers.
+#
+# AMPLICON	NUMBER	LEFT	RIGHT
+AMPLICON	1	31-54	386-410
+AMPLICON	2	321-342	705-726
+# Summary stats.
+# Use 'grep ^FSS | cut -f 2-' to extract this part.
+FSS	1_hard_clipped.expected	raw total sequences:	8
+FSS	1_hard_clipped.expected	filtered sequences:	0
+FSS	1_hard_clipped.expected	failed primer match:	2
+FSS	1_hard_clipped.expected	matching sequences:	6
+FSS	1_hard_clipped.expected	consensus depth count < 1 and >= 1:	132	517
+FSS	1_hard_clipped.expected	consensus depth count < 20 and >= 20:	649	0
+FSS	1_hard_clipped.expected	consensus depth count < 100 and >= 100:	649	0
+# Absolute matching read counts per amplicon.
+# Use 'grep ^FREADS | cut -f 2-' to extract this part.
+FREADS	1_hard_clipped.expected	5	1
+# Read percentage of distribution between amplicons.
+# Use 'grep ^FRPERC | cut -f 2-' to extract this part.
+FRPERC	1_hard_clipped.expected	83.333	16.667
+# Read depth per amplicon.
+# Use 'grep ^FREADS | cut -f 2-' to extract this part.
+FDEPTH	1_hard_clipped.expected	2.8	0.5
+# Percentage coverage per amplicon
+# Use 'grep ^FPCOV | cut -f 2-' to extract this part.
+FPCOV-1	1_hard_clipped.expected	100.00	51.80
+FPCOV-20	1_hard_clipped.expected	0.00	0.00
+FPCOV-100	1_hard_clipped.expected	0.00	0.00
+# Distribution of aligned template coordinates.
+# Use 'grep ^FTCOORD | cut -f 2-' to extract this part.
+FTCOORD	1_hard_clipped.expected	1
+FTCOORD	1_hard_clipped.expected	2
+# Classification of amplicon status.  Columns are
+# number with both primers from this amplicon, number with
+# primers from different amplicon, and number with a position
+# not matching any valid amplicon primer site
+# Use 'grep ^FAMP | cut -f 2-' to extract this part.
+FAMP	1_hard_clipped.expected	0	2	0	2
+FAMP	1_hard_clipped.expected	1	2	0	1
+FAMP	1_hard_clipped.expected	2	0	0	1
+# Summary stats.
+# Use 'grep ^FSS | cut -f 2-' to extract this part.
+FSS	1_soft_clipped.expected	raw total sequences:	8
+FSS	1_soft_clipped.expected	filtered sequences:	0
+FSS	1_soft_clipped.expected	failed primer match:	2
+FSS	1_soft_clipped.expected	matching sequences:	6
+FSS	1_soft_clipped.expected	consensus depth count < 1 and >= 1:	132	517
+FSS	1_soft_clipped.expected	consensus depth count < 20 and >= 20:	649	0
+FSS	1_soft_clipped.expected	consensus depth count < 100 and >= 100:	649	0
+# Absolute matching read counts per amplicon.
+# Use 'grep ^FREADS | cut -f 2-' to extract this part.
+FREADS	1_soft_clipped.expected	5	1
+# Read percentage of distribution between amplicons.
+# Use 'grep ^FRPERC | cut -f 2-' to extract this part.
+FRPERC	1_soft_clipped.expected	83.333	16.667
+# Read depth per amplicon.
+# Use 'grep ^FREADS | cut -f 2-' to extract this part.
+FDEPTH	1_soft_clipped.expected	2.8	0.5
+# Percentage coverage per amplicon
+# Use 'grep ^FPCOV | cut -f 2-' to extract this part.
+FPCOV-1	1_soft_clipped.expected	100.00	51.80
+FPCOV-20	1_soft_clipped.expected	0.00	0.00
+FPCOV-100	1_soft_clipped.expected	0.00	0.00
+# Distribution of aligned template coordinates.
+# Use 'grep ^FTCOORD | cut -f 2-' to extract this part.
+FTCOORD	1_soft_clipped.expected	1
+FTCOORD	1_soft_clipped.expected	2
+# Classification of amplicon status.  Columns are
+# number with both primers from this amplicon, number with
+# primers from different amplicon, and number with a position
+# not matching any valid amplicon primer site
+# Use 'grep ^FAMP | cut -f 2-' to extract this part.
+FAMP	1_soft_clipped.expected	0	2	0	2
+FAMP	1_soft_clipped.expected	1	2	0	1
+FAMP	1_soft_clipped.expected	2	0	0	1
+# Summary stats.
+# Use 'grep ^FSS | cut -f 2-' to extract this part.
+FSS	1_soft_clipped_strand.expected	raw total sequences:	8
+FSS	1_soft_clipped_strand.expected	filtered sequences:	0
+FSS	1_soft_clipped_strand.expected	failed primer match:	2
+FSS	1_soft_clipped_strand.expected	matching sequences:	6
+FSS	1_soft_clipped_strand.expected	consensus depth count < 1 and >= 1:	132	517
+FSS	1_soft_clipped_strand.expected	consensus depth count < 20 and >= 20:	649	0
+FSS	1_soft_clipped_strand.expected	consensus depth count < 100 and >= 100:	649	0
+# Absolute matching read counts per amplicon.
+# Use 'grep ^FREADS | cut -f 2-' to extract this part.
+FREADS	1_soft_clipped_strand.expected	5	1
+# Read percentage of distribution between amplicons.
+# Use 'grep ^FRPERC | cut -f 2-' to extract this part.
+FRPERC	1_soft_clipped_strand.expected	83.333	16.667
+# Read depth per amplicon.
+# Use 'grep ^FREADS | cut -f 2-' to extract this part.
+FDEPTH	1_soft_clipped_strand.expected	2.8	0.5
+# Percentage coverage per amplicon
+# Use 'grep ^FPCOV | cut -f 2-' to extract this part.
+FPCOV-1	1_soft_clipped_strand.expected	100.00	51.80
+FPCOV-20	1_soft_clipped_strand.expected	0.00	0.00
+FPCOV-100	1_soft_clipped_strand.expected	0.00	0.00
+# Distribution of aligned template coordinates.
+# Use 'grep ^FTCOORD | cut -f 2-' to extract this part.
+FTCOORD	1_soft_clipped_strand.expected	1
+FTCOORD	1_soft_clipped_strand.expected	2
+# Classification of amplicon status.  Columns are
+# number with both primers from this amplicon, number with
+# primers from different amplicon, and number with a position
+# not matching any valid amplicon primer site
+# Use 'grep ^FAMP | cut -f 2-' to extract this part.
+FAMP	1_soft_clipped_strand.expected	0	2	0	2
+FAMP	1_soft_clipped_strand.expected	1	2	0	1
+FAMP	1_soft_clipped_strand.expected	2	0	0	1
+# Summary stats.
+# Use 'grep ^FSS | cut -f 2-' to extract this part.
+FSS	2_both_clipped.expected	raw total sequences:	2
+FSS	2_both_clipped.expected	filtered sequences:	0
+FSS	2_both_clipped.expected	failed primer match:	0
+FSS	2_both_clipped.expected	matching sequences:	2
+FSS	2_both_clipped.expected	consensus depth count < 1 and >= 1:	319	330
+FSS	2_both_clipped.expected	consensus depth count < 20 and >= 20:	649	0
+FSS	2_both_clipped.expected	consensus depth count < 100 and >= 100:	649	0
+# Absolute matching read counts per amplicon.
+# Use 'grep ^FREADS | cut -f 2-' to extract this part.
+FREADS	2_both_clipped.expected	2	0
+# Read percentage of distribution between amplicons.
+# Use 'grep ^FRPERC | cut -f 2-' to extract this part.
+FRPERC	2_both_clipped.expected	100.000	0.000
+# Read depth per amplicon.
+# Use 'grep ^FREADS | cut -f 2-' to extract this part.
+FDEPTH	2_both_clipped.expected	2.0	0.0
+# Percentage coverage per amplicon
+# Use 'grep ^FPCOV | cut -f 2-' to extract this part.
+FPCOV-1	2_both_clipped.expected	100.00	0.00
+FPCOV-20	2_both_clipped.expected	0.00	0.00
+FPCOV-100	2_both_clipped.expected	0.00	0.00
+# Distribution of aligned template coordinates.
+# Use 'grep ^FTCOORD | cut -f 2-' to extract this part.
+FTCOORD	2_both_clipped.expected	1
+FTCOORD	2_both_clipped.expected	2
+# Classification of amplicon status.  Columns are
+# number with both primers from this amplicon, number with
+# primers from different amplicon, and number with a position
+# not matching any valid amplicon primer site
+# Use 'grep ^FAMP | cut -f 2-' to extract this part.
+FAMP	2_both_clipped.expected	0	2	0	0
+FAMP	2_both_clipped.expected	1	2	0	0
+FAMP	2_both_clipped.expected	2	0	0	0
+# Summary stats.
+# Use 'grep ^CSS | cut -f 2-' to extract this part.
+CSS	COMBINED	raw total sequences:	26
+CSS	COMBINED	filtered sequences:	0
+CSS	COMBINED	failed primer match:	6
+CSS	COMBINED	matching sequences:	20
+CSS	COMBINED	consensus depth count < 1 and >= 1:	649	0
+CSS	COMBINED	consensus depth count < 20 and >= 20:	649	0
+CSS	COMBINED	consensus depth count < 100 and >= 100:	649	0
+# Absolute matching read counts per amplicon.
+# Use 'grep ^CREADS | cut -f 2-' to extract this part.
+CREADS	COMBINED	17	3
+CREADS	MEAN	4.2	0.8
+CREADS	STDDEV	1.3	0.4
+# Read percentage of distribution between amplicons.
+# Use 'grep ^CRPERC | cut -f 2-' to extract this part.
+CRPERC	COMBINED	87.500	12.500
+CRPERC	MEAN	87.500	12.500
+CRPERC	STDDEV	7.217	7.217
+# Read depth per amplicon.
+# Use 'grep ^CREADS | cut -f 2-' to extract this part.
+CDEPTH	COMBINED	10.4	1.6
+CDEPTH	MEAN	2.6	0.4
+CDEPTH	STDDEV	0.3	0.2
+CPCOV-1	MEAN	100.0	38.9
+CPCOV-1	STDDEV	0.0	22.4
+CPCOV-20	MEAN	0.0	0.0
+CPCOV-20	STDDEV	0.0	0.0
+CPCOV-100	MEAN	0.0	0.0
+CPCOV-100	STDDEV	0.0	0.0
+# Distribution of aligned template coordinates.
+# Use 'grep ^CTCOORD | cut -f 2-' to extract this part.
+CTCOORD	COMBINED	1
+CTCOORD	COMBINED	2
+# Classification of amplicon status.  Columns are
+# number with both primers from this amplicon, number with
+# primers from different amplicon, and number with a position
+# not matching any valid amplicon primer site
+# Use 'grep ^CAMP | cut -f 2-' to extract this part.
+CAMP	COMBINED	0	8	0	6
+CAMP	COMBINED	1	8	0	3
+CAMP	COMBINED	2	0	0	3

--- a/test/test.pl
+++ b/test/test.pl
@@ -71,6 +71,7 @@ test_split($opts, threads=>2);
 test_large_positions($opts);
 test_ampliconclip($opts);
 test_ampliconclip($opts, threads=>2);
+test_ampliconstats($opts, threads=>2);
 
 print "\nNumber of tests:\n";
 printf "    total            .. %d\n", $$opts{nok}+$$opts{nfailed}+$$opts{nxfail}+$$opts{nxpass};
@@ -3166,4 +3167,12 @@ sub test_ampliconclip
     test_cmd($opts, out=>'ampliconclip/1_hard_clipped.expected.sam', cmd=>"$$opts{bin}/samtools ampliconclip${threads} --no-PG --output-fmt=sam --hard-clip -b $$opts{path}/ampliconclip/ac_test.bed $$opts{path}/ampliconclip/1_test_data.sam");
     test_cmd($opts, out=>'ampliconclip/1_soft_clipped_strand.expected.sam', cmd=>"$$opts{bin}/samtools ampliconclip${threads} --no-PG --output-fmt=sam --strand -b $$opts{path}/ampliconclip/ac_test.bed $$opts{path}/ampliconclip/1_test_data.sam");
     test_cmd($opts, out=>'ampliconclip/2_both_clipped.expected.sam', cmd=>"$$opts{bin}/samtools ampliconclip${threads} --no-PG --output-fmt=sam --strand --both-ends -b $$opts{path}/ampliconclip/ac_test.bed $$opts{path}/ampliconclip/2_both_test_data.sam");
+}
+
+sub test_ampliconstats
+{
+    my ($opts,%args) = @_;
+
+    my $threads = exists($args{threads}) ? " -@ $args{threads}" : "";
+    test_cmd($opts, out=>'ampliconstats/stats.expected.txt', cmd=>"$$opts{bin}/samtools ampliconstats${threads} -t 50 -d 1,20,100 $$opts{path}/ampliconclip/ac_test.bed $$opts{path}/ampliconclip/*.expected.sam | egrep -v 'Samtools version|Command line' | tee /tmp/out.txt");
 }


### PR DESCRIPTION
This fixes #1234 by making MAX_AMP_LEN configurable, adding command line and program version to the output, and improving some error messages.

The TLEN output has also been completely rewritten and is now TCOORD instead.  TLEN wasn't used by any plots and it's not that helpful either.  The actual start and end coords for the template are more informative than length as it permits us to count the frequency of each primer being used and to see which alts are working.  Note to be useful requires fixmates to have been run after primer clipping.

TODO:  write a plot for TCOORD (but I already know what I want this to look like as I've done manual constructions of it)