### PR TITLE
Support an HTSlib source tree that has a separate build directory

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -123,6 +123,9 @@ specify further optional external requirements:
     installation directory (i.e., it has 'include' and 'lib' subdirectories
     containing HTSlib headers and libraries).
 
+    (If the desired HTSlib source tree has been configured to build in a
+    separate build directory, DIR should refer to the build directory.)
+
     By default, configure looks for an HTSlib source tree within or alongside
     the samtools source directory; if there are several likely candidates,
     you will have to choose one via this option.


### PR DESCRIPTION
Companion PR to samtools/htslib#1277 which enables samtools's _configure_ to recognise an HTSlib separate build directory, which is treated the same as a source directory — as for external projects' purposes this is identical apart from `-I` needing to point to the associated source directory (only).

Pick `HTSSRCDIR` out of the HTSlib build directory's _htslib_vars.mk_ (generated from _builddirs_vars.mk.in_). `@HTSLIB_CPPFLAGS@` and `@HTSLIB_LDFLAGS@` need to be fully expanded: `$(HTSDIR)` would not be available for external projects that don't use `@HTSDIR@` or _htslib.mk_.

In due course _m4/ax_with_htslib.m4_ should be copied to bcftools too.