### PR TITLE
Explicitly document that sort -n is incompatible with indexing

### DIFF
--- a/bam_sort.c
+++ b/bam_sort.c
@@ -2599,7 +2599,7 @@ static void sort_usage(FILE *fp)
 "  -m INT     Set maximum memory per thread; suffix K/M/G recognized [768M]\n"
 "  -M         Use minimiser for clustering unaligned/unplaced reads\n"
 "  -K INT     Kmer size to use for minimiser [20]\n"
-"  -n         Sort by read name\n"
+"  -n         Sort by read name (not compatible with samtools index command)\n"
 "  -t TAG     Sort by value of TAG. Uses position as secondary index (or read name if -n is set)\n"
 "  -o FILE    Write final output to FILE rather than standard output\n"
 "  -T PREFIX  Write temporary files to PREFIX.nnnn.bam\n"

--- a/doc/samtools-sort.1
+++ b/doc/samtools-sort.1
@@ -89,6 +89,16 @@ Consider using
 .B samtools collate
 instead if you need name collated data without a full lexicographical sort.
 
+Note that if the sorted output file is to be indexed with
+.BR "samtools index" ,
+the default coordinate sort must be used.
+Thus the
+.B -n
+and
+.B -t
+options are incompatible with
+.BR "samtools index" .
+
 .SH OPTIONS
 
 .TP 11


### PR DESCRIPTION
Neophytes getting mysterious errors from `samtools index` because they prepared their BAM files with `samtools sort -n` is somehow in vogue at the moment: see [Q1](https://bioinformatics.stackexchange.com/questions/13997/samtools-index-chromosome-blocks-not-continuous), [Q2](https://bioinformatics.stackexchange.com/questions/14179/no-coor-reads-not-in-a-single-block-at-the-end-0-1), and also [Q3](https://bioinformatics.stackexchange.com/questions/5352/error-given-while-trying-to-index-a-bam-file-with-samtools-index-no-coor).

This spells out in the documentation that for use with `samtools index`, you just want the default sort.

Now that there is a header API, it would be possible to emit a warning (at least) if the input has an `@HD SO` value other than `coordinate` or `unknown`, but that all happens under the covers in `sam_index_build3()` so would be a separate HTSlib PR.