### PR TITLE
Expand "samtools --version" with more details.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for samtools, utilities for the Sequence Alignment/Map format.
 #
-#    Copyright (C) 2008-2020 Genome Research Ltd.
+#    Copyright (C) 2008-2021 Genome Research Ltd.
 #    Portions copyright (C) 2010-2012 Broad Institute.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -123,6 +123,13 @@ version.h: $(if $(wildcard version.h),$(if $(findstring "$(PACKAGE_VERSION)",$(s
 #	echo '#define SAMTOOLS_VERSION "`git describe --always --dirty`"' > $@
 version.h:
 	echo '#define SAMTOOLS_VERSION "$(PACKAGE_VERSION)"' > $@
+	echo '#define SAMTOOLS_CC "$(CC)"' >> $@
+	echo '#define SAMTOOLS_CPPFLAGS "$(CPPFLAGS)"' >> $@
+	echo '#define SAMTOOLS_CFLAGS "$(CFLAGS)"' >> $@
+	echo '#define SAMTOOLS_LDFLAGS "$(LDFLAGS)"' >> $@
+	echo '#define SAMTOOLS_HTSDIR "$(HTSDIR)"' >> $@
+	echo '#define SAMTOOLS_LIBS "$(LIBS)"' >> $@
+	echo '#define SAMTOOLS_CURSES_LIB "$(CURSES_LIB)"' >> $@
 
 print-version:
 	@echo $(PACKAGE_VERSION)
@@ -191,7 +198,7 @@ bam_tview_curses.o: bam_tview_curses.c config.h $(bam_tview_h)
 bam_tview_html.o: bam_tview_html.c config.h $(bam_tview_h)
 bam_flags.o: bam_flags.c config.h $(htslib_sam_h)
 bamshuf.o: bamshuf.c config.h $(htslib_sam_h) $(htslib_hts_h) $(htslib_ksort_h) $(samtools_h) $(htslib_thread_pool_h) $(sam_opts_h) $(htslib_khash_h)
-bamtk.o: bamtk.c config.h $(htslib_hts_h) $(samtools_h) version.h
+bamtk.o: bamtk.c config.h $(htslib_hts_h) $(htslib_hfile_h) $(samtools_h) version.h
 bedcov.o: bedcov.c config.h $(htslib_kstring_h) $(htslib_sam_h) $(htslib_thread_pool_h) $(samtools_h) $(sam_opts_h) $(htslib_kseq_h)
 bedidx.o: bedidx.c config.h $(bedidx_h) $(htslib_ksort_h) $(htslib_kseq_h) $(htslib_khash_h)
 cut_target.o: cut_target.c config.h $(htslib_hts_h) $(htslib_sam_h) $(htslib_faidx_h) $(samtools_h) $(sam_opts_h)

