### PR TITLE
[view] Added -N to filter by file containing read names

### DIFF
--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -87,6 +87,7 @@ option is required whenever writing CRAM output.
 The
 .BR -L ,
 .BR -M ,
+.BR -N ,
 .BR -r ,
 .BR -R ,
 .BR -d ,
@@ -253,6 +254,10 @@ regions specified on the command line will be reported multiple times.
 The usage of a BED file is optional and its path has to be preceded by
 .BR -L
 option.
+.TP
+.BI "-N " FILE
+Output only alignments with read names listed in
+.I FILE.
 .TP
 .BI "-r " STR
 Output alignments in read group

--- a/sam_view.c
+++ b/sam_view.c
@@ -41,16 +41,15 @@ DEALINGS IN THE SOFTWARE.  */
 #include "sam_opts.h"
 #include "bedidx.h"
 
-KHASH_SET_INIT_STR(rg)
-KHASH_SET_INIT_STR(tv)
+KHASH_SET_INIT_STR(str)
 
-typedef khash_t(rg) *rghash_t;
-typedef khash_t(tv) *tvhash_t;
+typedef khash_t(str) *strhash_t;
 
 // This structure contains the settings for a samview run
 typedef struct samview_settings {
-    rghash_t rghash;
-    tvhash_t tvhash;
+    strhash_t rghash;
+    strhash_t rnhash;
+    strhash_t tvhash;
     int min_mapQ;
     int flag_on;
     int flag_off;
@@ -97,16 +96,22 @@ static int process_aln(const sam_hdr_t *h, bam1_t *b, samview_settings_t* settin
     if (settings->rghash) {
         uint8_t *s = bam_aux_get(b, "RG");
         if (s) {
-            khint_t k = kh_get(rg, settings->rghash, (char*)(s + 1));
+            khint_t k = kh_get(str, settings->rghash, (char*)(s + 1));
             if (k == kh_end(settings->rghash)) return 1;
         }
     }
     if (settings->tvhash && settings->tag) {
         uint8_t *s = bam_aux_get(b, settings->tag);
         if (s) {
-            khint_t k = kh_get(tv, settings->tvhash, (char*)(s + 1));
+            khint_t k = kh_get(str, settings->tvhash, (char*)(s + 1));
             if (k == kh_end(settings->tvhash)) return 1;
         } else {
+            return 1;
+        }
+    }
+    if (settings->rnhash) {
+        const char* rn = bam_get_qname(b);
+        if (!rn || kh_get(str, settings->rnhash, rn) == kh_end(settings->rnhash)) {
             return 1;
         }
     }
@@ -128,42 +133,11 @@ static int process_aln(const sam_hdr_t *h, bam1_t *b, samview_settings_t* settin
 
 static int usage(FILE *fp, int exit_status, int is_long_help);
 
-static int add_read_group_single(const char *subcmd, samview_settings_t *settings, char *name)
-{
-    char *d = strdup(name);
-    int ret = 0;
-
-    if (d == NULL) goto err;
-
-    if (settings->rghash == NULL) {
-        settings->rghash = kh_init(rg);
-        if (settings->rghash == NULL) goto err;
-    }
-
-    kh_put(rg, settings->rghash, d, &ret);
-    if (ret == -1) goto err;
-    if (ret ==  0) free(d); /* Duplicate */
-    return 0;
-
- err:
-    print_error(subcmd, "Couldn't add \"%s\" to read group list: memory exhausted?", name);
-    free(d);
-    return -1;
-}
-
-static int add_read_groups_file(const char *subcmd, samview_settings_t *settings, char *fn)
+static int populate_lookup_from_file(const char *subcmd, strhash_t lookup, char *fn)
 {
     FILE *fp;
     char buf[1024];
     int ret = 0;
-    if (settings->rghash == NULL) {
-        settings->rghash = kh_init(rg);
-        if (settings->rghash == NULL) {
-            perror(NULL);
-            return -1;
-        }
-    }
-
     fp = fopen(fn, "r");
     if (fp == NULL) {
         print_error_errno(subcmd, "failed to open \"%s\" for reading", fn);
@@ -173,7 +147,7 @@ static int add_read_groups_file(const char *subcmd, samview_settings_t *settings
     while (ret != -1 && !feof(fp) && fscanf(fp, "%1023s", buf) > 0) {
         char *d = strdup(buf);
         if (d != NULL) {
-            kh_put(rg, settings->rghash, d, &ret);
+            kh_put(str, lookup, d, &ret);
             if (ret == 0) free(d); /* Duplicate */
         } else {
             ret = -1;
@@ -187,6 +161,53 @@ static int add_read_groups_file(const char *subcmd, samview_settings_t *settings
     return (ret != -1) ? 0 : -1;
 }
 
+static int add_read_group_single(const char *subcmd, samview_settings_t *settings, char *name)
+{
+    char *d = strdup(name);
+    int ret = 0;
+
+    if (d == NULL) goto err;
+
+    if (settings->rghash == NULL) {
+        settings->rghash = kh_init(str);
+        if (settings->rghash == NULL) goto err;
+    }
+
+    kh_put(str, settings->rghash, d, &ret);
+    if (ret == -1) goto err;
+    if (ret ==  0) free(d); /* Duplicate */
+    return 0;
+
+ err:
+    print_error(subcmd, "Couldn't add \"%s\" to read group list: memory exhausted?", name);
+    free(d);
+    return -1;
+}
+
+static int add_read_names_file(const char *subcmd, samview_settings_t *settings, char *fn)
+{
+    if (settings->rnhash == NULL) {
+        settings->rnhash = kh_init(str);
+        if (settings->rnhash == NULL) {
+            perror(NULL);
+            return -1;
+        }
+    }
+    return populate_lookup_from_file(subcmd, settings->rnhash, fn);
+}
+
+static int add_read_groups_file(const char *subcmd, samview_settings_t *settings, char *fn)
+{
+    if (settings->rghash == NULL) {
+        settings->rghash = kh_init(str);
+        if (settings->rghash == NULL) {
+            perror(NULL);
+            return -1;
+        }
+    }
+    return populate_lookup_from_file(subcmd, settings->rghash, fn);
+}
+
 static int add_tag_value_single(const char *subcmd, samview_settings_t *settings, char *name)
 {
     char *d = strdup(name);
@@ -195,11 +216,11 @@ static int add_tag_value_single(const char *subcmd, samview_settings_t *settings
     if (d == NULL) goto err;
 
     if (settings->tvhash == NULL) {
-        settings->tvhash = kh_init(tv);
+        settings->tvhash = kh_init(str);
         if (settings->tvhash == NULL) goto err;
     }
 
-    kh_put(tv, settings->tvhash, d, &ret);
+    kh_put(str, settings->tvhash, d, &ret);
     if (ret == -1) goto err;
     if (ret ==  0) free(d); /* Duplicate */
     return 0;
@@ -212,38 +233,14 @@ static int add_tag_value_single(const char *subcmd, samview_settings_t *settings
 
 static int add_tag_values_file(const char *subcmd, samview_settings_t *settings, char *fn)
 {
-    FILE *fp;
-    char buf[1024];
-    int ret = 0;
     if (settings->tvhash == NULL) {
-        settings->tvhash = kh_init(tv);
+        settings->tvhash = kh_init(str);
         if (settings->tvhash == NULL) {
             perror(NULL);
             return -1;
         }
     }
-
-    fp = fopen(fn, "r");
-    if (fp == NULL) {
-        print_error_errno(subcmd, "failed to open \"%s\" for reading", fn);
-        return -1;
-    }
-
-    while (ret != -1 && !feof(fp) && fscanf(fp, "%1023s", buf) > 0) {
-        char *d = strdup(buf);
-        if (d != NULL) {
-            kh_put(tv, settings->tvhash, d, &ret);
-            if (ret == 0) free(d); /* Duplicate */
-        } else {
-            ret = -1;
-        }
-    }
-    if (ferror(fp)) ret = -1;
-    if (ret == -1) {
-        print_error_errno(subcmd, "failed to read \"%s\"", fn);
-    }
-    fclose(fp);
-    return (ret != -1) ? 0 : -1;
+    return populate_lookup_from_file(subcmd, settings->tvhash, fn);
 }
 
 static inline int check_sam_write1(samFile *fp, const sam_hdr_t *h, const bam1_t *b, const char *fname, int *retp)
@@ -309,7 +306,7 @@ int main_samview(int argc, char *argv[])
     opterr = 0;
 
     while ((c = getopt_long(argc, argv,
-                            "SbBcCt:h1Ho:O:q:f:F:G:ul:r:T:R:d:D:L:s:@:m:x:U:MX",
+                            "SbBcCt:h1Ho:O:q:f:F:G:ul:r:T:R:N:d:D:L:s:@:m:x:U:MX",
                             lopts, NULL)) >= 0) {
         switch (c) {
         case 's':
@@ -364,6 +361,12 @@ int main_samview(int argc, char *argv[])
             break;
         case 'R':
             if (add_read_groups_file("view", &settings, optarg) != 0) {
+                ret = 1;
+                goto view_end;
+            }
+            break;
+        case 'N':
+            if (add_read_names_file("view", &settings, optarg) != 0) {
                 ret = 1;
                 goto view_end;
             }
@@ -772,13 +775,19 @@ view_end:
         khint_t k;
         for (k = 0; k < kh_end(settings.rghash); ++k)
             if (kh_exist(settings.rghash, k)) free((char*)kh_key(settings.rghash, k));
-        kh_destroy(rg, settings.rghash);
+        kh_destroy(str, settings.rghash);
+    }
+    if (settings.rnhash) {
+        khint_t k;
+        for (k = 0; k < kh_end(settings.rnhash); ++k)
+            if (kh_exist(settings.rnhash, k)) free((char*)kh_key(settings.rnhash, k));
+        kh_destroy(str, settings.rnhash);
     }
     if (settings.tvhash) {
         khint_t k;
         for (k = 0; k < kh_end(settings.tvhash); ++k)
             if (kh_exist(settings.tvhash, k)) free((char*)kh_key(settings.tvhash, k));
-        kh_destroy(tv, settings.tvhash);
+        kh_destroy(str, settings.tvhash);
     }
     if (settings.remove_aux_len) {
         free(settings.remove_aux);
@@ -823,6 +832,7 @@ static int usage(FILE *fp, int exit_status, int is_long_help)
 "  -L FILE  only include reads overlapping this BED FILE [null]\n"
 "  -r STR   only include reads in read group STR [null]\n"
 "  -R FILE  only include reads with read group listed in FILE [null]\n"
+"  -N FILE  only include reads with read name listed in FILE [null]\n"
 "  -d STR:STR\n"
 "           only include reads with tag STR and associated value STR [null]\n"
 "  -D STR:FILE\n"


### PR DESCRIPTION
Also refactored the string khash sets to remove code duplication.

This feature has come up multiple times on biostars and I personally have had to use (the much slower) `picard.FilterSamReads` multiple times purely because this option is missing from samtools.


More generally, what is the threshold for inclusion into samtools? I'm slowly building up a collection of useful but not-quite-as-universally-useful-as-samtools utilities. Should I make PRs for them, or keep them in a specialised utility? For example, my utility that converts just the unmapped bases (ie, unmapped reads, soft clipped bases, and the bases that don't map to any chimeric alignment) to fastq could be a PR to `samtools fastq/fasta`.