### PR TITLE
[view] Add support for single character value tags to options -d and -D

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -30,8 +30,9 @@ Release a.b
  * samtools view -d option now works without a tag associated value, which
    allows it to output all the reads with the given tag. (#1339; fixed #1317)
 
- * samtools view -d and -D options now accept integer values associated with
-   tags, not just strings. Thanks to `@dariome` for the suggestion. (#1357)
+ * samtools view -d and -D options now accept integer and single character
+   values associated with tags, not just strings. Thanks to `@dariome` and
+   Keiran Raine for the suggestions. (#1357, #1392)
 
  * samtools view now works with the filtering expressions introduced by HTSlib.
    The filtering expression is passed to the program using the specific option

--- a/sam_view.c
+++ b/sam_view.c
@@ -111,6 +111,10 @@ static int process_aln(const sam_hdr_t *h, bam1_t *b, samview_settings_t* settin
                     int ret = snprintf(t, 32, "%"PRId64, bam_aux2i(s));
                     if (ret > 0) val = t;
                     else return 1;
+                } else if (*s == 'A') {
+                    t[0] = *(s+1);
+                    t[1] = 0;
+                    val = t;
                 } else {
                     val = (char *)(s+1);
                 }

--- a/test/test.pl
+++ b/test/test.pl
@@ -1199,7 +1199,7 @@ sub filter_sam
                 if ($tag_values) {
                     my $tag_value = '';
                     for my $i (11 .. $#sam) {
-                        last if (($tag_value) = $sam[$i] =~ /^${tag}:[ZiIsScC]:(.*)/);
+                        last if (($tag_value) = $sam[$i] =~ /^${tag}:[ZiIsScCA]:(.*)/);
                     }
                     next if (!exists($tag_values->{$tag_value||""}));
                 }
@@ -2110,6 +2110,8 @@ sub test_view
          ['-d', 'BC:ACGT', '-d', 'RG:grp2' ], 1],
         ['tv_NM_13', { tag => 'NM', tag_values => { 13 => 1 }},
          ['-d', 'NM:13'], 0],
+        ['tv_ab_z', { tag => 'ab', tag_values => { z => 2 }},
+         ['-d', 'ab:z'], 0],
         # Libraries
         ['lib2', { libraries => { 'Library 2' => 1 }}, ['-l', 'Library 2'], 0],
         ['lib3', { libraries => { 'Library 3' => 1 }}, ['-l', 'Library 3'], 0],


### PR DESCRIPTION
`samtools view` can now filter alignments by tags with single character values (type `A`), using options -d or -D.

Fixes #1392 