### PR TITLE
Ensure all sam_read1() and sam_itr_next() failures are reported

### DIFF
--- a/bam2depth.c
+++ b/bam2depth.c
@@ -353,6 +353,12 @@ int main_depth(int argc, char *argv[])
     free(n_plp); free(plp);
     bam_mplp_destroy(mplp);
 
+    if (ret < 0) {
+        print_error("depth", "couldn't read from input file");
+        status = EXIT_FAILURE;
+        goto depth_end;
+    }
+
     if (all) {
         // Handle terminating region
         if (last_tid < 0 && reg) {
@@ -378,11 +384,6 @@ int main_depth(int argc, char *argv[])
             if (all < 2 || reg)
                 break;
         }
-    }
-
-    if (ret < 0) {
-        print_error("depth", "couldn't read from input file");
-        status = EXIT_FAILURE;
     }
 
 depth_end:

--- a/bam2depth.c
+++ b/bam2depth.c
@@ -350,7 +350,6 @@ int main_depth(int argc, char *argv[])
         }
         fputc('\n', file_out);
     }
-    if (ret < 0) status = EXIT_FAILURE;
     free(n_plp); free(plp);
     bam_mplp_destroy(mplp);
 
@@ -379,6 +378,11 @@ int main_depth(int argc, char *argv[])
             if (all < 2 || reg)
                 break;
         }
+    }
+
+    if (ret < 0) {
+        print_error("depth", "couldn't read from input file");
+        status = EXIT_FAILURE;
     }
 
 depth_end:

--- a/bam_mate.c
+++ b/bam_mate.c
@@ -372,7 +372,7 @@ static int bam_mating_core(samFile *in, samFile *out, int remove_reads, int prop
         curr = 1 - curr;
         pre_end = cur_end;
     }
