### PR TITLE
[stats] Adjust a few counters by better filtering

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,13 @@
 Release a.b
 -----------
 
+ * Samtools stats now displays the number of supplementary reads in the
+   SN section. Also, supplementary reads are no longer considered when
+   splitting read pairs by orientation (inward, outward, other).
+   
+ * Samtools stats now counts only the filtered alignments that overlap
+   target regions, if any are specified.
+
 Release 1.11 (22nd September 2020)
 ----------------------------------
 

--- a/doc/samtools-stats.1
+++ b/doc/samtools-stats.1
@@ -121,7 +121,8 @@ but more comprehensive.
 
 .RS
 .B raw total sequences
-- total number of reads in a file. Same number reported by
+- total number of reads in a file, excluding supplementary and secondary reads.
+Same number reported by
 .BR "samtools view -c".
 
 .B filtered sequences
@@ -170,6 +171,9 @@ fragment reads (flags 0x01 and 0x80 set, 0x40 not set).
 
 .B non-primary alignments
 - number of secondary reads (flag 0x100 (256) set).
+
+.B supplementary alignments
+- number of supplementary reads (flag 0x800 (2048) set).
 
 .B total length
 - number of processed bases from reads that are neither secondary nor supplementary (flags 0x100 (256) and 0x800 (2048) are not set).

