### PR TITLE
Add options to specifiy index location.

### DIFF
--- a/doc/samtools-faidx.1
+++ b/doc/samtools-faidx.1
@@ -3,7 +3,7 @@
 .SH NAME
 samtools faidx \- indexes or queries regions from a fasta file
 .\"
-.\" Copyright (C) 2008-2011, 2013-2018 Genome Research Ltd.
+.\" Copyright (C) 2008-2011, 2013-2018, 2020 Genome Research Ltd.
 .\" Portions copyright (C) 2010, 2011 Broad Institute.
 .\"
 .\" Author: Heng Li <lh3@sanger.ac.uk>
@@ -114,6 +114,13 @@ Append string <pos> to names when writing the forward strand and <neg> when
 writing the reverse strand.  Spaces are preserved, so it is possible to move
 the indicator into the comment part of the description line by including
 a leading space in the strings <pos> and <neg>.
+.RE
+.TP
+.B --fai-idx FILE
+Read/Write to specified index file.
+.TP
+.B --gzi-idx FILE
+Read/Write to specified compressed file index (used with .gz files).
 .TP
 .B -h, --help
 Print help message and exit.

--- a/doc/samtools-fqidx.1
+++ b/doc/samtools-fqidx.1
@@ -3,7 +3,7 @@
 .SH NAME
 samtools fqidx \- Indexes or queries regions from a fastq file
 .\"
-.\" Copyright (C) 2008-2011, 2013-2018 Genome Research Ltd.
+.\" Copyright (C) 2008-2011, 2013-2018, 2020 Genome Research Ltd.
 .\" Portions copyright (C) 2010, 2011 Broad Institute.
 .\"
 .\" Author: Heng Li <lh3@sanger.ac.uk>
@@ -112,6 +112,13 @@ Append string <pos> to names when writing the forward strand and <neg> when
 writing the reverse strand.  Spaces are preserved, so it is possible to move
 the indicator into the comment part of the description line by including
 a leading space in the strings <pos> and <neg>.
+.RE
+.TP
+.B --fai-idx FILE
+Read/Write to specified index file.
+.TP
+.B --gzi-idx FILE
+Read/Write to specified compressed file index (used with .gz files).
 .TP
 .B -h, --help
 Print help message and exit.

--- a/test/test.pl
+++ b/test/test.pl
@@ -603,6 +603,11 @@ sub test_faidx
     cmd("$$opts{bin}/samtools faidx --length 5 $$opts{tmp}/faidx.fa 1:1-104 > $$opts{tmp}/output_faidx_base.fa");
     cmd("$$opts{bin}/samtools faidx --length 5 --output $$opts{tmp}/output_faidx.fa $$opts{tmp}/faidx.fa 1:1-104 && $$opts{diff} $$opts{tmp}/output_faidx.fa $$opts{tmp}/output_faidx_base.fa");
 
+    # Write indices to a file
+    cmd("$$opts{bin}/samtools faidx --fai-idx $$opts{tmp}/fa_test.fai --gzi-idx $$opts{tmp}/fa_test.gzi $$opts{tmp}/faidx.fa.gz");
+    cmd("$$opts{diff} $$opts{tmp}/faidx.fa.fai $$opts{tmp}/fa_test.fai");
+    cmd("$$opts{diff} $$opts{tmp}/faidx.fa.gz.gzi $$opts{tmp}/fa_test.gzi");
+
     # test continuing after an error
     cmd("$$opts{bin}/samtools faidx --output $$opts{tmp}/output_faidx.fa --continue $$opts{tmp}/faidx.fa 100 EEE FFF");
 
@@ -738,6 +743,11 @@ sub test_fqidx
     # Write to file
     cmd("$$opts{bin}/samtools fqidx --length 5 $$opts{tmp}/fqidx.fq 1:1-104 > $$opts{tmp}/output_fqidx_base.fq");
     cmd("$$opts{bin}/samtools fqidx --length 5 --output $$opts{tmp}/output_fqidx.fq $$opts{tmp}/fqidx.fq 1:1-104 && $$opts{diff} $$opts{tmp}/output_fqidx.fq $$opts{tmp}/output_fqidx_base.fq");
+
+    # Write indices to a file
+    cmd("$$opts{bin}/samtools fqidx --fai-idx $$opts{tmp}/fq_test.fai --gzi-idx $$opts{tmp}/fq_test.gzi $$opts{tmp}/fqidx.fq.gz");
+    cmd("$$opts{diff} $$opts{tmp}/fqidx.fq.fai $$opts{tmp}/fq_test.fai");
+    cmd("$$opts{diff} $$opts{tmp}/fqidx.fq.gz.gzi $$opts{tmp}/fq_test.gzi");
 
     # test continuing after an error
     cmd("$$opts{bin}/samtools fqidx --output $$opts{tmp}/output_fqidx.fq --continue $$opts{tmp}/fqidx.fq 100 EEE FFF");


### PR DESCRIPTION
Options added ---fai-idx and --gzi-idx.

These are companion options to --output, specifying the locations of the .fai and (if needed) the .gzi index files.

As a convenience in indexing mode (so when no region file is specified) --output will be treated the same as --fai-idx.

This closes #983.