-    if (result < -1) goto fail;
+    if (result < -1) goto read_fail;
     if (has_prev && !remove_reads) { // If we still have a BAM in the buffer it must be unpaired
         bam1_t *pre = b[1-curr];
         if (pre->core.tid < 0 || pre->core.pos < 0 || pre->core.flag&BAM_FUNMAP) { // If unmapped
@@ -390,6 +390,10 @@ static int bam_mating_core(samFile *in, samFile *out, int remove_reads, int prop
     bam_destroy1(b[1]);
     ks_free(&str);
     return 0;
+
+ read_fail:
+    print_error("fixmate", "Couldn't read from input file");
+    goto fail;
 
  write_fail:
     print_error_errno("fixmate", "Couldn't write to output file");

--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -918,6 +918,12 @@ static int mpileup(mplp_conf_t *conf, int n, char **fn, char **fn_idx)
         }
     }
 
+    if (ret < 0) {
+        print_error("mpileup", "error reading from input file");
+        ret = EXIT_FAILURE;
+        goto fail;
+    }
+
     if (conf->all && !(conf->flag & MPLP_BCF)) {
         // Handle terminating region
         if (last_tid < 0 && conf->reg && conf->all > 1) {
@@ -937,11 +943,6 @@ static int mpileup(mplp_conf_t *conf, int n, char **fn, char **fn_idx)
             if (conf->all < 2 || conf->reg)
                 break;
         }
-    }
-
-    if (ret < 0) {
-        print_error("mpileup", "error reading from input file");
-        ret = EXIT_FAILURE;
     }
 
 fail:

--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -90,8 +90,10 @@ static inline int pileup_seq(FILE *fp, const bam_pileup1_t *p, hts_pos_t pos,
     int del_len = -p->indel;
     if (p->indel > 0) {
         int len = bam_plp_insertion(p, ks, &del_len);
-        if (len < 0)
+        if (len < 0) {
+            print_error("mpileup", "bam_plp_insertion() failed");
             return -1;
+        }
         putc('+', fp); printw(len, fp);
         if (bam_is_rev(p->b)) {
             char pad = rev_del ? '#' : '*';
@@ -935,6 +937,11 @@ static int mpileup(mplp_conf_t *conf, int n, char **fn, char **fn_idx)
             if (conf->all < 2 || conf->reg)
                 break;
         }
+    }
+
+    if (ret < 0) {
+        print_error("mpileup", "error reading from input file");
+        ret = EXIT_FAILURE;
     }
 
 fail:

--- a/bam_tview.c
+++ b/bam_tview.c
@@ -351,6 +351,7 @@ static int tv_push_aln(const bam1_t *b, tview_t *tv)
 
 int base_draw_aln(tview_t *tv, int tid, hts_pos_t pos)
 {
+    int ret;
     assert(tv!=NULL);
     // reset
     tv->my_clear(tv);
@@ -379,9 +380,14 @@ int base_draw_aln(tview_t *tv, int tid, hts_pos_t pos)
     bam_lplbuf_reset(tv->lplbuf);
     hts_itr_t *iter = sam_itr_queryi(tv->idx, tv->curr_tid, tv->left_pos, tv->left_pos + tv->mcol);
     bam1_t *b = bam_init1();
-    while (sam_itr_next(tv->fp, iter, b) >= 0) tv_push_aln(b, tv);
+    while ((ret = sam_itr_next(tv->fp, iter, b)) >= 0) tv_push_aln(b, tv);
     bam_destroy1(b);
     hts_itr_destroy(iter);
+    if (ret < -1) {
+        print_error("tview", "could not read from input file");
+        exit(1);
+    }
+
     bam_lplbuf_push(0, tv->lplbuf);
 
     while (tv->ccol < tv->mcol) {

--- a/bedcov.c
+++ b/bedcov.c
@@ -231,7 +231,7 @@ int main_bedcov(int argc, char *argv[])
             print_error("bedcov", "error reading from input file");
             status = 2;
             bam_mplp_destroy(mplp);
-            continue;
+            break;
         }
 
         for (i = 0; i < n; ++i) {

--- a/coverage.c
+++ b/coverage.c
@@ -633,7 +633,10 @@ int main_coverage(int argc, char *argv[]) {
         }
     }
 
-    if (ret < 0) status = EXIT_FAILURE;
+    if (ret < 0) {
+        print_error("coverage", "error reading from input file");
+        status = EXIT_FAILURE;
+    }
 
 coverage_end:
     if (n_plp) free(n_plp);

--- a/cut_target.c
+++ b/cut_target.c
@@ -170,7 +170,7 @@ static int read_aln(void *data, bam1_t *b)
 
 int main_cut_target(int argc, char *argv[])
 {
-    int c, tid, pos, n, lasttid = -1, usage = 0;
+    int c, tid, pos, n, lasttid = -1, usage = 0, status = EXIT_SUCCESS;
     hts_pos_t l, max_l;
     const bam_pileup1_t *p;
     bam_plp_t plp;
@@ -237,6 +237,12 @@ int main_cut_target(int argc, char *argv[])
         cns[pos] = gencns(&g, n, p);
     }
     process_cns(g.h, lasttid, l, cns);
+
+    if (n < 0) {
+        print_error("targetcut", "error reading from \"%s\"", argv[optind]);
+        status = EXIT_FAILURE;
+    }
+
     free(cns);
     sam_hdr_destroy(g.h);
     bam_plp_destroy(plp);
@@ -247,5 +253,5 @@ int main_cut_target(int argc, char *argv[])
     errmod_destroy(g.em);
     free(g.bases);
     sam_global_args_free(&ga);
-    return 0;
+    return status;
 }

--- a/phase.c
+++ b/phase.c
@@ -583,6 +583,7 @@ static int start_output(phaseg_t *g, int c, const char *middle, const htsFormat 
 int main_phase(int argc, char *argv[])
 {
     int c, tid, pos, vpos = 0, n, lasttid = -1, max_vpos = 0, usage = 0;
+    int status = EXIT_SUCCESS;
     const bam_pileup1_t *plp;
     bam_plp_t iter;
     nseq_t *seqs;
@@ -785,6 +786,12 @@ int main_phase(int argc, char *argv[])
             return 1;
         }
     }
+
+    if (n < 0) {
+        print_error("phase", "error reading from '%s'", argv[optind]);
+        status = EXIT_FAILURE;
+    }
+
     sam_hdr_destroy(g.fp_hdr);
     bam_plp_destroy(iter);
     sam_close(g.fp);
@@ -809,5 +816,5 @@ int main_phase(int argc, char *argv[])
     }
     free(g.arg_list);
     sam_global_args_free(&ga);
-    return 0;
+    return status;
 }


### PR DESCRIPTION
Ensure that error return codes from all invocations of these functions are captured and result in a diagnostic message and failing exit status. An audit of the 32 instances of `sam_read1()` and the 10 instances of `sam_itr_next()` in code contributing to the `samtools` executable showed that the following were missing and are fixed by this PR:

For coverage, depth, fixmate, mpileup: the command already exited with failure but this adds an error message. (For mpileup, this changes the exit status in this case from 255 (i.e., -1 🤮) to 1.)

For flagstat: convert a "Continue anyway" message into an error and failure.

For bedcov, phase, targetcut: add the missing `bam_[m]plp_auto()` check and error message and failure.

For tview: add the missing `sam_itr_next()` check, and exit immediately (as tview already does for other "can't happen" errors.)

Fixes #101. Fixes a number of instances of #51.