### PR TITLE
Mpileup maxcnt tweak.

### DIFF
--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -157,6 +157,7 @@ typedef struct {
     char **argv;
     char sep, empty;
     sam_global_args ga;
+    double max_depth_pos;
 } mplp_conf_t;
 
 typedef struct {
@@ -669,6 +670,8 @@ static int mpileup(mplp_conf_t *conf, int n, char **fn, char **fn_idx)
     // Only used when writing BCF
     max_indel_depth = conf->max_indel_depth * sm->n;
     bam_mplp_set_maxcnt(iter, max_depth);
+    if (conf->max_depth_pos)
+        bam_mplp_set_cntpos(iter, conf->max_depth_pos);
     bcf1_t *bcf_rec = bcf_init1();
     int ret;
     int last_tid = -1;
@@ -1157,6 +1160,7 @@ int bam_mpileup(int argc, char *argv[])
     mplp.min_baseQ = 13;
     mplp.capQ_thres = 0;
     mplp.max_depth = MPLP_MAX_DEPTH;
+    mplp.max_depth_pos = 0.0;
     mplp.max_indel_depth = MPLP_MAX_INDEL_DEPTH;
     mplp.openQ = 40; mplp.extQ = 20; mplp.tandemQ = 100;
     mplp.min_frac = 0.002; mplp.min_support = 1;
@@ -1258,7 +1262,13 @@ int bam_mpileup(int argc, char *argv[])
             if (mplp.fai == NULL) return 1;
             mplp.fai_fname = optarg;
             break;
-        case 'd': mplp.max_depth = atoi(optarg); break;
+        case 'd': {
+            double d = atof(optarg);
+            mplp.max_depth = d;
+            mplp.max_depth_pos = d - mplp.max_depth;
+            break;
+        }
+        //case 'd': mplp.max_depth = atoi(optarg); break;
         case 'r': mplp.reg = strdup(optarg); break;
         case 'l':
                   // In the original version the whole BAM was streamed which is inefficient

--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -1112,7 +1112,6 @@ static void print_usage(FILE *fp, const mplp_conf_t *mplp)
 "  -Q, --min-BQ INT        skip bases with baseQ/BAQ smaller than INT [%d]\n", mplp->min_baseQ);
     fprintf(fp,
 "  -r, --region REG        region in which pileup is generated\n"
-"  -R, --ignore-RG         ignore RG tags (one BAM = one sample)\n"
 "  --rf, --incl-flags STR|INT  required flags: skip reads with mask bits unset [%s]\n", tmp_require);
     fprintf(fp,
 "  --ff, --excl-flags STR|INT  filter flags: skip reads with mask bits set\n"

--- a/doc/samtools-mpileup.1
+++ b/doc/samtools-mpileup.1
@@ -250,9 +250,6 @@ two requests.
 .I STR
 [all sites]
 .TP
-.B -R,\ --ignore-RG
-Ignore RG tags. Treat all reads in one BAM as one sample.
-.TP
 .BI --rf,\ --incl-flags \ STR|INT
 Required flags: skip reads with mask bits unset [null]
 .TP


### PR DESCRIPTION
Uses https://github.com/samtools/htslib/pull/1084

By default no change in behaviour, but the -d option now doubles up as a location too.  `-d 10` is equiv to `-d 10.0` meaning left end.  `-d 10.7` means use depth 70% of the way through the read.