### PR TITLE
samtools flags: allow multiple flag arguments to be converted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ bam_stat.o: bam_stat.c config.h $(htslib_sam_h) $(samtools_h) $(sam_opts_h)
 bam_tview.o: bam_tview.c config.h $(bam_tview_h) $(htslib_faidx_h) $(htslib_sam_h) $(htslib_bgzf_h) $(samtools_h) $(sam_opts_h)
 bam_tview_curses.o: bam_tview_curses.c config.h $(bam_tview_h)
 bam_tview_html.o: bam_tview_html.c config.h $(bam_tview_h)
-bam_flags.o: bam_flags.c config.h $(htslib_sam_h)
+bam_flags.o: bam_flags.c config.h $(htslib_sam_h) $(samtools_h)
 bamshuf.o: bamshuf.c config.h $(htslib_sam_h) $(htslib_hts_h) $(htslib_ksort_h) $(samtools_h) $(htslib_thread_pool_h) $(sam_opts_h) $(htslib_khash_h)
 bamtk.o: bamtk.c config.h $(htslib_hts_h) $(htslib_hfile_h) $(samtools_h) version.h
 bedcov.o: bedcov.c config.h $(htslib_kstring_h) $(htslib_sam_h) $(htslib_thread_pool_h) $(samtools_h) $(sam_opts_h) $(htslib_kseq_h)

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,10 @@
 Release a.b
 -----------
 
+ * samtools flags now accepts any number of command line arguments,
+   allowing multiple SAM flag combinations to be converted at once. (PR #1401)
+
+
 Release 1.12 (17th March 2021)
 ------------------------------
 

--- a/bam_flags.c
+++ b/bam_flags.c
@@ -32,38 +32,54 @@ DEALINGS IN THE SOFTWARE.  */
 #include <unistd.h>
 #include <stdarg.h>
 #include <htslib/sam.h>
+#include "samtools.h"
 
-static void usage(void)
+static void usage(FILE *fp)
 {
-    fprintf(stderr, "\n");
-    fprintf(stderr, "About: Convert between textual and numeric flag representation\n");
-    fprintf(stderr, "Usage: samtools flags INT|STR[,...]\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "Flags:\n");
-    fprintf(stderr, "\t0x%x\tPAIRED        .. paired-end (or multiple-segment) sequencing technology\n", BAM_FPAIRED);
-    fprintf(stderr, "\t0x%x\tPROPER_PAIR   .. each segment properly aligned according to the aligner\n", BAM_FPROPER_PAIR);
-    fprintf(stderr, "\t0x%x\tUNMAP         .. segment unmapped\n", BAM_FUNMAP);
-    fprintf(stderr, "\t0x%x\tMUNMAP        .. next segment in the template unmapped\n", BAM_FMUNMAP);
-    fprintf(stderr, "\t0x%x\tREVERSE       .. SEQ is reverse complemented\n", BAM_FREVERSE);
-    fprintf(stderr, "\t0x%x\tMREVERSE      .. SEQ of the next segment in the template is reversed\n", BAM_FMREVERSE);
-    fprintf(stderr, "\t0x%x\tREAD1         .. the first segment in the template\n", BAM_FREAD1);
-    fprintf(stderr, "\t0x%x\tREAD2         .. the last segment in the template\n", BAM_FREAD2);
-    fprintf(stderr, "\t0x%x\tSECONDARY     .. secondary alignment\n", BAM_FSECONDARY);
-    fprintf(stderr, "\t0x%x\tQCFAIL        .. not passing quality controls\n", BAM_FQCFAIL);
-    fprintf(stderr, "\t0x%x\tDUP           .. PCR or optical duplicate\n", BAM_FDUP);
-    fprintf(stderr, "\t0x%x\tSUPPLEMENTARY .. supplementary alignment\n", BAM_FSUPPLEMENTARY);
-    fprintf(stderr, "\n");
+    static const struct { int bit; const char *desc; } *fl, flags[] = {
+        { BAM_FPAIRED, "paired-end / multiple-segment sequencing technology" },
+        { BAM_FPROPER_PAIR, "each segment properly aligned according to aligner" },
+        { BAM_FUNMAP, "segment unmapped" },
+        { BAM_FMUNMAP, "next segment in the template unmapped" },
+        { BAM_FREVERSE, "SEQ is reverse complemented" },
+        { BAM_FMREVERSE, "SEQ of next segment in template is rev.complemented" },
+        { BAM_FREAD1, "the first segment in the template" },
+        { BAM_FREAD2, "the last segment in the template" },
+        { BAM_FSECONDARY, "secondary alignment" },
+        { BAM_FQCFAIL, "not passing quality controls or other filters" },
+        { BAM_FDUP, "PCR or optical duplicate" },
+        { BAM_FSUPPLEMENTARY, "supplementary alignment" },
+        { 0, NULL }
+    };
+
+    fprintf(fp,
+"About: Convert between textual and numeric flag representation\n"
+"Usage: samtools flags FLAGS...\n"
+"\n"
+"Each FLAGS argument is either an INT (in decimal/hexadecimal/octal) representing\n"
+"a combination of the following numeric flag values, or a comma-separated string\n"
+"NAME,...,NAME representing a combination of the following flag names:\n"
+"\n");
+    for (fl = flags; fl->desc; fl++) {
+        char *name = bam_flag2str(fl->bit);
+        fprintf(fp, "%#6x %5d  %-15s%s\n", fl->bit, fl->bit, name, fl->desc);
+        free(name);
+    }
 }
 
 
 int main_flags(int argc, char *argv[])
 {
-    if ( argc!=2 ) usage();
-    else
+    if ( argc < 2 ) { usage(stdout); return 0; }
+
+    int i;
+    for (i = 1; i < argc; i++)
     {
-        int mask = bam_str2flag(argv[1]);
-        if ( mask<0 ) { fprintf(stderr,"Error: Could not parse \"%s\"\n", argv[1]); usage(); return 1; }
-        printf("0x%x\t%d\t%s\n", mask, mask, bam_flag2str(mask));
+        int mask = bam_str2flag(argv[i]);
+        if ( mask<0 ) { print_error("flags", "Could not parse \"%s\"", argv[i]); usage(stderr); return 1; }
+        char *str = bam_flag2str(mask);
+        printf("0x%x\t%d\t%s\n", mask, mask, str);
+        free(str);
     }
     return 0;
 }

--- a/doc/samtools-flags.1
+++ b/doc/samtools-flags.1
@@ -44,11 +44,16 @@ samtools flags \- convert between textual and numeric flag representation.
 .SH SYNOPSIS
 .PP
 samtools flags
-.IR INT | STR [,...]
+.IR FLAGS ...
 
 .SH DESCRIPTION
 .PP
 Convert between textual and numeric flag representation.
+
+Each \fIFLAGS\fP argument may be either an integer (in decimal, hexadecimal,
+or octal) representing a combination of the listed numeric flag values,
+or a comma-separated string \fINAME\fB,\fR...\fB,\fINAME\fR representing
+a combination of the flag names listed below.
 
 .B FLAGS:
 .TS


### PR DESCRIPTION
The `samtools flags` command has long annoyed me every time I use it by refusing to convert more than one flag value at once. There's no reason for this, so this PR relaxes the restriction that only one argument be supplied.

Clarify the documentation: each argument is either one INT or one string that is itself a comma-separated list of STRs; note in the man page and usage that multiple arguments are allowed, and reformat the usage to fit in 80 columns.

Fix memory leak: the string returned by `bam_flag2str()` should be `free()`ed by the caller.

Fixes #749 by implementing the desired functionality rather than tweaking the ambiguous documentation. :smile: