### PR TITLE
Add -u option to various samtools commands.

### DIFF
--- a/bam_addrprg.c
+++ b/bam_addrprg.c
@@ -51,6 +51,7 @@ struct parsed_opts {
     rg_mode mode;
     sam_global_args ga;
     htsThreadPool p;
+    int uncompressed;
 };
 
 struct state;
@@ -171,6 +172,7 @@ static void usage(FILE *fp)
             "  -o FILE   Where to write output to [stdout]\n"
             "  -r STRING @RG line text\n"
             "  -R STRING ID of @RG line in existing header to use\n"
+            "  -u        Output uncompressed data\n"
             "  --no-PG   Do not add a PG line\n"
             );
     sam_global_opt_help(fp, "..O..@..");
@@ -198,7 +200,7 @@ static bool parse_args(int argc, char** argv, parsed_opts_t** opts)
     };
     kstring_t rg_line = {0,0,NULL};
 
-    while ((n = getopt_long(argc, argv, "r:R:m:o:O:h@:", lopts, NULL)) >= 0) {
+    while ((n = getopt_long(argc, argv, "r:R:m:o:O:h@:u", lopts, NULL)) >= 0) {
         switch (n) {
             case 'r':
                 // Are we adding to existing rg line?
@@ -234,6 +236,9 @@ static bool parse_args(int argc, char** argv, parsed_opts_t** opts)
                 return true;
             case 1:
                 retval->no_pg = 1;
+                break;
+            case 'u':
+                retval->uncompressed = 1;
                 break;
             case '?':
                 usage(stderr);
@@ -314,7 +319,7 @@ static void orphan_only_func(const state_t* state, bam1_t* file_read)
 }
 
 static bool init(const parsed_opts_t* opts, state_t** state_out) {
-    char output_mode[8] = "w";
+    char output_mode[9] = "w";
     state_t* retval = (state_t*) calloc(1, sizeof(state_t));
 
     if (retval == NULL) {
@@ -332,8 +337,12 @@ static bool init(const parsed_opts_t* opts, state_t** state_out) {
     retval->input_header = sam_hdr_read(retval->input_file);
 
     retval->output_header = sam_hdr_dup(retval->input_header);
+
+    if (opts->uncompressed)
+        strcat(output_mode, "0");
     if (opts->output_name) // File format auto-detection
-        sam_open_mode(output_mode + 1, opts->output_name, NULL);
+        sam_open_mode(output_mode + strlen(output_mode),
+                      opts->output_name, NULL);
     retval->output_file = sam_open_format(opts->output_name == NULL?"-":opts->output_name, output_mode, &opts->ga.out);
 
     if (retval->output_file == NULL) {

--- a/bam_ampliconclip.c
+++ b/bam_ampliconclip.c
@@ -766,6 +766,7 @@ static void usage(void) {
     fprintf(stderr, " -b  FILE            bedfile of amplicons to be removed.\n");
     fprintf(stderr, " -o  FILE            output file name (default stdout).\n");
     fprintf(stderr, " -f  FILE            write stats to file name (default stderr)\n");
+    fprintf(stderr, " -u                  Output uncompressed data\n");
     fprintf(stderr, " --soft-clip         soft clip amplicons from reads (default)\n");
     fprintf(stderr, " --hard-clip         hard clip amplicons from reads.\n");
     fprintf(stderr, " --both-ends         clip on both ends.\n");
@@ -783,7 +784,7 @@ static void usage(void) {
 
 int amplicon_clip_main(int argc, char **argv) {
     int c, ret;
-    char wmode[3] = {'w', 'b', 0};
+    char wmode[4] = {'w', 'b', 0, 0};
     char *bedfile = NULL, *fnout = "-";
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
     htsThreadPool p = {NULL, 0};
@@ -807,11 +808,12 @@ int amplicon_clip_main(int argc, char **argv) {
         {NULL, 0, NULL, 0}
     };
 
-    while ((c = getopt_long(argc, argv, "b:@:o:O:f:", lopts, NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "b:@:o:O:f:u", lopts, NULL)) >= 0) {
         switch (c) {
             case 'b': bedfile = optarg; break;
             case 'o': fnout = optarg; break;
             case 'f': param.stats_file = optarg; break;
+            case 'u': wmode[2] = '0'; break;
             case 1002: param.add_pg = 0; break;
             case 1003: clipping = soft_clip; break;
             case 1004: clipping = hard_clip; break;

--- a/bam_markdup.c
+++ b/bam_markdup.c
@@ -1744,6 +1744,7 @@ static int markdup_usage(void) {
     fprintf(stderr, "  -m --mode TYPE   Duplicate decision method for paired reads.\n"
                     "                   TYPE = t measure positions based on template start/end (default).\n"
                     "                          s measure positions based on sequence start.\n");
+    fprintf(stderr, "  -u               Output uncompressed data\n");
     fprintf(stderr, "  --include-fails  Include quality check failed reads.\n");
     fprintf(stderr, "  --no-PG          Do not add a PG line\n");
     fprintf(stderr, "  -t               Mark primary duplicates with the name of the original in a \'do\' tag."
@@ -1760,7 +1761,7 @@ static int markdup_usage(void) {
 
 int bam_markdup(int argc, char **argv) {
     int c, ret;
-    char wmode[3] = {'w', 'b', 0};
+    char wmode[4] = {'w', 'b', 0, 0};
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
     htsThreadPool p = {NULL, 0};
     kstring_t tmpprefix = {0, 0, NULL};
@@ -1776,7 +1777,7 @@ int bam_markdup(int argc, char **argv) {
         {NULL, 0, NULL, 0}
     };
 
-    while ((c = getopt_long(argc, argv, "rsl:StT:O:@:f:d:ncm:", lopts, NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "rsl:StT:O:@:f:d:ncm:u", lopts, NULL)) >= 0) {
         switch (c) {
             case 'r': param.remove_dups = 1; break;
             case 'l': param.max_length = atoi(optarg); break;
@@ -1798,6 +1799,7 @@ int bam_markdup(int argc, char **argv) {
                 }
 
                 break;
+            case 'u': wmode[2] = '0'; break;
             case 1001: param.include_fails = 1; break;
             case 1002: param.no_pg = 1; break;
             default: if (parse_sam_global_opt(c, optarg, lopts, &ga) == 0) break;

--- a/bam_mate.c
+++ b/bam_mate.c
@@ -410,6 +410,7 @@ void usage(FILE* where)
 "  -p           Disable FR proper pair check\n"
 "  -c           Add template cigar ct tag\n"
 "  -m           Add mate score tag\n"
+"  -u           Uncompressed output\n"
 "  --no-PG      do not add a PG line\n");
 
     sam_global_opt_help(where, "-.O..@-.");
@@ -427,7 +428,7 @@ int bam_mating(int argc, char *argv[])
     samFile *in = NULL, *out = NULL;
     int c, remove_reads = 0, proper_pair_check = 1, add_ct = 0, res = 1, mate_score = 0, no_pg = 0;
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
-    char wmode[3] = {'w', 'b', 0};
+    char wmode[4] = {'w', 'b', 0, 0};
     static const struct option lopts[] = {
         SAM_OPT_GLOBAL_OPTIONS('-', 0, 'O', 0, 0, '@'),
         {"no-PG", no_argument, NULL, 1},
@@ -437,12 +438,13 @@ int bam_mating(int argc, char *argv[])
 
     // parse args
     if (argc == 1) { usage(stdout); return 0; }
-    while ((c = getopt_long(argc, argv, "rpcmO:@:", lopts, NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "rpcmO:@:u", lopts, NULL)) >= 0) {
         switch (c) {
             case 'r': remove_reads = 1; break;
             case 'p': proper_pair_check = 0; break;
             case 'c': add_ct = 1; break;
             case 'm': mate_score = 1; break;
+            case 'u': wmode[2] = '0'; break;
             case 1: no_pg = 1; break;
             default:  if (parse_sam_global_opt(c, optarg, lopts, &ga) == 0) break;
                       /* else fall-through */

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -2595,6 +2595,7 @@ static void sort_usage(FILE *fp)
 "Usage: samtools sort [options...] [in.bam]\n"
 "Options:\n"
 "  -l INT     Set compression level, from 0 (uncompressed) to 9 (best)\n"
+"  -u         Output uncompressed data (equivalent to -l 0)\n"
 "  -m INT     Set maximum memory per thread; suffix K/M/G recognized [768M]\n"
 "  -M         Use minimiser for clustering unaligned/unplaced reads\n"
 "  -K INT     Kmer size to use for minimiser [20]\n"
@@ -2641,7 +2642,7 @@ int bam_sort(int argc, char *argv[])
         { NULL, 0, NULL, 0 }
     };
 
-    while ((c = getopt_long(argc, argv, "l:m:no:O:T:@:t:MK:", lopts, NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "l:m:no:O:T:@:t:MK:u", lopts, NULL)) >= 0) {
         switch (c) {
         case 'o': fnout = optarg; o_seen = 1; break;
         case 'n': is_by_qname = 1; break;
@@ -2656,6 +2657,7 @@ int bam_sort(int argc, char *argv[])
             }
         case 'T': kputs(optarg, &tmpprefix); break;
         case 'l': level = atoi(optarg); break;
+        case 'u': level = 0; break;
         case   1: no_pg = 1; break;
         case 'M': by_minimiser = 1; break;
         case 'K':

--- a/doc/samtools-addreplacerg.1
+++ b/doc/samtools-addreplacerg.1
@@ -51,6 +51,7 @@ samtools addreplacerg
 .IR rg-ID ]
 .RB [ -m
 .IR mode ]
+.RB [ -u ]
 .RB [ -o
 .IR out.bam ]
 .I in.bam
@@ -80,12 +81,15 @@ Write the final output to STRING. The default is to write to stdout.
 By default, samtools tries to select a format based on the output
 filename extension; if output is to standard output or no format can be
 deduced,
-.B bam
+.B sam
 is selected.
-.TP
+.TP 8
+.B -u
+Output uncompressed SAM, BAM or CRAM.
+.TP 8
 .BI --no-PG
 Do not add a @PG line to the header of the output file.
-.TP
+.TP 8
 .BI "-@, --threads " INT
 Number of input/output compression threads to use in addition to main thread [0].
 

--- a/doc/samtools-ampliconclip.1
+++ b/doc/samtools-ampliconclip.1
@@ -61,6 +61,7 @@ samtools ampliconclip
 .RB [ --rejects-file
 .IR rejects.file ]
 .RB [ --no-PG ]
+.RB [ -u ]
 .B -b
 .I bed.file in.file
 
@@ -87,6 +88,9 @@ Output file name (defaults to stdout).
 .TP
 .BI "-f " FILE
 File to write stats to (defaults to stderr).
+.TP
+.B -u
+Output uncompressed SAM, BAM or CRAM.
 .TP
 .B --soft-clip
 Soft clip reads (default).

--- a/doc/samtools-fixmate.1
+++ b/doc/samtools-fixmate.1
@@ -44,7 +44,7 @@ samtools fixmate \- fills in mate coordinates and insert size fields.
 .SH SYNOPSIS
 .PP
 samtools fixmate
-.RB [ -rpcm ]
+.RB [ -rpcmu ]
 .RB [ -O
 .IR format ]
 .I in.nameSrt.bam out.bam
@@ -69,6 +69,9 @@ Add template cigar ct tag.
 Add ms (mate score) tags.  These are used by
 .B markdup
 to select the best reads to keep.
+.TP
+.B -u
+Output uncompressed BAM or CRAM.
 .TP
 .BI "-O " FORMAT
 Write the final output as

--- a/doc/samtools-markdup.1
+++ b/doc/samtools-markdup.1
@@ -60,6 +60,7 @@ samtools markdup
 .RB [ --mode ]
 .RB [ --include-fails ]
 .RB [ --no-PG ]
+.RB [ -u ]
 .I in.algsort.bam out.bam
 
 .SH DESCRIPTION
@@ -112,6 +113,9 @@ Mode \fBs\fR measures positions based on sequence start.
 While the two methods identify mostly the same reads as duplicates, mode 
 \fBs\fR tends to return more results.  Unpaired reads are treated identically
 by both modes.
+.TP
+.B -u
+Output uncompressed SAM, BAM or CRAM.
 .TP
 .B --include-fails
 Include quality checked failed reads.

--- a/doc/samtools-sort.1
+++ b/doc/samtools-sort.1
@@ -45,6 +45,7 @@ samtools sort \- sorts SAM/BAM/CRAM files
 samtools sort
 .RB [ -l
 .IR level ]
+.RB [ -u ]
 .RB [ -m
 .IR maxMem ]
 .RB [ -o
@@ -104,6 +105,10 @@ compression level setting.
 If
 .B -l
 is not used, the default compression level will apply.
+.TP
+.B "-u "
+Set the compression level to 0, for uncompressed output.  This is a
+synonym for \fB-l 0\fR.
 .TP
 .BI "-m " INT
 Approximately the maximum required memory per thread, specified either in bytes


### PR DESCRIPTION
This changes `fixmate`, `addreplacerg`, `markdup`, `ampliconclip`, and `sort`.  Unchanged is `split` as it already uses -u for something else.