### PR TITLE
Typo patrol

### DIFF
--- a/doc/samtools-ampliconstats.1
+++ b/doc/samtools-ampliconstats.1
@@ -127,7 +127,7 @@ line consists of the amplicon number and the \fIstart\fR-\fIend\fR
 coordinates of the left and right primers.  Where multiple primers are
 available these are comma separated, for example \fB10-30,15-40\fR in
 the left primer column indicates two primers have been multiplex
-together covering genome coords 10-30 inclusive and 14-40 inclusively.
+together covering genome coordinates 10-30 inclusive and 14-40 inclusively.
 
 
 .SH CSS SECTION

--- a/doc/samtools-dict.1
+++ b/doc/samtools-dict.1
@@ -59,7 +59,7 @@ Specify the assembly for the AS tag.
 Add an AN tag with the same value as the SN tag, except that a \(lqchr\(rq
 prefix is removed if SN has one or added if it does not.
 For mitochondria (i.e., when SN is \(lqM\(rq or \(lqMT\(rq, with or without a
-\(lqchr\(rq prefix), also adds the remaining combiniations of \(lqchr/M/MT\(rq
+\(lqchr\(rq prefix), also adds the remaining combinations of \(lqchr/M/MT\(rq
 to the AN tag.
 .TP
 .B -H,\ --no-header

--- a/doc/samtools-fasta.1
+++ b/doc/samtools-fasta.1
@@ -94,7 +94,7 @@ Sequences will be written to standard output unless one of the
 .BR -1 ", " -2 ", " -o ", or " -0
 options is used, in which case sequences for that category will be written to
 the specified file.
-The same filename may be specified with multiple options, in which ase the
+The same filename may be specified with multiple options, in which case the
 sequences will be multiplexed in order of occurrence.
 
 If a singleton file is specified using the

--- a/doc/samtools-mpileup.1
+++ b/doc/samtools-mpileup.1
@@ -234,7 +234,7 @@ for all reads aligned to a reference in the file.  See
 below.
 .TP
 .BI -G,\ --exclude-RG \ FILE
-Exclude reads from readgroups listed in FILE (one @RG-ID per line)
+Exclude reads from read groups listed in FILE (one @RG-ID per line)
 .TP
 .BI -l,\ --positions \ FILE
 BED or position list file containing a list of regions or sites where
@@ -337,7 +337,7 @@ values and a list of NM tag values. Field values are always displayed before
 tag values.
 .TP
 .BI "--output-sep" \ CHAR
-Specify a different separtor character for tag value lists, when those values
+Specify a different separator character for tag value lists, when those values
 might contain one or more commas (\fB,\fR), which is the default list separator.
 This option only affects columns for two-letter tags like NM; standard
 fields like FLAG or QNAME will always be separated by commas.
@@ -381,7 +381,7 @@ option.  To disable it, use the
 .B -B
 option.
 
-It is possible to store pre-calculated BAQ values in a SAM BQ:Z tag.
+It is possible to store precalculated BAQ values in a SAM BQ:Z tag.
 Samtools mpileup will use the precalculated values if it finds them.
 The
 .B -E

--- a/doc/samtools-phase.1
+++ b/doc/samtools-phase.1
@@ -1,7 +1,7 @@
 '\" t
 .TH samtools-phase 1 "17 March 2021" "samtools-1.12" "Bioinformatics tools"
 .SH NAME
-samtools phase \- call and phase heterozygous SNPS
+samtools phase \- call and phase heterozygous SNPs
 .\"
 .\" Copyright (C) 2008-2011, 2013-2018 Genome Research Ltd.
 .\" Portions copyright (C) 2010, 2011 Broad Institute.

--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -386,14 +386,14 @@ Import SAM to BAM when
 .B @SQ
 lines are present in the header:
 .EX 2
-samtools view -bS aln.sam > aln.bam
+samtools view -bo aln.bam aln.sam
 .EE
 If
 .B @SQ
 lines are absent:
 .EX 2
 samtools faidx ref.fa
-samtools view -bt ref.fa.fai aln.sam > aln.bam
+samtools view -bt ref.fa.fai -o aln.bam aln.sam
 .EE
 where
 .I ref.fa.fai
@@ -404,7 +404,7 @@ command.
 .IP o 2
 Convert a BAM file to a CRAM file using a local reference sequence.
 .EX 2
-samtools view -C -T ref.fa aln.bam > aln.cram
+samtools view -C -T ref.fa -o aln.cram aln.bam
 .EE
 
 .IP o 2

--- a/doc/samtools.1
+++ b/doc/samtools.1
@@ -955,7 +955,7 @@ Grouping	(, )	E.g. "(1+2)*3"
 Values:	literals, vars	Numbers, strings and variables
 Unary ops:	+, -, !, ~ 	E.g. -10 +10, !10 (not), ~5 (bit not)
 Math ops:	*, /, %	Multiply, division and (integer) modulo
-Math ops:	+, -	Addition / subtractin
+Math ops:	+, -	Addition / subtraction
 Bit-wise:	&	Integer AND
 Bit-wise	^	Integer XOR
 Bit-wise	|	Integer OR
@@ -1038,7 +1038,7 @@ for alignments with many mismatches and \fB[RG]=~"grp[ABC]-"\fR will
 match the read-group string.
 
 If no comparison is used with an auxiliary tag it is taken simply to
-be a test for the existance of that tag.  So "[NM]" will return any
+be a test for the existence of that tag.  So "[NM]" will return any
 record containing an NM tag, even if that tag is zero (\fBNM:i:0\fR).
 
 If you need to check specifically for a non-zero value then use \fB[NM]
@@ -1103,7 +1103,7 @@ local cache is used.
 
 To avoid many files being stored in the same directory, REF_CACHE may
 be defined as a pattern using \fB%\fR\fInum\fR\fBs\fR to consume \fInum\fR
-chracters of the MD5sum and \fB%s\fR to consume all remaining characters.
+characters of the MD5sum and \fB%s\fR to consume all remaining characters.
 If REF_CACHE lacks \fB%s\fR then it will get an implicit \fB/%s\fR appended.
 
 To aid population of the REF_CACHE directory a script


### PR DESCRIPTION
I noticed the “_in which ase_” one just now, and here is the result of running a spelling checker over the man pages. A pity this didn't all happen a couple of weeks ago… :smile:

Also modernise the `samtools view` examples: Demonstrate using `-o` rather than shell redirection, which is more error-prone particularly in conjunction with `nohup`.

In particular, purge the very legacy `samtools view -bS in.sam > out.bam` usage.