### PR TITLE
[cat] Fix the short option for the number of threads

### DIFF
--- a/bam_cat.c
+++ b/bam_cat.c
@@ -467,7 +467,7 @@ int main_cat(int argc, char *argv[])
     char *outfn = 0;
     char **infns = NULL; // files to concatenate
     int infns_size = 0;
-    int c, ret = 0, no_pg = 0;
+    int c, ret = 0, no_pg = 0, usage = 0;
     samFile *in;
     sam_global_args ga;
 
@@ -481,7 +481,7 @@ int main_cat(int argc, char *argv[])
 
     sam_global_args_init(&ga);
 
-    while ((c = getopt_long(argc, argv, "h:o:b:", lopts, NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "h:o:b:@:", lopts, NULL)) >= 0) {
         switch (c) {
             case 'h': {
                 samFile *fph = sam_open(optarg, "r");
@@ -522,6 +522,8 @@ int main_cat(int argc, char *argv[])
                 break;
             default:
                 if (parse_sam_global_opt(c, optarg, lopts, &ga) == 0) break;
+                /* else fall-through */
+            case '?': usage=1; break;
         }
     }
 
@@ -539,7 +541,7 @@ int main_cat(int argc, char *argv[])
     }
 
     // Require at least one input file
-    if (infns_size + nargv_fns == 0) {
+    if (infns_size + nargv_fns == 0 || usage) {
         fprintf(stderr, "Usage: samtools cat [options] <in1.bam>  [... <inN.bam>]\n");
         fprintf(stderr, "       samtools cat [options] <in1.cram> [... <inN.cram>]\n\n");
         fprintf(stderr, "Concatenate BAM or CRAM files, first those in <bamlist.fofn>, then those\non the command line.\n\n");


### PR DESCRIPTION
`samtools cat` was missing the short option for the number of threads from the option string passed to `getopt_long`. This caused `optarg` to be 0.

Fixes #1336 