### PR TITLE
Stop calling unneeded code in markdup.

### DIFF
--- a/bam_markdup.c
+++ b/bam_markdup.c
@@ -910,6 +910,9 @@ static int duplicate_chain_check(md_param_t *param, khash_t(duplicates) *dup_has
     int have_original = !(ori->b->core.flag & BAM_FDUP);
     int ori_paired = (ori->b->core.flag & BAM_FPAIRED) && !(ori->b->core.flag & BAM_FMUNMAP);
 
+    if (!(param->tag || param->opt_dist))
+        return ret; // nothing to do here
+
     while (current) {
         int current_paired = (current->b->core.flag & BAM_FPAIRED) && !(current->b->core.flag & BAM_FMUNMAP);
 


### PR DESCRIPTION
The code that corrects tags when multiple duplicates of single read occur should only be called when tagging is needed.