### PR TITLE
Add -w option to allow a wider window with -d T

### DIFF
--- a/bam_tview.c
+++ b/bam_tview.c
@@ -407,7 +407,8 @@ static void error(const char *format, ...)
 "   -d display      output as (H)tml or (C)urses or (T)ext \n"
 "   -X              include customized index file\n"
 "   -p chr:pos      go directly to this position\n"
-"   -s STR          display only reads from this sample or group\n");
+"   -s STR          display only reads from this sample or group\n"
+"   -w INT          display width (with -d T only)\n");
         sam_global_opt_help(stderr, "-.--.--.");
     }
     else
@@ -430,7 +431,7 @@ extern tview_t* text_tv_init(const char *fn, const char *fn_fa, const char *fn_i
 
 int bam_tview_main(int argc, char *argv[])
 {
-    int view_mode=display_ncurses;
+    int view_mode=display_ncurses, display_width = 0;
     tview_t* tv=NULL;
     char *samples=NULL, *position=NULL, *ref, *fn_idx=NULL;
     int c, has_index_file = 0, ref_index = 0;
@@ -441,8 +442,13 @@ int bam_tview_main(int argc, char *argv[])
         { NULL, 0, NULL, 0 }
     };
 
-    while ((c = getopt_long(argc, argv, "s:p:d:X", lopts, NULL)) >= 0) {
+    char *tmp;
+    while ((c = getopt_long(argc, argv, "s:p:d:Xw:", lopts, NULL)) >= 0) {
         switch (c) {
+            case 'w':
+                display_width = strtol(optarg,&tmp,10);
+                if ( tmp==optarg || *tmp || display_width<1 ) error("Could not parse: -w %s\n",optarg);
+                break;
             case 's': samples=optarg; break;
             case 'p': position=optarg; break;
             case 'X': has_index_file=1; break; // -X flag for index filename
@@ -463,6 +469,7 @@ int bam_tview_main(int argc, char *argv[])
         }
     }
     if (argc==optind) error(NULL);
+    if (display_width && view_mode!=display_text) error("The -w option is currently supported only with -d T\n");
 
     ref = NULL;
     ref_index = optind;
@@ -487,6 +494,7 @@ int bam_tview_main(int argc, char *argv[])
 
         case display_text:
             tv = text_tv_init(argv[ref_index], ref, fn_idx, samples, &ga.in);
+            if ( display_width ) tv->mcol = display_width;
             break;
 
         case display_html:


### PR DESCRIPTION
Add a new `-w` option to allow a wider window of tview's text output.