### PR TITLE
correcting typo in samtools fasta docs

### DIFF
--- a/doc/samtools-fasta.1
+++ b/doc/samtools-fasta.1
@@ -267,7 +267,7 @@ samtools fastq -0 /dev/null -s single.fq -N in_name.bam > paired.fq
 
 .SH BUGS
 .IP o 2
-The way of specifying output files is far to complicated and easy to get wrong.
+The way of specifying output files is far too complicated and easy to get wrong.
 
 .SH AUTHOR
 .PP


### PR DESCRIPTION
Hi,

I corrected a minor typo in the documentation (to complicated --> too complicated).

Cheers,
Wouter