### PR TITLE
Ampliconstats index

### DIFF
--- a/misc/plot-ampliconstats
+++ b/misc/plot-ampliconstats
@@ -42,11 +42,14 @@ my $res = GetOptions("size=s"      => \$opts{size},
                      "help"        => \$opts{help},
                      "page=i"      => \$opts{page},
                      "amp_add=i"   => \$opts{amp_add},
+                     "amp-add=i"   => \$opts{amp_add},
                      "orient=s"    => \$opts{orient},
                      "depth_max=s" => \$opts{depth_max},
+                     "depth-max=s" => \$opts{depth_max},
                      "thumbnails"  => \$opts{thumbnails},
                      "thumb_size=i"=> \$opts{thumb_size},
-                     "index_only"  => \$opts{index_only});
+                     "thumb-size=i"=> \$opts{thumb_size},
+                     "index-only"  => \$opts{index_only});
 
 $opts{size}      = "1000,800" unless $opts{size};
 $opts{size2}     = "1000,400" unless $opts{size2};
@@ -71,11 +74,11 @@ Options:
     -size2 W,H    Set image width to W and height to H for graphs (horizontal)
     -size3 W,H    Set image width to W and height to H for graphs (vertical)
     -page N       Maximum number of samples per page in heatmaps
-    -amp_add X    Small sample fudge: NErr/(NAll+X) in amplicon count plots
+    -amp-add X    Small sample fudge: NErr/(NAll+X) in amplicon count plots
     -orient h/v   Orientation for plots, defaults to h (horizontal)
-    -depth_max N  Force -reads.png plots to have a fixed yrange
+    -depth-max N  Force -reads.png plots to have a fixed yrange
     -thumbnails   Produce scaled down thumbnail images
-    -thumb_size N Display thumbnails as N pixels wide.
+    -thumb-size N Display thumbnails as N pixels wide.
 
 If FILE is not specified, reads from stdin.
 END

--- a/misc/plot-ampliconstats
+++ b/misc/plot-ampliconstats
@@ -43,7 +43,10 @@ my $res = GetOptions("size=s"      => \$opts{size},
                      "page=i"      => \$opts{page},
                      "amp_add=i"   => \$opts{amp_add},
                      "orient=s"    => \$opts{orient},
-                     "depth_max=s" => \$opts{depth_max});
+                     "depth_max=s" => \$opts{depth_max},
+                     "thumbnails"  => \$opts{thumbnails},
+                     "thumb_size=i"=> \$opts{thumb_size},
+                     "index_only"  => \$opts{index_only});
 
 $opts{size}      = "1000,800" unless $opts{size};
 $opts{size2}     = "1000,400" unless $opts{size2};
@@ -52,6 +55,8 @@ $opts{page}      = 96         unless $opts{page};
 $opts{amp_add}   = 100        unless $opts{amp_add};
 $opts{orient}    = "h"        unless $opts{orient};
 $opts{depth_max} = 0          unless $opts{depth_max};
+$opts{thumbnails}= 0          unless $opts{thumbnails};
+$opts{thumb_size}= 200        unless $opts{thumb_size};
 
 my $max_depth = 0;
 
@@ -69,6 +74,8 @@ Options:
     -amp_add X    Small sample fudge: NErr/(NAll+X) in amplicon count plots
     -orient h/v   Orientation for plots, defaults to h (horizontal)
     -depth_max N  Force -reads.png plots to have a fixed yrange
+    -thumbnails   Produce scaled down thumbnail images
+    -thumb_size N Display thumbnails as N pixels wide.
 
 If FILE is not specified, reads from stdin.
 END
@@ -79,6 +86,9 @@ if ($res != 1 or $opts{help} or scalar(@ARGV) < 1) {
 }
 
 my $prefix = shift(@ARGV);
+
+# Useful for debugging, but undocumented
+goto index_only if ($opts{index_only});
 
 #-----------------------------------------------------------------------------
 # Check gnuplot version.
@@ -1252,7 +1262,11 @@ END
 
 #---------------------------------
 #adding html file to show plots
