### PR TITLE
Typo fixes mostly in user-visible documentation [minor]

### DIFF
--- a/doc/samtools-stats.1
+++ b/doc/samtools-stats.1
@@ -450,8 +450,7 @@ Number of input/output compression threads to use in addition to main thread [0]
 .SH AUTHOR
 .PP
 Written by Petr Danacek with major modifications by Nicholas Clarke,
-Martin Pollard, Nicholas Clarke, Josh Randall and Valeriu Ohan, all
-from the Sanger Institute.
+Martin Pollard, Josh Randall, and Valeriu Ohan, all from the Sanger Institute.
 
 .SH SEE ALSO
 .IR samtools (1),

--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -228,7 +228,7 @@ If the reference file is not local,
 but is accessed instead via an https://, s3:// or other URL,
 the index file will need to be supplied by the server alongside the reference.
 It is possible to have the reference and index files in different locations
-by supplying both to this option seperated by the string "##idx##",
+by supplying both to this option separated by the string "##idx##",
 for example:
 
 .B -T ftp://x.com/ref.fa##idx##ftp://y.com/index.fa.fai

--- a/doc/samtools.1
+++ b/doc/samtools.1
@@ -876,7 +876,7 @@ For example: to convert a BAM to a compressed SAM with CSI indexing:
 samtools view -h -O sam,level=6 --write-index in.bam -o out.sam.gz
 .EE
 .PP
-To convert a SAM to a compresed BAM using BAI indexing:
+To convert a SAM to a compressed BAM using BAI indexing:
 .EX 4
 samtools view --write-index in.sam -o out.bam##idx##out.bam.bai
 .EE

--- a/tmp_file.h
+++ b/tmp_file.h
@@ -31,7 +31,7 @@ DEALINGS IN THE SOFTWARE
 #include <lz4.h>
 #include "htslib/sam.h"
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 


### PR DESCRIPTION
List Nicholas only once. Fix `__cplusplus` spelling (though this would only make a difference if _tmp_file.h_ was copied into a C++ project).