### PR TITLE
Add missing samtools merge return code check

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -71,6 +71,9 @@ Release a.b
  * The documentation for `samtools depth -s` has been improved.
    Thanks to `@wulj2`. (#1355)
 
+ * Fixed a `samtools merge` segmentation fault when it failed to merge
+   header `@PG` records. Thanks to John Marshall.  (#1394; reported by
+   Kemin Zhou in #1393)
 
 Release 1.11 (22nd September 2020)
 ----------------------------------

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -724,6 +724,7 @@ static int trans_tbl_init(merged_header_t* merged_hdr, sam_hdr_t* translate,
     // Get translated header lines and fill in map for @PG records
     pg_list = trans_rg_pg(false, translate, merge_pg, merged_hdr->pg_ids,
                           tbl->pg_trans, NULL);
+    if (!pg_list) goto fail;
 
     // Fix-up PG: tags in the new @RG records and add to output
     if (finish_rg_pg(true, rg_list, tbl->pg_trans, &merged_hdr->out_rg))


### PR DESCRIPTION
This prevents a segfault in cases like #1393, though I don't know how the headers in that issue's input files have managed to get `NULL` from `trans_rg_pg()`.