### PR TITLE
docs: fix simple typo, defautl -> default

### DIFF
--- a/bam.h
+++ b/bam.h
@@ -77,7 +77,7 @@ typedef bam_hdr_t bam_header_t;
 #define BAM_OFHEX          1
 #define BAM_OFSTR          2
 
-/*! @abstract defautl mask for pileup */
+/*! @abstract default mask for pileup */
 #define BAM_DEF_MASK (BAM_FUNMAP | BAM_FSECONDARY | BAM_FQCFAIL | BAM_FDUP)
 
 /*! @typedef


### PR DESCRIPTION
There is a small typo in bam.h.

Should read `default` rather than `defautl`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md