### PR TITLE
Upgrade AppVeyor image

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,6 +18,9 @@ skip_tags: true
 #    - docs/*
 #    - '**/*.html'
 
+# Appveyor Windows images are based on Visual studio version
+image: Visual Studio 2019
+
 # We use Mingw/Msys, so use pacman for installs
 install:
   - set HOME=.


### PR DESCRIPTION
This fixes the keys so they'll work with newer Mingw builds and also upgrades pacman to support their .zst packages.

Replaces and closes #1332