--- a/bamtk.c
+++ b/bamtk.c
@@ -1,6 +1,6 @@
 /*  bamtk.c -- main samtools command front-end.
 
-    Copyright (C) 2008-2020 Genome Research Ltd.
+    Copyright (C) 2008-2021 Genome Research Ltd.
 
     Author: Heng Li <lh3@sanger.ac.uk>
 
@@ -30,6 +30,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <string.h>
 
 #include "htslib/hts.h"
+#include "htslib/hfile.h"
 #include "samtools.h"
 #include "version.h"
 
@@ -70,6 +71,69 @@ int main_ampliconstats(int argc, char *argv[]);
 const char *samtools_version()
 {
     return SAMTOOLS_VERSION;
+}
+
+// These come out of the config.h file built by autoconf or Makefile
+const char *samtools_feature_string(void) {
+    const char *fmt =
+
+#ifdef PACKAGE_URL
+    "build=configure "
+#else
+    "build=Makefile "
+#endif
+
+#ifdef HAVE_CURSES
+    "curses=yes "
+#else
+    "curses=no "
+#endif
+    ;
+
+    return fmt;
+}
+
+static void long_version(void) {
+    printf("samtools %s\n"
+           "Using htslib %s\n"
+           "Copyright (C) 2021 Genome Research Ltd.\n",
+           samtools_version(), hts_version());
+
+    printf("\nSamtools compilation details:\n");
+    printf("    Features:       %s\n", samtools_feature_string());
+    printf("    CC:             %s\n", SAMTOOLS_CC);
+    printf("    CPPFLAGS:       %s\n", SAMTOOLS_CPPFLAGS);
+    printf("    CFLAGS:         %s\n", SAMTOOLS_CFLAGS);
+    printf("    LDFLAGS:        %s\n", SAMTOOLS_LDFLAGS);
+    printf("    HTSDIR:         %s\n", SAMTOOLS_HTSDIR);
+    printf("    LIBS:           %s\n", SAMTOOLS_LIBS);
+    printf("    CURSES_LIB:     %s\n", SAMTOOLS_CURSES_LIB);
+
+    printf("\nHTSlib compilation details:\n");
+    printf("    Features:       %s\n", hts_feature_string());
+    printf("    CC:             %s\n", hts_test_feature(HTS_FEATURE_CC));
+    printf("    CPPFLAGS:       %s\n", hts_test_feature(HTS_FEATURE_CPPFLAGS));
+    printf("    CFLAGS:         %s\n", hts_test_feature(HTS_FEATURE_CFLAGS));
+    printf("    LDFLAGS:        %s\n", hts_test_feature(HTS_FEATURE_LDFLAGS));
+
+    // Plugins and schemes
+    printf("\nHTSlib plugins present:\n");
+    const char *plugins[100];
+    int np = 100, i, j;
+
+    if (hfile_list_plugins(plugins, &np) < 0)
+        return;
+
+    for (i = 0; i < np; i++) {
+        const char *sc_list[100];
+        int nschemes = 100;
+        if (hfile_list_schemes(plugins[i], sc_list, &nschemes) < 0)
+            return;
+
+        printf("    %s:\t", plugins[i]);
+        for (j = 0; j < nschemes; j++)
+            printf(" %s%c", sc_list[j], ",\n"[j+1==nschemes]);
+    }
 }
 
 static void usage(FILE *fp)
@@ -125,6 +189,10 @@ static void usage(FILE *fp)
 "     tview          text alignment viewer\n"
 "     view           SAM<->BAM<->CRAM conversion\n"
 "     depad          convert padded BAM to unpadded BAM\n"
+"\n"
+"  -- Misc\n"
+"     help [cmd]     display this help message or help for [cmd]\n"
+"     version        detailed version information\n"
 "\n");
 }
 
@@ -210,12 +278,9 @@ int main(int argc, char *argv[])
     }
     else if (strcmp(argv[1], "tview") == 0)   ret = bam_tview_main(argc-1, argv+1);
     else if (strcmp(argv[1], "ampliconstats") == 0)     ret = main_ampliconstats(argc-1, argv+1);
-    else if (strcmp(argv[1], "--version") == 0) {
-        printf(
-"samtools %s\n"
-"Using htslib %s\n"
-"Copyright (C) 2021 Genome Research Ltd.\n",
-               samtools_version(), hts_version());
+    else if (strcmp(argv[1], "version") == 0 || \
+             strcmp(argv[1], "--version") == 0) {
+        long_version();
     }
     else if (strcmp(argv[1], "--version-only") == 0) {
         printf("%s+htslib-%s\n", samtools_version(), hts_version());

--- a/test/test.pl
+++ b/test/test.pl
@@ -959,6 +959,7 @@ sub test_usage
 
     # now test subcommand usage as well
     foreach my $subcommand (@subcommands) {
+        next if ($subcommand =~ /^(help|version)$/);
         # Under msys the isatty function fails to recognise the terminal.
         # Skip these tests for now.
         next if ($^O =~ /^msys/ && $subcommand =~ /^(dict|sort|stats|view|fasta|fastq)$/);


### PR DESCRIPTION
This uses the new htslib introspection functions to report build information for htslib and which plugins it supports.
Also added similar logic to Samtools build, adding more variables to version.h (similar to Htslib's new config_vars.h).

Finally, the main samtools usage admits the existence of --version, --version-only and --help options, as the usage statement implies no [options] can be given without specifying a command.