### PR TITLE
Fix sam_view.o dependencies (and other very minor updates)

### DIFF
--- a/.ci_helpers/clone
+++ b/.ci_helpers/clone
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Usage: .travis/clone REPOSITORY [DIR] [BRANCH]
+# Usage: .ci_helpers/clone REPOSITORY [DIR] [BRANCH]
 #
 # Creates a shallow clone, checking out the specified branch.  If BRANCH is
 # omitted or if there is no branch with that name, checks out origin/HEAD

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ phase.o: phase.c config.h $(htslib_hts_h) $(htslib_sam_h) $(htslib_kstring_h) $(
 sam.o: sam.c config.h $(htslib_faidx_h) $(sam_h)
 sam_opts.o: sam_opts.c config.h $(sam_opts_h)
 sam_utils.o: sam_utils.c config.h $(samtools_h)
-sam_view.o: sam_view.c config.h $(htslib_sam_h) $(htslib_faidx_h) $(htslib_khash_h) $(htslib_thread_pool_h) $(samtools_h) $(sam_opts_h) $(bedidx_h)
+sam_view.o: sam_view.c config.h $(htslib_sam_h) $(htslib_faidx_h) $(htslib_khash_h) $(htslib_thread_pool_h) $(htslib_hts_expr_h) $(samtools_h) $(sam_opts_h) $(bedidx_h)
 sample.o: sample.c config.h $(sample_h) $(htslib_khash_h)
 stats_isize.o: stats_isize.c config.h $(stats_isize_h) $(htslib_khash_h)
 stats.o: stats.c config.h $(htslib_faidx_h) $(htslib_sam_h) $(htslib_hts_h) $(htslib_hts_defs_h) $(htslib_khash_str2int_h) $(samtools_h) $(htslib_khash_h) $(htslib_kstring_h) $(stats_isize_h) $(sam_opts_h) $(bedidx_h)

--- a/configure.ac
+++ b/configure.ac
@@ -137,7 +137,7 @@ case $host_alias in
     # This also sets __USE_MINGW_ANSI_STDIO which in turn makes PRId64,
     # %lld and %z printf formats work.  It also enforces the snprintf to
     # be C99 compliant so it returns the correct values (in kstring.c).
-    CPPFLAGS="$CPPCFLAGS -D_XOPEN_SOURCE=600"
+    CPPFLAGS="$CPPFLAGS -D_XOPEN_SOURCE=600"
     ;;
 esac
 


### PR DESCRIPTION
Add recently-added `$(htslib_hts_expr_h)` inclusion.

There is no `$CPPCFLAGS`. It's unlikely that MinGW users will set `$CPPFLAGS` themselves, but if they do, we should add to their value instead of overwriting it.

Update _.ci_helpers/clone_ comment.
