### PR TITLE
samtools view filtering and documentation

### DIFF
--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -307,6 +307,11 @@ sequence \(>=
 .I INT
 [0]
 .TP
+.BI "-e " STR
+Only include alignments that match the filter expression \fISTR\fR.
+The syntax for these expressions are in the main samtools(1) man page
+under the FILTER EXPRESSIONS heading.
+.TP
 .BI "-f " INT
 Only output alignments with all bits set in
 .I INT

--- a/doc/samtools.1
+++ b/doc/samtools.1
@@ -773,6 +773,11 @@ compression, otherwise SAM defaults to uncompressed.
 Specifies the number of threads to use during encoding and/or
 decoding.  For BAM this will be encoding only.  In CRAM the threads
 are dynamically shared between encoder and decoder.
+.TP
+.BI filter= STRING
+Apply filter STRING to all incoming records, rejecting any that do not
+satisfy the expression.  See the FILTER EXPRESSIONS section below for
+specifics.
 .\" CRAM specific
 .TP
 .BI reference= fasta_file
@@ -930,6 +935,133 @@ Look for MD5 via REF_CACHE environment variable.
 Look for MD5 in each element of the REF_PATH environment variable.
 .IP 4. 3
 Look for a local file listed in the UR: header tag.
+
+.PP
+.SH FILTER EXPRESSIONS
+.PP
+Filter expressions are used as an on-the-fly checking of incoming SAM,
+BAM or CRAM records, discarding records that do not match the
+specified expression.
+
+The language used is primarily C style, but with a few differences in
+the precedence rules for bit operators and the inclusion of regular
+expression matching.
+
+The operator precedence, from strongest binding to weakest, is:
+
+.TS
+l lb l .
+Grouping	(, )	E.g. "(1+2)*3"
+Values:	literals, vars	Numbers, strings and variables
+Unary ops:	+, -, !, ~ 	E.g. -10 +10, !10 (not), ~5 (bit not)
+Math ops:	*, /, %	Multiply, division and (integer) modulo
+Math ops:	+, -	Addition / subtractin
+Bit-wise:	&	Integer AND
+Bit-wise	^	Integer XOR
+Bit-wise	|	Integer OR
+Conditionals:	>, >=, <, <=
+Equality:	==, !=, =~ !~	=~ and !~ match regular expressions
+Boolean:	&&, ||	Logical AND / OR
+.TE
+
+Expressions are computed using floating point mathematics, so "10 / 4"
+evaluates to 2.5 rather than 2.  They may be written as integers in
+decimal or "0x" plus hexadecimal, and floating point with or without
+exponents.However operations that require integers first do an
+implicit type conversion, so "7.9 % 5" is 2 and "7.9 & 4.1" is
+equivalent to "7 & 4", which is 4.  Strings are always specified using
+double quotes.  To get a double quote in a string, use backslash.
+Similarly a double backslash is used to get a literal backslash.  For
+example \fBab\\"c\\\\d\fR is the string \fBab"c\\d\fR.
+
+Comparison operators are evaluated as a match being 1 and a mismatch
+being 0, thus "(2 > 1) + (3 < 5)" evaluates as 2.
+
+The variables are where the file format specifics are accessed from
+the expression.  The variables correspond to SAM fields, for example
+to find paired alignments with high mapping quality and a very large
+insert size, we may use the expression "\fBmapq >= 30 && (tlen >= 100000 || tlen <= -100000)\fR".
+Valid variable names and their data types are:
+
+.TS
+lb l l .
+flag	int	Combined FLAG field
+flag.paired	int	Single bit, 0 or 1
+flag.proper_pair	int	Single bit, 0 or 2
+flag.unmap	int	Single bit, 0 or 4
+flag.munmap	int	Single bit, 0 or 8
+flag.reverse	int	Single bit, 0 or 16
+flag.mreverse	int	Single bit, 0 or 32
+flag.read1	int	Single bit, 0 or 64
+flag.read2	int	Single bit, 0 or 128
+flag.secondary	int	Single bit, 0 or 256
+flag.qcfail	int	Single bit, 0 or 512
+flag.dup	int	Single bit, 0 or 1024
+flag.supplementary	int	Single bit, 0 or 2048
+library	string	Library (LB header via RG)
+mapq	int	Mapping quality
+mpos	int	Synonym for pnext
+mrefid	int	Mate reference number (0 based)
+mrname	string	Synonym for rnext
+ncigar	int	Number of cigar operations
+pnext	int	Mate's alignment position (1-based)
+pos	int	Alignment position (1-based)
+qlen	int	Alignment length: no. query bases
+qname	string	Query name
+qual	string	Quality values (raw, 0 based)
+refid	int	Integer reference number (0 based)
+rlen	int	Alignment length: no. reference bases
+rname	string	Reference name
+rnext	string	Mate's reference name
+seq	string	Sequence
+tlen	int	Template length (insert size)
+[XX]	int / string	XX tag value
+.TE
+
+Flags are returned either as the whole flag value or by checking for a
+single bit.  Hence the filter expression \fBflag.dup\fR is
+equivalent to \fBflag & 1024\fR.
+
+"qlen" and "rlen" are measured using the CIGAR string to count the
+number of query (sequence) and reference bases consumed.  Note "qlen"
+may not exactly match the length of the "seq" field if the sequence is
+"*".
+
+Reference names may be matched either by their string forms ("rname"
+and "mrname") or as the Nth \fB@SQ\fR line (counting from zero) as
+stored in BAM using "tid" and "mtid" respectively.
+
+Auxiliary tags are described in square brackets and these expand to
+either integer or string as defined by the tag itself (\fBXX:Z:\fIstring\fR or
+\fBXX:i:\fIint\fR).  For example \fB[NM]>=10\fR can be used to look
+for alignments with many mismatches and \fB[RG]=~"grp[ABC]-"\fR will
+match the read-group string.
+
+If no comparison is used with an auxiliary tag it is taken simply to
+be a test for the existance of that tag.  So "[NM]" will return any
+record containing an NM tag, even if that tag is zero (\fBNM:i:0\fR).
+
+If you need to check specifically for a non-zero value then use \fB[NM]
+&& [NM]!=0\fR.
+
+Some simple functions are available to operate on strings.  These
+treat the strings as arrays of bytes, permitting their length,
+minimum, maximum and average values to be computed.
+
+.TS
+lb l .
+length	Length of the string (excluding nul char)
+min	Minimum byte value in the string
+max	Maximum byte value in the string
+avg	Average byte value in the string
+.TE
+
+Note that "avg" is a floating point value and it may be NAN for empty
+strings.  This means that "avg(qual)" does not produce an error for
+records that have both seq and qual of "*".  This value will fail any
+conditional checks, so e.g. "avg(qual) > 20" works and will not report
+these records.
+
 .PP
 .SH ENVIRONMENT VARIABLES
 .PP

--- a/test/test.pl
+++ b/test/test.pl
@@ -2128,6 +2128,22 @@ sub test_view
         ['qlen11', { min_qlen => 11 }, ['-m', 11], 0],
         ['qlen15', { min_qlen => 15 }, ['-m', 15], 0],
         ['qlen16', { min_qlen => 16 }, ['-m', 16], 0],
+	# Filter expressions
+        ['expr_rej128req2', { flags_rejected => 128, flags_required => 2 },
+	    ['-e', '!(flag & 128) && (flag & 2)'], 0],
+	# filter_sam also removes the header line, so cannot compare.
+	# ['expr_RG', { read_groups => {grp1 => 1, grp3 => 1}}, ['-e', '[RG]=~"^grp[13]$"'], 0],
+	['expr_BC', { tag => 'BC', tag_values => { ACGT => 1, TGCA => 1, AATTCCGG => 1 }},
+	    ['-e', '[BC]'], 0],
+	['expr_BC2', { tag => 'BC', tag_values => { ACGT => 1, AATTCCGG => 1 }},
+	    ['-e', '[BC] == "ACGT" || [BC] == "AATTCCGG"'], 0],
+	['expr_mq50',  { min_map_qual => 50  },  ['-e', 'mapq >= 50' ], 0],
+	['expr_mq99',  { min_map_qual => 99  },  ['-e', 'mapq >= 99' ], 0],
+	['expr_mq100', { min_map_qual => 100 },  ['-e', 'mapq >= 100'], 0],
+	# TODO: add library to filter expression?  It needs to go via RG.
+	# TODO: add cigar.qbase and cigar.rbase counts for consumes
+	#       N bases of query and ref?  Not the same as qlen/rlen as
+	#       indels don't count the same.
         );
 
     my @filter_inputs = ([SAM  => $sam_with_ur],


### PR DESCRIPTION
Add filter expressions to samtools.1 man page

Also add -e FILTER to samtools view.

This is a validation of the new `sam_passes_filter` function, meaning it can be used in conjunction with -U to output the reads that do not match the filter.

Infact both can be used together.  For example

    samtools view \
        --input-fmt-option "filter=rlen-qlen >= 10" \
        -e 'ncigar <= 10' in.bam -o out.sam -U outU.sam

will pre-filter to only reads where the length on the reference is at least 10 bases longer than the length of the sequence.  Those that pass are then written to either out.sam or outU.sam depending on whether they have <= 10 cigar operations.
