### PR TITLE
List --write-index in samtools sort usage [trivial]

### DIFF
--- a/bam_sort.c
+++ b/bam_sort.c
@@ -2605,7 +2605,7 @@ static void sort_usage(FILE *fp)
 "  -o FILE    Write final output to FILE rather than standard output\n"
 "  -T PREFIX  Write temporary files to PREFIX.nnnn.bam\n"
 "  --no-PG    do not add a PG line\n");
-    sam_global_opt_help(fp, "-.O..@-.");
+    sam_global_opt_help(fp, "-.O..@..");
 }
 
 static void complain_about_memory_setting(size_t max_mem) {


### PR DESCRIPTION
This option was implemented for sort in PR #1148, but in a minor oversight, it was not added to the usage display shown by `samtools sort` without arguments.

(Tests will currently fail because samtools's _test/mpileup/mp_N2.sam_ suffers (on two lines) from the same CIGAR syntax error as one of HTSlib's test files as highlighted in samtools/htslib#1169.)