### PR TITLE
Added a reference to the SAM specification.

### DIFF
--- a/doc/samtools-flagstat.1
+++ b/doc/samtools-flagstat.1
@@ -52,8 +52,10 @@ Does a full pass through the input file to calculate and print statistics
 to stdout.
 
 Provides counts for each of 13 categories based primarily on bit flags in
-the FLAG field. Information on the meaning of the flags is given in the SAM specification
-document (https://samtools.github.io/hts-specs/SAMv1.pdf).
+the FLAG field.
+Information on the meaning of the flags is given in the SAM specification
+document <https://samtools.github.io/hts-specs/SAMv1.pdf>.
+
 Each category in the output is broken down into QC pass and QC fail.
 In the default output format, these are presented as "#PASS + #FAIL" followed
 by a description of the category.

--- a/doc/samtools-flagstat.1
+++ b/doc/samtools-flagstat.1
@@ -3,7 +3,7 @@
 .SH NAME
 samtools flagstat \- counts the number of alignments for each FLAG type
 .\"
-.\" Copyright (C) 2008-2011, 2013-2019 Genome Research Ltd.
+.\" Copyright (C) 2008-2011, 2013-2019, 2021 Genome Research Ltd.
 .\" Portions copyright (C) 2010, 2011 Broad Institute.
 .\"
 .\" Author: Heng Li <lh3@sanger.ac.uk>
@@ -52,7 +52,8 @@ Does a full pass through the input file to calculate and print statistics
 to stdout.
 
 Provides counts for each of 13 categories based primarily on bit flags in
-the FLAG field.
+the FLAG field. Information on the meaning of the flags is given in the SAM specification
+document (https://samtools.github.io/hts-specs/SAMv1.pdf).
 Each category in the output is broken down into QC pass and QC fail.
 In the default output format, these are presented as "#PASS + #FAIL" followed
 by a description of the category.

--- a/doc/samtools-stats.1
+++ b/doc/samtools-stats.1
@@ -3,7 +3,7 @@
 .SH NAME
 samtools stats \- produces comprehensive statistics from alignment file
 .\"
-.\" Copyright (C) 2008-2011, 2013-2018, 2020 Genome Research Ltd.
+.\" Copyright (C) 2008-2011, 2013-2018, 2020-2021 Genome Research Ltd.
 .\" Portions copyright (C) 2010, 2011 Broad Institute.
 .\"
 .\" Author: Heng Li <lh3@sanger.ac.uk>
@@ -110,6 +110,9 @@ fragments.
 Reads where PAIRED is set and either both READ1 and READ2 are set or
 neither is set are not counted in either category.
 .PP
+Information on the meaning of the flags is given in the SAM specification
+document (https://samtools.github.io/hts-specs/SAMv1.pdf).
+
 The CHK row contains distinct CRC32 checksums of read names, sequences
 and quality values.  The checksums are computed per alignment record
 and summed, meaning the checksum does not change if the input file has

--- a/doc/samtools-stats.1
+++ b/doc/samtools-stats.1
@@ -111,7 +111,7 @@ Reads where PAIRED is set and either both READ1 and READ2 are set or
 neither is set are not counted in either category.
 .PP
 Information on the meaning of the flags is given in the SAM specification
-document (https://samtools.github.io/hts-specs/SAMv1.pdf).
+document <https://samtools.github.io/hts-specs/SAMv1.pdf>.
 
 The CHK row contains distinct CRC32 checksums of read names, sequences
 and quality values.  The checksums are computed per alignment record


### PR DESCRIPTION
Add a reference in a couple of man pages to the SAM specification.  This is to provide further information on flags that the man pages do not go into.  This should close #1376. 