### PR TITLE
Add a check for multi-ref BED files in ampliconclip & ampliconstats.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -76,6 +76,12 @@ Release a.b
    header `@PG` records. Thanks to John Marshall.  (#1394; reported by
    Kemin Zhou in #1393)
 
+ * Ampliconclip and ampliconstats now guard against the BED file
+   containing more than one reference (chromosome) and fail when
+   found.  Adding proper support for multiple references will appear
+   later.  (#1398)
+
+
 Release 1.11 (22nd September 2020)
 ----------------------------------
 

--- a/amplicon_stats.c
+++ b/amplicon_stats.c
@@ -1,6 +1,6 @@
 /*  stats.c -- This is the former bamcheck integrated into samtools/htslib.
 
-    Copyright (C) 2020 Genome Research Ltd.
+    Copyright (C) 2020-2021 Genome Research Ltd.
 
     Author: James Bonfield <jkb@sanger.ac.uk>
 

--- a/bam_ampliconclip.c
+++ b/bam_ampliconclip.c
@@ -92,6 +92,8 @@ int load_bed_file_pairs(char *infile, int get_strand, int sort_by_pos,
         goto error;
     }
 
+    *pairs->ref = 0;
+    char ref[256];
     while (line.l = 0, kgetline(&line, (kgets_func *)hgets, fp) >= 0) {
         line_count++;
 
@@ -102,11 +104,22 @@ int load_bed_file_pairs(char *infile, int get_strand, int sort_by_pos,
         if (get_strand) {
             char strand;
 
-            if (sscanf(line.s, "%*s %"SCNd64" %"SCNd64" %*s %*s %c", &left, &right, &strand) != 3) {
+            if (sscanf(line.s, "%255s %"SCNd64" %"SCNd64" %*s %*s %c",
+                       ref, &left, &right, &strand) != 4) {
                 fprintf(stderr, "[ampliconclip] error: bad bed file format in line %d of %s.\n",
                                     line_count, infile);
                 ret = 1;
                 goto error;
+            }
+            if (*pairs->ref) {
+                if (strncmp(ref, pairs->ref, 256)) {
+                    fprintf(stderr, "[ampliconclip] error: "
+                            "bed file contains more than one reference.\n");
+                    ret = 1;
+                    goto error;
+                }
+            } else {
+                memcpy(pairs->ref, ref, 256);
             }
 
             if (strand == '+') {
@@ -163,6 +176,7 @@ error:
     if (hclose(fp) != 0) {
         fprintf(stderr, "[ampliconclip] warning: failed to close %s", infile);
     }
+    if (ret) free(pairs->bp);
 
     return ret;
 }
@@ -579,7 +593,7 @@ static int bam_clip(samFile *in, samFile *out, samFile *reject, char *bedfile,
     int64_t longest = 0;
     kstring_t str = KS_INITIALIZE;
     kstring_t oat = KS_INITIALIZE;
-    bed_pair_list_t sites = {NULL, 0, 0};
+    bed_pair_list_t sites = {NULL, 0, 0, {0}};
     FILE *stats_fp = stderr;
 
     if (load_bed_file_pairs(bedfile, param->use_strand, 1, &sites, &longest)) {

--- a/bam_ampliconclip.h
+++ b/bam_ampliconclip.h
@@ -1,6 +1,6 @@
 /*  bam_ampliconclip.h -- shared functions between amplicon clip/stats
 
-    Copyright (C) 2020 Genome Research Ltd.
+    Copyright (C) 2020-2021 Genome Research Ltd.
 
     Author: James Bonfield <jkb@sanger.ac.uk>
 

--- a/bam_ampliconclip.h
+++ b/bam_ampliconclip.h
@@ -35,6 +35,7 @@ typedef struct {
     bed_pair_t *bp;
     int length;
     int size;
+    char ref[256];
 } bed_pair_list_t;
 
 int load_bed_file_pairs(char *infile, int get_strand, int sort_by_pos,


### PR DESCRIPTION
(See #1396.  **This isn't a fix**, but it detects the problem and responds more gracefully than a crash.)

Long term we wish to make these cope, but for now we take a more
defensive approach by recognising the case where we would give
incorrect results.

This extends bed_pair_list_t with a fixed length buffer, which is a
temporary fudge.  It'll need something like the pooled string
allocator and a ref name pointer within bed_pair_t to properly deal
with multi-ref BEDs.

Ampliconstats now also has code to filter out any reads that are for
another chromosome, so if we have a multi-ref BAM and a single-ref BED
then it'll still work correctly.