### PR TITLE
[manpage, minor] Mention BAI chromosome length limit

### DIFF
--- a/doc/samtools-index.1
+++ b/doc/samtools-index.1
@@ -82,6 +82,11 @@ or
 .IB aln.sam.gz .csi
 will be created, depending on the index format selected.
 
+The BAI index format can handle individual chromosomes up to 512 Mbp
+(2^29 bases) in length.
+If your input file might contain reads mapped to positions greater than that,
+you will need to use a CSI index.
+
 .SH OPTIONS
 .TP 8
 .B -b


### PR DESCRIPTION
On a [bfx.SE answer](https://bioinformatics.stackexchange.com/a/13283/134) noting that BAI indexes cannot handle chromosomes longer than 2<sup>29</sup>, someone pseudonymously asks

> Do you have a reference for this limitation? Is it mentioned in the docs somewhere?

This is common knowledge in the field of course and is spelt out in e.g. SAMv1.pdf. But I didn't see an explicit mention in the samtools man pages, so this adds it to `man samtools index`.