### PR TITLE
[view] Add support for int value tags to options -d and -D

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,8 @@ Release a.b
  * Samtools stats now counts only the filtered alignments that overlap
    target regions, if any are specified.
 
+ * Samtools view now supports int value tags for options -d and -D.
+
 Release 1.11 (22nd September 2020)
 ----------------------------------
 

--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -281,8 +281,9 @@ This behaviour may change in a future release.
 Only output alignments with tag
 .I STR1
 and associated value
-.I STR2
-[null]. The value can be omitted, in which case only the tag is considered.
+.IR STR2 ,
+which can be a string or an integer [null].
+The value can be omitted, in which case only the tag is considered.
 .TP
 .BI "-D " STR:FILE
 Only output alignments with tag

--- a/sam_view.c
+++ b/sam_view.c
@@ -106,7 +106,15 @@ static int process_aln(const sam_hdr_t *h, bam1_t *b, samview_settings_t* settin
         uint8_t *s = bam_aux_get(b, settings->tag);
         if (s) {
             if (settings->tvhash) {
-                khint_t k = kh_get(str, settings->tvhash, (char*)(s + 1));
+                char t[32], *val;
+                if (*s == 'i' || *s == 'I' || *s == 'c' || *s == 'C') {
+                    int ret = snprintf(t, 32, "%"PRId64, bam_aux2i(s));
+                    if (ret > 0) val = t;
+                    else return 1;
+                } else {
+                    val = (char *)(s+1);
+                }
+                khint_t k = kh_get(str, settings->tvhash, val);
                 if (k == kh_end(settings->tvhash)) return 1;
             }
         } else {

--- a/test/test.pl
+++ b/test/test.pl
@@ -1198,7 +1198,7 @@ sub filter_sam
                 if ($tag_values) {
                     my $tag_value = '';
                     for my $i (11 .. $#sam) {
-                        last if (($tag_value) = $sam[$i] =~ /^${tag}:Z:(.*)/);
+                        last if (($tag_value) = $sam[$i] =~ /^${tag}:[ZiIcC]:(.*)/);
                     }
                     next if (!exists($tag_values->{$tag_value||""}));
                 }
@@ -2107,6 +2107,8 @@ sub test_view
          ['-D', "BClong:${fobc}"], 1],
         ['tv_d_different_tags', { tag => 'BC', tag_values => { ACGT => 1, grp2 => 1 }},
          ['-d', 'BC:ACGT', '-d', 'RG:grp2' ], 1],
+        ['tv_NM_13', { tag => 'NM', tag_values => { 13 => 1 }},
+         ['-d', 'NM:13'], 0],
         # Libraries
         ['lib2', { libraries => { 'Library 2' => 1 }}, ['-l', 'Library 2'], 0],
         ['lib3', { libraries => { 'Library 3' => 1 }}, ['-l', 'Library 3'], 0],


### PR DESCRIPTION
`samtools view` can now filter alignments by tags with integer values, using options **-d** or **-D**.

Fixes #1357 