--- a/stats.c
+++ b/stats.c
@@ -1138,6 +1138,8 @@ static void remove_overlaps(bam1_t *bam_line, khash_t(qn2pair) *read_pairs, stat
 
 void collect_stats(bam1_t *bam_line, stats_t *stats, khash_t(qn2pair) *read_pairs)
 {
+    if ( !is_in_regions(bam_line,stats) )
+        return;
     if ( stats->rg_hash )
     {
         const uint8_t *rg = bam_aux_get(bam_line, "RG");
@@ -1154,8 +1156,6 @@ void collect_stats(bam1_t *bam_line, stats_t *stats, khash_t(qn2pair) *read_pair
         stats->nreads_filtered++;
         return;
     }
-    if ( !is_in_regions(bam_line,stats) )
-        return;
     if ( stats->info->filter_readlen!=-1 && bam_line->core.l_qseq!=stats->info->filter_readlen )
         return;
 

--- a/test/stat/1.stats.expected
+++ b/test/stat/1.stats.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	1a1c1362	29c426ae	7bab45da
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	2
+SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	0
 SN	total length:	70	# ignores clipping
 SN	total first fragment length:	35	# ignores clipping
 SN	total last fragment length:	35	# ignores clipping

--- a/test/stat/1.stats.large.expected
+++ b/test/stat/1.stats.large.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	1a1c1362	29c426ae	7bab45da
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	2
+SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	0
 SN	total length:	70	# ignores clipping
 SN	total first fragment length:	35	# ignores clipping
 SN	total last fragment length:	35	# ignores clipping

--- a/test/stat/10.stats.expected
+++ b/test/stat/10.stats.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	343826c4	53884d5c	f7568bb4
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	4
+SN	raw total sequences:	4	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	4
 SN	is sorted:	0
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	0
 SN	total length:	140	# ignores clipping
 SN	total first fragment length:	70	# ignores clipping
 SN	total last fragment length:	70	# ignores clipping

--- a/test/stat/10_map_cigar.sam_s1_a_1.expected.bamstat
+++ b/test/stat/10_map_cigar.sam_s1_a_1.expected.bamstat
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	1a1c1362	29c426ae	7bab45da
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	2
+SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	0
 SN	total length:	70	# ignores clipping
 SN	total first fragment length:	35	# ignores clipping
 SN	total last fragment length:	35	# ignores clipping

--- a/test/stat/10_map_cigar.sam_s1_b_1.expected.bamstat
+++ b/test/stat/10_map_cigar.sam_s1_b_1.expected.bamstat
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	1a1c1362	29c426ae	7bab45da
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	2
+SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	0
 SN	total length:	70	# ignores clipping
 SN	total first fragment length:	35	# ignores clipping
 SN	total last fragment length:	35	# ignores clipping

--- a/test/stat/11.stats.expected
+++ b/test/stat/11.stats.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	cb2d2d82	bcd83869	62ec814e
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	26
+SN	raw total sequences:	26	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	26
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	1	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	0
 SN	total length:	260	# ignores clipping
 SN	total first fragment length:	140	# ignores clipping
 SN	total last fragment length:	120	# ignores clipping

--- a/test/stat/11.stats.g4.expected
+++ b/test/stat/11.stats.g4.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	cb2d2d82	bcd83869	62ec814e
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	26
+SN	raw total sequences:	26	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	26
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	1	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	0
 SN	total length:	260	# ignores clipping
 SN	total first fragment length:	140	# ignores clipping
 SN	total last fragment length:	120	# ignores clipping

--- a/test/stat/12.2reads.nooverlap.expected
+++ b/test/stat/12.2reads.nooverlap.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	5b31676a	b0edee94	471895da
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	2
+SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	0
 SN	total length:	200	# ignores clipping
 SN	total first fragment length:	100	# ignores clipping
 SN	total last fragment length:	100	# ignores clipping

--- a/test/stat/12.2reads.overlap.expected
+++ b/test/stat/12.2reads.overlap.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	5b31676a	b0edee94	471895da
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	2
+SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	0
 SN	total length:	200	# ignores clipping
 SN	total first fragment length:	100	# ignores clipping
 SN	total last fragment length:	100	# ignores clipping

--- a/test/stat/12.3reads.nooverlap.expected
+++ b/test/stat/12.3reads.nooverlap.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	09f8b87f	140798ec	2b989f07
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	3
+SN	raw total sequences:	3	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	3
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	0
 SN	total length:	300	# ignores clipping
 SN	total first fragment length:	100	# ignores clipping
 SN	total last fragment length:	200	# ignores clipping

--- a/test/stat/12.3reads.overlap.expected
+++ b/test/stat/12.3reads.overlap.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	09f8b87f	140798ec	2b989f07
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	3
+SN	raw total sequences:	3	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	3
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	0
 SN	total length:	300	# ignores clipping
 SN	total first fragment length:	100	# ignores clipping
 SN	total last fragment length:	200	# ignores clipping

--- a/test/stat/13.barcodes.bc.ok.expected
+++ b/test/stat/13.barcodes.bc.ok.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	00b48ec6	e5330ff5	ee3f18a6
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	2696
+SN	raw total sequences:	2696	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2696
 SN	is sorted:	0
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	0
 SN	total length:	29656	# ignores clipping
 SN	total first fragment length:	14828	# ignores clipping
 SN	total last fragment length:	14828	# ignores clipping

--- a/test/stat/13.barcodes.ox.ok.expected
+++ b/test/stat/13.barcodes.ox.ok.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	00b48ec6	e5330ff5	ee3f18a6
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	2696
+SN	raw total sequences:	2696	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2696
 SN	is sorted:	0
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	0
 SN	total length:	29656	# ignores clipping
 SN	total first fragment length:	14828	# ignores clipping
 SN	total last fragment length:	14828	# ignores clipping

--- a/test/stat/1_map_cigar.sam_s1_a_1.expected.bamstat
+++ b/test/stat/1_map_cigar.sam_s1_a_1.expected.bamstat
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	1a1c1362	29c426ae	7bab45da
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	2
+SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	0
 SN	total length:	70	# ignores clipping
 SN	total first fragment length:	35	# ignores clipping
 SN	total last fragment length:	35	# ignores clipping

--- a/test/stat/2.stats.expected
+++ b/test/stat/2.stats.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	1a1c1362	29c426ae	7bab45da
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	2
+SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	0
 SN	total length:	70	# ignores clipping
 SN	total first fragment length:	35	# ignores clipping
 SN	total last fragment length:	35	# ignores clipping

--- a/test/stat/2.stats.large.expected
+++ b/test/stat/2.stats.large.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	1a1c1362	29c426ae	7bab45da
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	2
+SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	0
 SN	total length:	70	# ignores clipping
 SN	total first fragment length:	35	# ignores clipping
 SN	total last fragment length:	35	# ignores clipping

--- a/test/stat/3.stats.expected
+++ b/test/stat/3.stats.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	1a1c1362	ce379e9a	7bab45da
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	2
+SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	0
 SN	total length:	70	# ignores clipping
 SN	total first fragment length:	35	# ignores clipping
 SN	total last fragment length:	35	# ignores clipping

--- a/test/stat/3.stats.large.expected
+++ b/test/stat/3.stats.large.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	1a1c1362	ce379e9a	7bab45da
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	2
+SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	0
 SN	total length:	70	# ignores clipping
 SN	total first fragment length:	35	# ignores clipping
 SN	total last fragment length:	35	# ignores clipping

--- a/test/stat/4.stats.expected
+++ b/test/stat/4.stats.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	1a1c1362	e7724556	7bab45da
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	2
+SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	0
 SN	total length:	70	# ignores clipping
 SN	total first fragment length:	35	# ignores clipping
 SN	total last fragment length:	35	# ignores clipping

--- a/test/stat/4.stats.large.expected
+++ b/test/stat/4.stats.large.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	1a1c1362	e7724556	7bab45da
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	2
+SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	0
 SN	total length:	70	# ignores clipping
 SN	total first fragment length:	35	# ignores clipping
 SN	total last fragment length:	35	# ignores clipping

--- a/test/stat/5.stats.expected
+++ b/test/stat/5.stats.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	1a1c1362	32507d92	7bab45da
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	2
+SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	0
 SN	total length:	70	# ignores clipping
 SN	total first fragment length:	35	# ignores clipping
 SN	total last fragment length:	35	# ignores clipping

--- a/test/stat/5.stats.large.expected
+++ b/test/stat/5.stats.large.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	1a1c1362	32507d92	7bab45da
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	2
+SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	0
 SN	total length:	70	# ignores clipping
 SN	total first fragment length:	35	# ignores clipping
 SN	total last fragment length:	35	# ignores clipping

--- a/test/stat/6.stats.expected
+++ b/test/stat/6.stats.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	1a1c1362	32507d92	7bab45da
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	2
+SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	0
 SN	total length:	70	# ignores clipping
 SN	total first fragment length:	35	# ignores clipping
 SN	total last fragment length:	35	# ignores clipping

--- a/test/stat/7.stats.expected
+++ b/test/stat/7.stats.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	272a1d13	10b7aabd	7baa45da
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	2
+SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	1
 SN	total length:	70	# ignores clipping
 SN	total first fragment length:	35	# ignores clipping
 SN	total last fragment length:	35	# ignores clipping

--- a/test/stat/7.stats.large.expected
+++ b/test/stat/7.stats.large.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	272a1d13	10b7aabd	7baa45da
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	2
+SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	1
 SN	total length:	70	# ignores clipping
 SN	total first fragment length:	35	# ignores clipping
 SN	total last fragment length:	35	# ignores clipping

--- a/test/stat/8.stats.expected
+++ b/test/stat/8.stats.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	272a1d13	94e79452	b980e8c7
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	2
+SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	1
+SN	supplementary alignments:	0
 SN	total length:	70	# ignores clipping
 SN	total first fragment length:	35	# ignores clipping
 SN	total last fragment length:	35	# ignores clipping

--- a/test/stat/8.stats.large.expected
+++ b/test/stat/8.stats.large.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	272a1d13	94e79452	b980e8c7
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	2
+SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	1
+SN	supplementary alignments:	0
 SN	total length:	70	# ignores clipping
 SN	total first fragment length:	35	# ignores clipping
 SN	total last fragment length:	35	# ignores clipping

--- a/test/stat/9.stats.expected
+++ b/test/stat/9.stats.expected
@@ -2,7 +2,7 @@
 # CHK, CRC32 of reads which passed filtering followed by addition (32bit overflow)
 CHK	1a1c1362	29c426ae	7bab45da
 # Summary Numbers. Use `grep ^SN | cut -f 2-` to extract this part.
-SN	raw total sequences:	2
+SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
 SN	is sorted:	1
@@ -17,6 +17,7 @@ SN	reads duplicated:	0	# PCR or optical duplicate bit set
 SN	reads MQ0:	0	# mapped and MQ=0
 SN	reads QC failed:	0
 SN	non-primary alignments:	0
+SN	supplementary alignments:	0
 SN	total length:	70	# ignores clipping
 SN	total first fragment length:	35	# ignores clipping
 SN	total last fragment length:	35	# ignores clipping


### PR DESCRIPTION
 * `samtools stats` now displays the number of supplementary reads in the
   **SN** section. Also, supplementary reads are no longer considered when
   splitting read pairs by orientation (inward, outward, other).
   
 * `samtools stats` now counts only the filtered alignments that overlap
   target regions, if any are specified.

Fixes #1331
Fixes #1360 