### PR TITLE
Update CI test configuration to recurse htslib submodules

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,14 +36,14 @@ install:
 clone_script:
   - "sh -lc \"if test x$APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME != x ; then git clone --branch=$APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH https://github.com/$APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME $APPVEYOR_BUILD_FOLDER ; else false ; fi || git clone --branch=$APPVEYOR_REPO_BRANCH https://github.com/$APPVEYOR_REPO_NAME $APPVEYOR_BUILD_FOLDER\""
   - "sh -lc \"git show-branch --sha1-name HEAD"
-  - "sh -lc \"git clone --branch=$APPVEYOR_REPO_BRANCH https://github.com/`echo $APPVEYOR_REPO_NAME|sed 's#/samtools#/htslib#'`.git $APPVEYOR_BUILD_FOLDER/htslib || git clone https://github.com/samtools/htslib.git $APPVEYOR_BUILD_FOLDER/htslib \""
+  - "sh -lc \"git clone --branch=$APPVEYOR_REPO_BRANCH --recurse-submodules --shallow-submodules https://github.com/`echo $APPVEYOR_REPO_NAME|sed 's#/samtools#/htslib#'`.git $APPVEYOR_BUILD_FOLDER/htslib || git clone --recurse-submodules --shallow-submodules https://github.com/samtools/htslib.git $APPVEYOR_BUILD_FOLDER/htslib \""
   - "sh -lc \"cd $APPVEYOR_BUILD_FOLDER/htslib && git show-branch --sha1-name HEAD\""
 
 build_script:
   - set HOME=.
   - set MSYSTEM=MINGW64
   - set PATH=C:/msys64/usr/bin;C:/msys64/mingw64/bin;%PATH%
-  - "sh -lc \"(cd htslib; aclocal && autoheader && autoconf)\""
+  - "sh -lc \"(cd htslib; autoreconf -i)\""
   - "sh -lc \"aclocal && autoheader && autoconf && ./configure --enable-werror && make -j2\""
 
 test_script:

--- a/.travis/clone
+++ b/.travis/clone
@@ -14,4 +14,4 @@ ref=''
 [ -z "$ref" ] && repository='git://github.com/samtools/htslib.git'
 
 set -x
-git clone --depth=50 ${ref:+--branch="$branch"} "$repository" "$localdir"
+git clone --recurse-submodules --shallow-submodules --depth=50 ${ref:+--branch="$branch"} "$repository" "$localdir"


### PR DESCRIPTION
In anticipation of samtools/htslib#929 merge, which adds a submodule.

Also makes Appveyor use `autoreconf -i` when setting up HTSlib as that will be required for autoconf 2.70.

Note that both Travis and cirrus-ci use the `.travis/clone` script.