-my $fname  = "index.html";
+index_only:
+
+# index.html is in the same dir as the images
+my ($prefix_dir) = $prefix=~/(.*\/)/;
+my $fname  = "${prefix_dir}index.html";
 
 open(my $fh,'>',$fname) or error("$fname: $!");
 print $fh q[
@@ -1287,30 +1301,35 @@ my @imgs = sort {
     $A=~s/(\d+)/sprintf("%09d",$1)/ge;
     $B=~s/(\d+)/sprintf("%09d",$1)/ge;
     $A cmp $B
-} <$prefix*.png>;
+} grep {!/thumb\.png/} <$prefix*.png>;
 
 my $last = "";
 my $new_section = 0;
 for (my ($i,$j)=(0,0); $i < @imgs; $i++, $j++)
 {
-    my $fn_prefix = $imgs[$i];
-    $fn_prefix =~ s/-(\w+|read-perc|read-perc-log)(-\d+)*\.png$//;
-    if ($fn_prefix ne $last || $j % 6 == 0) {
-	if ($fn_prefix ne $last) {
-	    $last=$fn_prefix;
-	    $new_section = 1;
-	    $j = 0;
-	}
+    my $fn_base = $imgs[$i];
+    $fn_base =~ s/-(\w+|read-perc|read-perc-log)(-\d+)*\.png$//;
+    if ($fn_base ne $last || $j % 6 == 0) {
+        if ($fn_base ne $last) {
+            $last=$fn_base;
+            $new_section = 1;
+            $j = 0;
+        }
     
-	if ( $i>0 ) { print $fh "</tr>\n"; }
-	if ($new_section) {
-	    print $fh "<tr><td>$fn_prefix</td></tr>\n";
-	    $new_section = 0;
-	}
-	print $fh "<tr>";
-	print $fh qq[<td><a class="thumbnail" href="$imgs[$i]"><img src="$imgs[$i]" width="200px"></a></td>\n];
+        if ( $i>0 ) { print $fh "</tr>\n"; }
+        if ($new_section) {
+            print $fh "<tr><td>$fn_base</td></tr>\n";
+            $new_section = 0;
+        }
+        print $fh "<tr>";
+    }
+    my ($img) = $imgs[$i]=~/(?:.*\/)?(.*)/;
+    if ($opts{thumbnails}) {
+        my $scale = 100*$opts{thumb_size}/[split(",",$opts{size})]->[0],"\n";
+        system("convert -scale $scale% $imgs[$i] $imgs[$i].thumb.png") && die $!;
+        print $fh qq[<td><a class="thumbnail" href="$img"><img src="$img.thumb.png" width="$opts{thumb_size}px"></a></td>\n];
     } else {
-	print $fh qq[<td><a class="thumbnail" href="$imgs[$i]"><img src="$imgs[$i]" width="200px"></a></td>\n];
+        print $fh qq[<td><a class="thumbnail" href="$img"><img src="$img" width="$opts{thumb_size}px"></a></td>\n];
     }
 }
 print $fh qq[

--- a/misc/plot-ampliconstats
+++ b/misc/plot-ampliconstats
@@ -247,20 +247,20 @@ while (<>) {
 
     # Amplicon coordinates
     if (/^AMPLICON/) {
-	my $min_left=1e9;
-	foreach (split(",",$F[2])) {
-	    /\d+-(\d+)/;
-	    $min_left=$1 if ($min_left > $1);
-	}
-	my $max_right=0;
-	foreach (split(",",$F[3])) {
-	    /(\d+)-\d+/;
-	    $max_right=$1 if ($max_right < $1);
-	}
-	$amp_start[$F[1]]=$min_left;
-	$amp_end[$F[1]]=$max_right;
+        my $min_left=1e9;
+        foreach (split(",",$F[2])) {
+            /\d+-(\d+)/;
+            $min_left=$1 if ($min_left > $1);
+        }
+        my $max_right=0;
+        foreach (split(",",$F[3])) {
+            /(\d+)-\d+/;
+            $max_right=$1 if ($max_right < $1);
+        }
+        $amp_start[$F[1]]=$min_left;
+        $amp_end[$F[1]]=$max_right;
 
-	$ref_len = $max_right if ($ref_len < $max_right);
+        $ref_len = $max_right if ($ref_len < $max_right);
     }
 
     # Heatmaps showing all files & all amplicons
@@ -597,8 +597,8 @@ END
     }
 
     if (/^(FREADS|FDEPTH|FVDEPTH)/) {
-	my $max = max(@F[2..$#F]);
-	$max_depth = $max if $max_depth < $max;
+        my $max = max(@F[2..$#F]);
+        $max_depth = $max if $max_depth < $max;
     }
 
     # Per file graphs; accumulate multiple stats here and dump out at end
@@ -610,22 +610,22 @@ END
         push(@{$file{$F[1]}{$F[0]}}, 100*($F[4]+$F[5])/($F[3]+$F[4]+$F[5]+$opts{amp_add}));
     }
     if (/^FTCOORD/) {
-	local $"="\t$F[2]\n";
-	$_="@F[3..$#F]";
-	s/,/\t/g;
-	push(@{$file{$F[1]}{$F[0]}}, "$_\t$F[2]") if ($_ ne "");
+        local $"="\t$F[2]\n";
+        $_="@F[3..$#F]";
+        s/,/\t/g;
+        push(@{$file{$F[1]}{$F[0]}}, "$_\t$F[2]") if ($_ ne "");
     }
 
     if (/^CTCOORD/) {
-	local $"="\t$F[2]\n";
-	$_="@F[3..$#F]";
-	s/,/\t/g;
-	push(@combined_coord, "$_\t$F[2]") if ($_ ne "");
+        local $"="\t$F[2]\n";
+        $_="@F[3..$#F]";
+        s/,/\t/g;
+        push(@combined_coord, "$_\t$F[2]") if ($_ ne "");
     }
 
     if(/^[FC]DP_(ALL|VALID)/) {
-	local $"="\n";
-	push(@{$file{$F[1]}{$F[0]}}, "@F[2..$#F]") if ($_ ne "");
+        local $"="\n";
+        push(@{$file{$F[1]}{$F[0]}}, "@F[2..$#F]") if ($_ ne "");
     }
 }
 
@@ -673,7 +673,7 @@ foreach (keys %fh_cover) {
 #--- Combined
 if ($opts{depth_max}) {
     if ($max_depth > $opts{depth_max}) {
-	print STDERR "Warning: specified -depth_max is lower than the data maximum of $max_depth\n";
+        print STDERR "Warning: specified -depth_max is lower than the data maximum of $max_depth\n";
     }
     $max_depth = $opts{depth_max};
 }
@@ -825,14 +825,14 @@ END
 
     my @x2tics = ();
     for (my $i=1;$i<=$namp;$i++) {
-	my $col = ($i%2)?"blue":"green";
-	print $fh "set obj rect from $amp_start[$i], graph 0 to $amp_end[$i], graph 1 fillcolor rgb '$col' fillstyle transparent solid 0.1 noborder\n";
-	if ($i%2 == 0) {
-	    my $ts = $i>=2    ? $amp_end[$i-1]   : $amp_start[$i];
-	    my $te = $i<$namp ? $amp_start[$i+1] : $amp_end[$i];
-	    my $tpos = ($ts+$te)/2;
-	    push(@x2tics, "\"$i\" " . ($amp_start[$i]+$amp_end[$i])/2);
-	}
+        my $col = ($i%2)?"blue":"green";
+        print $fh "set obj rect from $amp_start[$i], graph 0 to $amp_end[$i], graph 1 fillcolor rgb '$col' fillstyle transparent solid 0.1 noborder\n";
+        if ($i%2 == 0) {
+            my $ts = $i>=2    ? $amp_end[$i-1]   : $amp_start[$i];
+            my $te = $i<$namp ? $amp_start[$i+1] : $amp_end[$i];
+            my $tpos = ($ts+$te)/2;
+            push(@x2tics, "\"$i\" " . ($amp_start[$i]+$amp_end[$i])/2);
+        }
     }
     print $fh "set x2tics (" . join(", ", @x2tics) . ")\n";
 
@@ -873,14 +873,14 @@ END
 
     my @x2tics = ();
     for (my $i=1;$i<=$namp;$i++) {
-	my $col = ($i%2)?"blue":"green";
-	print $fh "set obj rect from $amp_start[$i], graph 0 to $amp_end[$i], graph 1 fillcolor rgb '$col' fillstyle transparent solid 0.1 noborder\n";
-	if ($i%2 == 0) {
-	    my $ts = $i>=2    ? $amp_end[$i-1]   : $amp_start[$i];
-	    my $te = $i<$namp ? $amp_start[$i+1] : $amp_end[$i];
-	    my $tpos = ($ts+$te)/2;
-	    push(@x2tics, "\"$i\" " . ($amp_start[$i]+$amp_end[$i])/2);
-	}
+        my $col = ($i%2)?"blue":"green";
+        print $fh "set obj rect from $amp_start[$i], graph 0 to $amp_end[$i], graph 1 fillcolor rgb '$col' fillstyle transparent solid 0.1 noborder\n";
+        if ($i%2 == 0) {
+            my $ts = $i>=2    ? $amp_end[$i-1]   : $amp_start[$i];
+            my $te = $i<$namp ? $amp_start[$i+1] : $amp_end[$i];
+            my $tpos = ($ts+$te)/2;
+            push(@x2tics, "\"$i\" " . ($amp_start[$i]+$amp_end[$i])/2);
+        }
     }
     print $fh "set x2tics (" . join(", ", @x2tics) . ")\n";
 
@@ -891,7 +891,7 @@ END
     # Sort by descending freq so high freq colours are on top.
     local $"="\n";
     my @sorted = sort {
-	[split(/\s+/,$a)]->[2] <=> [split(/\s+/,$b)]->[2]
+        [split(/\s+/,$a)]->[2] <=> [split(/\s+/,$b)]->[2]
     } split("\n", "@{$file{$f}{FTCOORD}}");
     print $fh "@sorted\nend\n";
 
@@ -901,10 +901,10 @@ END
 
     #--- Template coordinates: COMBINED
     if (scalar(@combined_coord) > 0 && !$combined_done) {
-	my $fn = "$prefix-combined-tcoord";  # filename prefix
-	open(my $fh, ">", "$fn.gp") || die "$fn.gp";
+        my $fn = "$prefix-combined-tcoord";  # filename prefix
+        open(my $fh, ">", "$fn.gp") || die "$fn.gp";
 
-	print $fh <<"END";
+        print $fh <<"END";
 set title "Template coordinate frequencies, all files"
 unset key
 set xlabel "position"
@@ -926,27 +926,27 @@ set linetype 3 lc "black
 seed=rand(-1)
 END
 
-	my @x2tics = ();
-	for (my $i=1;$i<=$namp;$i++) {
-	    my $col = ($i%2)?"blue":"green";
-	    print $fh "set obj rect from $amp_start[$i], graph 0 to $amp_end[$i], graph 1 fillcolor rgb '$col' fillstyle transparent solid 0.1 noborder\n";
-	    if ($i%2 == 0) {
-		my $ts = $i>=2    ? $amp_end[$i-1]   : $amp_start[$i];
-		my $te = $i<$namp ? $amp_start[$i+1] : $amp_end[$i];
-		my $tpos = ($ts+$te)/2;
-		push(@x2tics, "\"$i\" " . ($amp_start[$i]+$amp_end[$i])/2);
-	    }
-	}
-	print $fh "set x2tics (" . join(", ", @x2tics) . ")\n";
+        my @x2tics = ();
+        for (my $i=1;$i<=$namp;$i++) {
+            my $col = ($i%2)?"blue":"green";
+            print $fh "set obj rect from $amp_start[$i], graph 0 to $amp_end[$i], graph 1 fillcolor rgb '$col' fillstyle transparent solid 0.1 noborder\n";
+            if ($i%2 == 0) {
+                my $ts = $i>=2    ? $amp_end[$i-1]   : $amp_start[$i];
+                my $te = $i<$namp ? $amp_start[$i+1] : $amp_end[$i];
+                my $tpos = ($ts+$te)/2;
+                push(@x2tics, "\"$i\" " . ($amp_start[$i]+$amp_end[$i])/2);
+            }
+        }
+        print $fh "set x2tics (" . join(", ", @x2tics) . ")\n";
 
-	print $fh <<"END";
+        print $fh <<"END";
 plot "-" using 1:(\$3+rand(0)):(\$2-\$1):(0):(int(\$4)?\$4+1:(int(\$5) % 2)) with vector nohead lw 3 lc var
 END
-	local $"="\n";
-	print $fh "@combined_coord\nend\n";
+        local $"="\n";
+        print $fh "@combined_coord\nend\n";
 
-	close($fh);
-	system("gnuplot $fn.gp") && die $!;
+        close($fh);
+        system("gnuplot $fn.gp") && die $!;
     }
 
 
@@ -978,14 +978,14 @@ END
 
     my @x2tics = ();
     for (my $i=1;$i<=$namp;$i++) {
-	my $col = ($i%2)?"blue":"green";
-	print $fh "set obj rect from $amp_start[$i], graph 0 to $amp_end[$i], graph 1 fillcolor rgb '$col' fillstyle transparent solid 0.1 noborder\n";
-	if ($i%2 == 0) {
-	    my $ts = $i>=2    ? $amp_end[$i-1]   : $amp_start[$i];
-	    my $te = $i<$namp ? $amp_start[$i+1] : $amp_end[$i];
-	    my $tpos = ($ts+$te)/2;
-	    push(@x2tics, "\"$i\" " . ($amp_start[$i]+$amp_end[$i])/2);
-	}
+        my $col = ($i%2)?"blue":"green";
+        print $fh "set obj rect from $amp_start[$i], graph 0 to $amp_end[$i], graph 1 fillcolor rgb '$col' fillstyle transparent solid 0.1 noborder\n";
+        if ($i%2 == 0) {
+            my $ts = $i>=2    ? $amp_end[$i-1]   : $amp_start[$i];
+            my $te = $i<$namp ? $amp_start[$i+1] : $amp_end[$i];
+            my $tpos = ($ts+$te)/2;
+            push(@x2tics, "\"$i\" " . ($amp_start[$i]+$amp_end[$i])/2);
+        }
     }
     print $fh "set x2tics (" . join(", ", @x2tics) . ")\n";
 
@@ -994,18 +994,18 @@ plot "-" using (xa=xa+\$2):(\$1+.1) with fsteps lw 1 title "all templates", \\
      "-" using (xv=xv+\$2):(\$1+.1) with fsteps lw 2 title "valid templates"
 END
     if (exists($file{$f}{FDP_ALL})) {
-	foreach (split(/\s+/,"@{$file{$f}{FDP_ALL}}")) {
-	    s/,/ /;
-	    print $fh "$_\n";
-	}
+        foreach (split(/\s+/,"@{$file{$f}{FDP_ALL}}")) {
+            s/,/ /;
+            print $fh "$_\n";
+        }
     }
     print $fh "end\n";
 
     if (exists($file{$f}{FDP_VALID})) {
-	foreach (split(/\s+/, "@{$file{$f}{FDP_VALID}}")) {
-	    s/,/ /;
-	    print $fh "$_\n";
-	}
+        foreach (split(/\s+/, "@{$file{$f}{FDP_VALID}}")) {
+            s/,/ /;
+            print $fh "$_\n";
+        }
     }
     print $fh "end\n";
 
@@ -1015,10 +1015,10 @@ END
 
     #--- Template depth: FILE
     if (!$combined_done) {
-	my $fn = "$prefix-combined-tdepth";  # filename prefix
-	open(my $fh, ">", "$fn.gp") || die "$fn.gp";
+        my $fn = "$prefix-combined-tdepth";  # filename prefix
+        open(my $fh, ">", "$fn.gp") || die "$fn.gp";
 
-	print $fh <<"END";
+        print $fh <<"END";
 set title "Template depth per base, all files"
 set key below
 set xlabel "position"
@@ -1040,41 +1040,41 @@ xa=0
 xv=0
 END
 
-	my @x2tics = ();
-	for (my $i=1;$i<=$namp;$i++) {
-	    my $col = ($i%2)?"blue":"green";
-	    print $fh "set obj rect from $amp_start[$i], graph 0 to $amp_end[$i], graph 1 fillcolor rgb '$col' fillstyle transparent solid 0.1 noborder\n";
-	    if ($i%2 == 0) {
-		my $ts = $i>=2    ? $amp_end[$i-1]   : $amp_start[$i];
-		my $te = $i<$namp ? $amp_start[$i+1] : $amp_end[$i];
-		my $tpos = ($ts+$te)/2;
-		push(@x2tics, "\"$i\" " . ($amp_start[$i]+$amp_end[$i])/2);
-	    }
-	}
-	print $fh "set x2tics (" . join(", ", @x2tics) . ")\n";
+        my @x2tics = ();
+        for (my $i=1;$i<=$namp;$i++) {
+            my $col = ($i%2)?"blue":"green";
+            print $fh "set obj rect from $amp_start[$i], graph 0 to $amp_end[$i], graph 1 fillcolor rgb '$col' fillstyle transparent solid 0.1 noborder\n";
+            if ($i%2 == 0) {
+                my $ts = $i>=2    ? $amp_end[$i-1]   : $amp_start[$i];
+                my $te = $i<$namp ? $amp_start[$i+1] : $amp_end[$i];
+                my $tpos = ($ts+$te)/2;
+                push(@x2tics, "\"$i\" " . ($amp_start[$i]+$amp_end[$i])/2);
+            }
+        }
+        print $fh "set x2tics (" . join(", ", @x2tics) . ")\n";
 
-	print $fh <<"END";
+        print $fh <<"END";
 plot "-" using (xa=xa+\$2):((\$1+.1)/$nfile) with fsteps lw 1 title "all templates", \\
      "-" using (xv=xv+\$2):((\$1+.1)/$nfile) with fsteps lw 2 title "valid templates"
 END
-	if (exists($file{COMBINED}{CDP_ALL})) {
-	    foreach (split(/\s+/,"@{$file{COMBINED}{CDP_ALL}}")) {
-		s/,/ /;
-		print $fh "$_\n";
-	    }
-	}
-	print $fh "end\n";
+        if (exists($file{COMBINED}{CDP_ALL})) {
+            foreach (split(/\s+/,"@{$file{COMBINED}{CDP_ALL}}")) {
+                s/,/ /;
+                print $fh "$_\n";
+            }
+        }
+        print $fh "end\n";
 
-	if (exists($file{COMBINED}{CDP_VALID})) {
-	    foreach (split(/\s+/, "@{$file{COMBINED}{CDP_VALID}}")) {
-		s/,/ /;
-		print $fh "$_\n";
-	    }
-	}
-	print $fh "end\n";
+        if (exists($file{COMBINED}{CDP_VALID})) {
+            foreach (split(/\s+/, "@{$file{COMBINED}{CDP_VALID}}")) {
+                s/,/ /;
+                print $fh "$_\n";
+            }
+        }
+        print $fh "end\n";
 
-	close($fh);
-	system("gnuplot $fn.gp") && die $!;
+        close($fh);
+        system("gnuplot $fn.gp") && die $!;
     }
 
     #--- Read count / depth


### PR DESCRIPTION
Builds on top of @FredDodd6's PR #1298 with a few additional tweaks:

- Renamed fn_prefix to fn_base as we use prefix already and it's confusing.
    
- Added the ability to create .thumb.png images via -thumbnails option, although this needs ImageMagick convert too.
    
- Thumbnail (visible) size in index.html is now configurable via --thumb_size.  Defaults at 200 pixels.
    
- Hidden option of -index-only; used mainly for debugging so we can keep regenerating index.html without running the rest of the script.
    
- Index.html is generated in the same directory as the images themselves, via the global $prefix.
    
          plot-ampliconstats run1234 ampstats.txt
    
will create run1234-*.png and index.html in current dir, while
    
          plot-ampliconstats /tmp/output/run1234 ampstats.txt
    
will create /tmp/output/run1234*.png and /tmp/output/index.html.
    
- Filenames referred to in index.html will always be relative to that path, so we can move the directory without breaking the links.

- Add -long-opt aliases to -long_opt for consistency with Unix norms.  -long-opt are the ones listed in the help now.

- Removed tabs.
