### PR TITLE
[view] Use -d option without a value

### DIFF
--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -277,12 +277,12 @@ Note that records with no
 tag will also be output when using this option.
 This behaviour may change in a future release.
 .TP
-.BI "-d " STR:STR
+.BI "-d " STR1[:STR2]
 Only output alignments with tag
-.I STR
+.I STR1
 and associated value
-.I STR
-[null].
+.I STR2
+[null]. The value can be omitted, in which case only the tag is considered.
 .TP
 .BI "-D " STR:FILE
 Only output alignments with tag

--- a/test/test.pl
+++ b/test/test.pl
@@ -2087,6 +2087,8 @@ sub test_view
         ['rn', { read_names => { 'unaligned_grp3_p001' => 1, 'ref1_grp1_p001' => 1, 'r008' => 1, 'r009' => 1 } },
          ['-N', $forn], 0],
         # Tag with values
+        ['tv_BC', { tag => 'BC', tag_values => { ACGT => 1, TGCA => 1, AATTCCGG => 1 }},
+         ['-d', 'BC'], 0],
         ['tv_BC_TGCA', { tag => 'BC', tag_values => { TGCA => 1 }},
          ['-d', 'BC:TGCA'], 0],
         ['tv_BC_fobc', { tag => 'BC', tag_values => { ACGT => 1, AATTCCGG => 1 }},


### PR DESCRIPTION
`samtools view` now accepts just a tag (without an associated value) as an argument to `-d` option (e.g. `-d BC`), which selects all the alignments with that respective tag, irrespective of the corresponding values.

Fixes #1317 