### PR TITLE
[view] Support extra int type encodings for auxiliary tags

### DIFF
--- a/sam_view.c
+++ b/sam_view.c
@@ -1,6 +1,6 @@
 /*  sam_view.c -- SAM<->BAM<->CRAM conversion.
 
-    Copyright (C) 2009-2020 Genome Research Ltd.
+    Copyright (C) 2009-2021 Genome Research Ltd.
     Portions copyright (C) 2009, 2011, 2012 Broad Institute.
 
     Author: Heng Li <lh3@sanger.ac.uk>

--- a/sam_view.c
+++ b/sam_view.c
@@ -107,7 +107,7 @@ static int process_aln(const sam_hdr_t *h, bam1_t *b, samview_settings_t* settin
         if (s) {
             if (settings->tvhash) {
                 char t[32], *val;
-                if (*s == 'i' || *s == 'I' || *s == 'c' || *s == 'C') {
+                if (*s == 'i' || *s == 'I' || *s == 's' || *s == 'S' || *s == 'c' || *s == 'C') {
                     int ret = snprintf(t, 32, "%"PRId64, bam_aux2i(s));
                     if (ret > 0) val = t;
                     else return 1;

--- a/test/test.pl
+++ b/test/test.pl
@@ -1198,7 +1198,7 @@ sub filter_sam
                 if ($tag_values) {
                     my $tag_value = '';
                     for my $i (11 .. $#sam) {
-                        last if (($tag_value) = $sam[$i] =~ /^${tag}:[ZiIcC]:(.*)/);
+                        last if (($tag_value) = $sam[$i] =~ /^${tag}:[ZiIsScC]:(.*)/);
                     }
                     next if (!exists($tag_values->{$tag_value||""}));
                 }


### PR DESCRIPTION
Integer value types of auxiliary tags supported by BAM are: **c** (`int8_t`), **C** (`uint8_t`), **s** (`int16_t`), **S** (`uint16_t`), **i** (`int32_t`), **I** (`uint32_t`).

Related to #1367 