### PR TITLE
new tool : "samtools samples"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ AOBJS=      bam_index.o bam_plcmd.o sam_view.o bam_fastq.o \
             faidx.o dict.o stats.o stats_isize.o bam_flags.o bam_split.o \
             bam_tview.o bam_tview_curses.o bam_tview_html.o bam_lpileup.o \
             bam_quickcheck.o bam_addrprg.o bam_markdup.o tmp_file.o \
-	    bam_ampliconclip.o amplicon_stats.o bam_import.o
+            bam_ampliconclip.o amplicon_stats.o bam_import.o bam_samples.o
 LZ4OBJS  =  $(LZ4DIR)/lz4.o
 
 prefix      = /usr/local
@@ -218,6 +218,7 @@ amplicon_stats.o: amplicon_stats.c config.h $(htslib_sam_h) $(htslib_khash_h) $(
 bam_markdup.o: bam_markdup.c config.h $(htslib_thread_pool_h) $(htslib_sam_h) $(sam_opts_h) $(samtools_h) $(htslib_khash_h) $(htslib_klist_h) $(htslib_kstring_h) $(tmp_file_h)
 tmp_file.o: tmp_file.c config.h $(tmp_file_h) $(htslib_sam_h)
 bam_ampliconclip.o: bam_ampliconclip.c config.h $(htslib_thread_pool_h) $(sam_opts_h) $(htslib_hts_h) $(htslib_hfile_h) $(htslib_kstring_h) $(htslib_sam_h) $(samtools_h) bam_ampliconclip.h
+bam_samples.o: bam_samples.c config.h  $(sam_opts_h) $(htslib_hts_h) $(htslib_hfile_h) $(samtools_h)
 
 # Maintainer source code checks
 # - copyright boilerplate presence

--- a/bam_samples.c
+++ b/bam_samples.c
@@ -217,13 +217,13 @@ static int print_samples(Params* params, const char* fname, const char* baifname
         hts_idx_t *bam_idx;
         /* path to bam index was specified */
         if (baifname != NULL) {
-            bam_idx = sam_index_load2(in, fname, baifname);
+            bam_idx = sam_index_load3(in, fname, baifname, HTS_IDX_SILENT_FAIL);
         }
         /* get default index */
         else {
-            bam_idx = sam_index_load(in, fname);
+            bam_idx = sam_index_load3(in, fname, NULL, HTS_IDX_SILENT_FAIL);
         }
-        has_index = bam_idx!=NULL;
+        has_index = bam_idx != NULL;
         if (bam_idx != NULL) hts_idx_destroy(bam_idx);
         /* and we continue... we have tested the index file but we always test for the samples and the references */
     }

--- a/bam_samples.c
+++ b/bam_samples.c
@@ -355,7 +355,6 @@ int main_samples(int argc, char** argv) {
         params.out = stdout;
     }
 
-    
     if (print_header) {
         fprintf(params.out, "#%s\tPATH", params.tag);
         if (params.test_index) fprintf(params.out, "\tINDEX");

--- a/bam_samples.c
+++ b/bam_samples.c
@@ -147,7 +147,7 @@ static int print_sample(
     fputc('\t', params->out);
     fputs(fname, params->out);
     if (params->test_index) {
-        fprintf(params->out, "\t%d", has_index);
+        fprintf(params->out, "\t%c", has_index ? 'Y' : 'N');
     }
     if (params->faidx != NULL) {
         FaidxPath* ref = NULL;

--- a/bam_samples.c
+++ b/bam_samples.c
@@ -1,0 +1,370 @@
+/*  bam_samples -- print samples in a set of BAM files
+
+    Copyright (C) 2021 Pierre Lindenbaum
+    Institut du Thorax. u1087 Nantes. France.
+    @yokofakun
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.  */
+
+#include <config.h>
+#include <htslib/hts.h>
+#include <htslib/kseq.h>
+#include <htslib/sam.h>
+#include <htslib/faidx.h>
+#include <htslib/hfile.h>
+#include "htslib/khash.h"
+#include <samtools.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+KHASH_MAP_INIT_STR(sm, int)
+
+/** and chained struct containing the faidx and the fasta filename
+    will be compared with the @SQ lines in the SAM header
+*/
+typedef struct FaidxPath {
+    /** path to reference */
+    char* filename;
+    /** fasta index  */
+    faidx_t * faidx;
+    struct FaidxPath* next;
+    } FaidxPath;
+
+/** program parameters */    
+typedef struct Params {
+    /** output stream */
+    FILE* out;
+    /** tag in @RG line. default is "SM" */
+    char tag[3];
+    /** first faidx/path in chained list */
+    FaidxPath* faidx;
+    /** enable more than one sample in a bam */
+    int enable_multiple;
+    /** enable no sample in a bam */
+    int enable_missing;
+    /** show wether the bam is indexed */
+    int test_index;
+    } Params;
+
+/** print usage */
+static void usage_samples(FILE *write_to) {
+    fprintf(write_to,
+"Usage: samtools samples [options] <input> [...]\n"
+"       find dir1 dir2 -type f \\( -name \"*.bam\" -o -name \"*.cram\" \\) | samtools samples [options]\n"
+"\n"
+"Options:\n"
+"  -h              print help and exit\n"
+"  -H              print a header\n"
+"  -i              test if the file is indexed.\n"
+"  -T <tag>        set the TAG in the @RG line [SM].\n"
+"  -o <file>       output file [stdout].\n"
+"  -d              enable multiple samples in one bam\n"
+"  -m              enable missing sample in one bam. \".\" will be used as the default name.\n"
+"  -f <file.fa>    add an indexed fasta in the collection of reference. Can be used multiple times.\n"
+"  -F <file.txt>   read a file containing the path to the indexed fasta references. One path per line.\n"
+"\n"
+" Using -f or -F will add a column containing the path to the reference or \".\" if the reference was not found.\n"
+"\n"
+    );
+}
+
+
+/** loads fasta fai file into FaidxPath, add it to params->faidx */
+static int load_dictionary(struct Params* params, const char* filename) {
+    FaidxPath* prev = params->faidx;
+    FaidxPath* ptr = (struct FaidxPath*)malloc(sizeof(struct FaidxPath));
+    if (ptr == NULL) {
+        print_error("samples","out of memory");
+        return EXIT_FAILURE;
+        }
+    ptr->filename = strdup(filename);
+    if (ptr->filename == NULL) {
+        print_error("samples","out of memory");
+        return EXIT_FAILURE;
+        }
+    ptr->faidx = fai_load(filename);
+    if (ptr->faidx == NULL) {
+        print_error_errno("samples","cannot load index from \"%s\".",filename);
+        return EXIT_FAILURE;
+        }
+    /* insert in chained list */
+    params->faidx = ptr;
+    ptr->next = prev;
+    return EXIT_SUCCESS;
+    }
+
+/** load a faidx file and append it to params */
+static int load_dictionaries(Params* params, const char* filename) {
+    int ret;
+    htsFile* in;
+    int status = EXIT_SUCCESS;
+    kstring_t  *ks = NULL;
+    in = hts_open(filename,"r");
+    
+    ks = &in->line;
+    if(in==NULL) {
+        print_error_errno("samples","cannot open \"%s\".",filename);
+        return EXIT_FAILURE;
+        }
+    while ((ret = hts_getline(in, KS_SEP_LINE, ks)) >= 0) {
+        if (load_dictionary(params, ks->s)!= EXIT_SUCCESS) {
+            status = EXIT_FAILURE;
+            break;
+            }
+        }
+    hts_close(in);
+    return status;
+    }
+
+/** print the sample information, search for a reference */
+static int print_sample(Params* params,sam_hdr_t *header, int has_index,const char* sample,const char* fname) {
+    fputs(sample, params->out);
+    fputc('\t', params->out);
+    fputs(fname, params->out);
+    if (params->test_index) {
+        fprintf(params->out, "\t%d",has_index); 
+        }
+    if (params->faidx!=NULL) {
+        FaidxPath* ref = NULL;
+        FaidxPath* curr = params->faidx;
+        while(curr!=NULL) {
+            /** check names and length are the same in the same order */
+            if ( faidx_nseq(curr->faidx) == header->n_targets ) {
+                int i;
+                for (i=0;i<  faidx_nseq(curr->faidx); i++) {
+                    /** check name if the same */
+                    if (strcmp(faidx_iseq(curr->faidx,i), header->target_name[i])!=0) break;
+                    /** check length if the same */
+                    if (faidx_seq_len(curr->faidx,faidx_iseq(curr->faidx,i)) != header->target_len[i]) break;
+                    }
+                if (i== faidx_nseq(curr->faidx)) {
+                    ref = curr;
+                    break;
+                    }
+                }
+            curr = curr->next;
+            }
+        fputc('\t', params->out);
+        if (ref == NULL) {
+            fputc('.', params->out);
+            }
+        else
+            {
+            fputs(curr->filename, params->out);
+            }
+        }
+    fputc('\n', params->out);
+    return 0;
+    }
+
+
+/** open a sam file. Search for all samples in the @RG lines */
+static int print_samples(Params* params,const char* fname) {
+    samFile *in = 0;
+    sam_hdr_t *header = NULL;
+    int n_rg;
+    int status = EXIT_SUCCESS;
+    khash_t(sm) *sample_set = kh_init(sm);
+    khint_t k;
+    int count_samples = 0;
+    int has_index = 0;
+
+
+    /* open sam file */
+    if ((in = sam_open_format(fname, "r", NULL)) == 0) {
+            print_error_errno("samples", "failed to open \"%s\" for reading.", fname);
+            status = EXIT_FAILURE;
+            goto end_print;
+            }
+     /* load header */
+     if ((header = sam_hdr_read(in)) == 0) {
+            print_error("samples", "failed to read the header from \"%s\".", fname);
+            status = EXIT_FAILURE;
+        goto end_print;
+        }
+
+     /* try to load index if required */
+     if (params->test_index) {
+        hts_idx_t *bam_idx =  sam_index_load(in, fname);
+        has_index = bam_idx!=NULL;
+        if (bam_idx != NULL) hts_idx_destroy(bam_idx);
+        }
+
+
+    /* get the RG lines */
+    n_rg = sam_hdr_count_lines(header, "RG");
+    if (n_rg >0 ) {
+        int i,r,ret;
+        char* sample;
+        kstring_t sm_val = KS_INITIALIZE;
+        /* loop over the RG lines and search for the params->tag */
+        for (i = 0; i < n_rg; i++) {
+            r = sam_hdr_find_tag_pos(header, "RG", i, params->tag, &sm_val);
+            if (r < 0) continue;
+            k = kh_get(sm, sample_set, sm_val.s);
+            if (k != kh_end(sample_set)) continue;
+            sample = strdup(sm_val.s);
+            if (sample == NULL) {
+                print_error("samples", "out of memory.");
+                goto end_print;
+                }
+            kh_put(sm, sample_set, sample, &ret);
+            ++count_samples;
+            }
+        ks_free(&sm_val);
+        }
+    if ( count_samples == 0) {
+        if (params->enable_missing) {
+            print_sample(params, header, has_index, ".", fname);
+        } else {
+            print_error("samples", "no @RG:%s in \"%s\". Use option -m to enable missing.", params->tag, fname);
+            status = EXIT_FAILURE;
+            goto end_print;
+        }
+    } else if ( count_samples > 1 && !params->enable_multiple ) {
+        print_error("samples", "multiple @RG:\"%s\" in \"%s\". Use option -d to enable multiple.", params->tag, fname);
+        status = EXIT_FAILURE;
+        goto end_print;
+    } else {
+        for (k = kh_begin(sample_set); k != kh_end(sample_set); ++k) {
+             if (kh_exist(sample_set, k)) {
+                char* sample = (char*)kh_key(sample_set, k);
+                print_sample(params, header, has_index, sample, fname);
+                }
+            }
+        }
+
+    end_print:
+        for (k = kh_begin(sample_set); k != kh_end(sample_set); ++k) {
+             if (kh_exist(sample_set, k)) {
+                char* sample = (char*)kh_key(sample_set, k);
+                if (kh_exist(sample_set, k)) free(sample);
+                }
+            }
+        kh_destroy(sm,sample_set);
+        if (header!=NULL) sam_hdr_destroy(header);
+        if (in!=NULL) sam_close(in);
+        
+    return status;
+    }
+
+
+int main_samples(int argc, char** argv) {
+    int status = EXIT_SUCCESS;
+    int print_header = 0;
+    Params params;
+    char* out_filename = NULL;
+    strcpy(params.tag,"SM");
+    params.faidx = NULL;
+    params.enable_multiple = 0;
+    params.enable_missing = 0;
+    params.test_index =0;
+
+    int opt;
+    while ((opt = getopt(argc, argv,  "hHdmio:f:F:t:T:")) != -1) {
+        switch (opt) {
+        case 'H':
+            print_header = 1;
+            break;
+        case 'o':
+            out_filename = optarg;
+            break;
+        case 'd':
+            params.enable_multiple = 1;
+            break;
+        case 'i':
+            params.test_index = 1;
+        break;
+        case 'm':
+            params.enable_missing = 1;
+            break;
+        case 'f':
+            if (load_dictionary(&params,optarg) != EXIT_SUCCESS) {
+                return EXIT_FAILURE;
+                }
+            break;
+         case 'F':
+            if (load_dictionaries(&params,optarg) != EXIT_SUCCESS) {
+                return EXIT_FAILURE;
+                }
+            break;
+         case 'T':
+            if (strlen(optarg)!=2) {
+                print_error("samples","length ot a TAG must be 2 but got \"%s\".", optarg);
+                return EXIT_FAILURE;
+                }
+            strcpy(params.tag,optarg);
+            break;
+         case 'h':
+            usage_samples(stdout);
+            return EXIT_SUCCESS;
+        default:
+            usage_samples(stderr);
+            return EXIT_FAILURE;
+        }
+    }
+
+   if(out_filename!=NULL) {
+        params.out = fopen(out_filename,"w");
+        if (params.out == NULL) {
+            print_error_errno("samples","cannot open \"%s\" for writing.", out_filename);
+            return EXIT_FAILURE;
+            }
+        } else {
+        params.out = stdout;
+    }
+    
+    if ( print_header) {
+        fprintf(params.out, "#%s\tPATH", params.tag);
+        if (params.test_index) fprintf(params.out, "\tINDEX");
+        if (params.faidx != NULL) fprintf(params.out, "\tREFERENCE");
+        fprintf(params.out,"\n");
+    }
+
+   /* input is stdin, each line contains the path to a bam file */
+   if (argc == optind) {
+        htsFile* fp = hts_open("-","r");
+            kstring_t  *ks = &fp->line;
+        int ret;
+        while ((ret = hts_getline(fp, KS_SEP_LINE, ks)) >= 0) {
+            if (print_samples(&params, ks->s) != EXIT_SUCCESS) {
+                status = EXIT_FAILURE;
+                break;
+                }
+            }
+        hts_close(fp);
+        }
+    else {
+        /* loop over each bam file */
+        int i;
+        for( i = optind ; i < argc; i++) {
+            if (print_samples(&params, argv[i]) != EXIT_SUCCESS) {
+                status = EXIT_FAILURE;
+                break;
+                }
+            }
+        }
+
+
+    fflush(params.out);
+    if (out_filename!=NULL) fclose(params.out);
+
+    return status;
+    }

--- a/bam_samples.c
+++ b/bam_samples.c
@@ -33,6 +33,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <getopt.h>
 
 KHASH_MAP_INIT_STR(sm, int)
 
@@ -151,7 +152,7 @@ static int print_sample(
     if (params->faidx != NULL) {
         FaidxPath* ref = NULL;
         FaidxPath* curr = params->faidx;
-        while(curr != NULL) {
+        while (curr != NULL) {
             /** check names and length are the same in the same order */
             if (faidx_nseq(curr->faidx) == header->n_targets) {
                 int i;
@@ -298,7 +299,7 @@ int main_samples(int argc, char** argv) {
     params.test_index =0;
 
     int opt;
-    while ((opt = getopt(argc, argv,  "?hiXo:f:F:T:")) != -1) {
+    while ((opt = getopt_long(argc, argv,  "?hiXo:f:F:T:", NULL, NULL)) != -1) {
         switch (opt) {
         case 'h':
             print_header = 1;
@@ -339,13 +340,13 @@ int main_samples(int argc, char** argv) {
     }
 
 
-     /* if no file was provided and input is the terminal, print the usage and exit */
-     if (argc == optind && isatty(STDIN_FILENO)) {
-        usage_samples(stderr);
-        return EXIT_FAILURE;
-        }
+    /* if no file was provided and input is the terminal, print the usage and exit */
+    if (argc == optind && isatty(STDIN_FILENO)) {
+       usage_samples(stderr);
+       return EXIT_FAILURE;
+    }
 
-    if(out_filename != NULL) {
+    if (out_filename != NULL) {
         params.out = fopen(out_filename, "w");
         if (params.out == NULL) {
             print_error_errno("samples", "Cannot open \"%s\" for writing", out_filename);

--- a/bamtk.c
+++ b/bamtk.c
@@ -68,6 +68,7 @@ int fqidx_main(int argc, char *argv[]);
 int amplicon_clip_main(int argc, char *argv[]);
 int main_ampliconstats(int argc, char *argv[]);
 int main_import(int argc, char *argv[]);
+int main_samples(int argc, char *argv[]);
 
 const char *samtools_version()
 {
@@ -191,6 +192,7 @@ static void usage(FILE *fp)
 "     tview          text alignment viewer\n"
 "     view           SAM<->BAM<->CRAM conversion\n"
 "     depad          convert padded BAM to unpadded BAM\n"
+"     samples        list the samples in a set of SAM/BAM/CRAM files\n"
 "\n"
 "  -- Misc\n"
 "     help [cmd]     display this help message or help for [cmd]\n"
@@ -275,6 +277,7 @@ int main(int argc, char *argv[])
     }
     else if (strcmp(argv[1], "tview") == 0)   ret = bam_tview_main(argc-1, argv+1);
     else if (strcmp(argv[1], "ampliconstats") == 0)     ret = main_ampliconstats(argc-1, argv+1);
+    else if (strcmp(argv[1], "samples") == 0)     ret = main_samples(argc-1, argv+1);
     else if (strcmp(argv[1], "version") == 0 || \
              strcmp(argv[1], "--version") == 0) {
         long_version();

--- a/doc/samtools-samples.1
+++ b/doc/samtools-samples.1
@@ -5,7 +5,7 @@ samtools samples \- prints the samples from an alignment file
 .\"
 .\" Copyright (C) 2021 Genome Research Ltd.
 .\"
-.\" Author: Pierre Lindenbaum <insert@email>
+.\" Author: Pierre Lindenbaum <pierre.lindenbaum@univ-nantes.fr>
 .\" Author: Valeriu Ohan <vo2@sanger.ac.uk>
 .\"
 .\" Permission is hereby granted, free of charge, to any person obtaining a
@@ -44,7 +44,7 @@ samtools samples \- prints the samples from an alignment file
 .PP
 .B samtools samples
 .RI [ options ]
-.I <input>
+.I (<input>|stdin)
 .PP
 .B samtools samples
 .RI [ options ]
@@ -53,14 +53,20 @@ samtools samples \- prints the samples from an alignment file
 
 .SH DESCRIPTION
 .PP
-Print the sample names from alignment files.
+Print the sample names found in the read-groups and the path to the reference genome from alignment files.
+The output of this tool can be used to create an input for any popular workflow manager.
+The input is a list of SAM/BAM/CRAM files, or the path to those files can be provided via stdin.
+The output is a tab-delimited file containing the sample name, the path to the alignment, the path to the reference genome and a flag indicating wether the file is indexed.
+If no reference is found for an alignment, a dot will be used in the reference column.
+If no sample is available in any read-group header, a dot will be used as the sample's name.
+If a bam file contains more than one sample, one line will be printed for each sample.
 
 .SH OPTIONS
 .TP 8
-.B -h
+.B -?
 print help and exit
 .TP
-.B -H
+.B -h
 print a header
 .TP
 .B -i
@@ -72,12 +78,6 @@ provide the sample tag name from the @RG line [SM].
 .BI "-o " FILE
 output file [stdout].
 .TP
-.B -d
-enable multiple samples in one bam
-.TP
-.B -m
-enable missing sample in one bam. A dot ('.') will be used as the default name.
-.TP
 .BI "-f " FILE
 load an indexed fasta file in the collection of references. Can be used multiple times.
 .TP
@@ -87,9 +87,107 @@ read a file containing the paths to indexed fasta files. One path per line.
 .B -X
 use a custom index file.
 
+.SH EXAMPLES
+.IP o 2
+print the samples from a set of BAM/SAM files, with a header. There is no sample defined in the header of 'toy.sam' to a dot is used.
+.EX 2
+$ samtools  samples -h S*.bam *.sam
+#SM	PATH
+S1	S1.bam
+S2	S2.bam
+S3	S3.bam
+S4	S4.bam
+S5	S5.bam
+\&.	toy.sam
+.EE
+.IP o 2
+print the samples from a set of BAM/SAM files, with a header, print wether the file is indexed.
+.EX 2
+$  samtools  samples -i -h S*.bam *.sam
+#SM	PATH	INDEX
+S1	S1.bam	1
+S2	S2.bam	1
+S3	S3.bam	1
+S4	S4.bam	1
+S5	S5.bam	1
+\&.	toy.sam	0
+.EE
+.IP o 2
+print wether the files are indexed using custom bai files.
+.EX 2
+$ samtools samples -i -h -X S1.bam S2.bam S1.bam.bai S2.bam.bai
+#SM	PATH	INDEX
+S1	S1.bam	1
+S2	S2.bam	1
+.EE
+.IP o 2
+read a tab delimited input <file>(tab)<bai> and print wether the files are indexed using custom bai files.
+.EX 2
+$ find . -type f \( -name "S*.bam" -o -name "S*.bai" \) | sort | paste - - | samtools samples -i -h -X
+#SM	PATH	INDEX
+S1	./S1.bam	1
+S2	./S2.bam	1
+S3	./S3.bam	1
+S4	./S4.bam	1
+S5	./S5.bam	1
+.EE
+.IP o 2
+print the samples from a set of BAM/CRAM files, with a header, use '@RG/LB' instead of '@RG/SM'.
+.EX 2
+$ samtools  samples -h -T LB S*.bam
+#LB	PATH
+S1	S1.bam
+S2	S2.bam
+S3	S3.bam
+S4	S4.bam
+S5Lib1	S5.bam
+S5Lib2	S5.bam
+.EE
+.IP o 2
+pipe a list of BAM/CRAM files , pipe it into  samtools samples.
+.EX 2
+$ find . -type f \( -name "S*.bam" -o -name "*.cram" \) | samtools  samples -h
+#SM	PATH
+S5	./S5.bam
+S2	./S2.bam
+S4	./S4.bam
+S3	./S3.bam
+S1	./toy.cram
+S1	./S1.bam
+.EE
+.IP o 2
+provide two reference sequences with option '-f', print the associated reference for each bam files.
+.EX 2
+$ samtools  samples  -h -f reference.fa -f toy.fa S*.bam *.sam *.cram
+#SM	PATH	REFERENCE
+S1	S1.bam	reference.fa
+S2	S2.bam	reference.fa
+S3	S3.bam	reference.fa
+S4	S4.bam	reference.fa
+S5	S5.bam	reference.fa
+\&.	toy.sam	toy.fa
+S1	toy.cram	toy.fa
+.EE
+.IP o 2
+provide a list of reference sequences with option '-F', print the associated reference for each bam files.
+.EX 2
+$ cat references.list
+reference.fa
+toy.fa
+$ samtools  samples  -h -F references.list S*.bam *.sam *.cram
+#SM	PATH	REFERENCE
+S1	S1.bam	reference.fa
+S2	S2.bam	reference.fa
+S3	S3.bam	reference.fa
+S4	S4.bam	reference.fa
+S5	S5.bam	reference.fa
+\&.	toy.sam	toy.fa
+S1	toy.cram	toy.fa
+.EE
+
 .SH AUTHOR
 .PP
-Written by Pierre Lindenbaum from Institut du Thorax.
+Written by Pierre Lindenbaum from Institut du Thorax U1087, Nantes, France.
 
 .PP
 Samtools website: <http://www.htslib.org/>

--- a/doc/samtools-samples.1
+++ b/doc/samtools-samples.1
@@ -53,13 +53,18 @@ samtools samples \- prints the samples from an alignment file
 
 .SH DESCRIPTION
 .PP
-Print the sample names found in the read-groups and the path to the reference genome from alignment files.
-The output of this tool can be used to create an input for any popular workflow manager.
-The input is a list of SAM/BAM/CRAM files, or the path to those files can be provided via stdin.
-The output is a tab-delimited file containing the sample name, the path to the alignment, the path to the reference genome and a flag indicating wether the file is indexed.
-If no reference is found for an alignment, a dot will be used in the reference column.
-If no sample is available in any read-group header, a dot will be used as the sample's name.
-If a bam file contains more than one sample, one line will be printed for each sample.
+Print the sample names found in the read-groups and the path to the reference
+genome from alignment files. The output of this tool can be used to create an
+input for any popular workflow manager. The input is a list of SAM/BAM/CRAM
+files, or the path to those files can be provided via stdin. The output is
+tab-delimited containing the sample name as the first column, the path to the
+alignment file as the second column, the path to the reference genome as a
+third optional column and a single character flag (Y/N) indicating whether the
+alignment file is indexed or not as the forth column.
+If no reference is found for an alignment, a dot (.) will be used in the
+reference path column. If no sample is available in any read-group header, a
+dot (.) will be used as the sample name. If a BAM file contains more than one
+sample, one line will be printed for each sample.
 
 .SH OPTIONS
 .TP 8
@@ -70,7 +75,8 @@ print help and exit
 print a header
 .TP
 .B -i
-test if the file is indexed.
+test if the file is indexed. Add an extra column to the output with a single
+character value (Y/N).
 .TP
 .BI "-T " TAG
 provide the sample tag name from the @RG line [SM].
@@ -79,7 +85,8 @@ provide the sample tag name from the @RG line [SM].
 output file [stdout].
 .TP
 .BI "-f " FILE
-load an indexed fasta file in the collection of references. Can be used multiple times.
+load an indexed fasta file in the collection of references. Can be used multiple
+times. Add an extra column with the path to the reference file.
 .TP
 .BI "-F " FILE
 read a file containing the paths to indexed fasta files. One path per line.
@@ -89,7 +96,8 @@ use a custom index file.
 
 .SH EXAMPLES
 .IP o 2
-print the samples from a set of BAM/SAM files, with a header. There is no sample defined in the header of 'toy.sam' to a dot is used.
+print the samples from a set of BAM/SAM files, with a header. There is no sample
+defined in the header of 'example.sam', so a dot is used for the sample name.
 .EX 2
 $ samtools  samples -h S*.bam *.sam
 #SM	PATH
@@ -98,41 +106,44 @@ S2	S2.bam
 S3	S3.bam
 S4	S4.bam
 S5	S5.bam
-\&.	toy.sam
+\&.	example.sam
 .EE
 .IP o 2
-print the samples from a set of BAM/SAM files, with a header, print wether the file is indexed.
+print the samples from a set of BAM/SAM files, with a header, print whether the
+file is indexed.
 .EX 2
 $  samtools  samples -i -h S*.bam *.sam
 #SM	PATH	INDEX
-S1	S1.bam	1
-S2	S2.bam	1
-S3	S3.bam	1
-S4	S4.bam	1
-S5	S5.bam	1
-\&.	toy.sam	0
+S1	S1.bam	Y
+S2	S2.bam	Y
+S3	S3.bam	Y
+S4	S4.bam	Y
+S5	S5.bam	Y
+\&.	example.sam	N
 .EE
 .IP o 2
 print wether the files are indexed using custom bai files.
 .EX 2
 $ samtools samples -i -h -X S1.bam S2.bam S1.bam.bai S2.bam.bai
 #SM	PATH	INDEX
-S1	S1.bam	1
-S2	S2.bam	1
+S1	S1.bam	Y
+S2	S2.bam	Y
 .EE
 .IP o 2
-read a tab delimited input <file>(tab)<bai> and print wether the files are indexed using custom bai files.
+read a tab delimited input <file>(tab)<bai> and print whether the files are
+indexed using custom bai files.
 .EX 2
 $ find . -type f \( -name "S*.bam" -o -name "S*.bai" \) | sort | paste - - | samtools samples -i -h -X
 #SM	PATH	INDEX
-S1	./S1.bam	1
-S2	./S2.bam	1
-S3	./S3.bam	1
-S4	./S4.bam	1
-S5	./S5.bam	1
+S1	./S1.bam	Y
+S2	./S2.bam	Y
+S3	./S3.bam	Y
+S4	./S4.bam	Y
+S5	./S5.bam	Y
 .EE
 .IP o 2
-print the samples from a set of BAM/CRAM files, with a header, use '@RG/LB' instead of '@RG/SM'.
+print the samples from a set of BAM/CRAM files, with a header, use '@RG/LB'
+instead of '@RG/SM'.
 .EX 2
 $ samtools  samples -h -T LB S*.bam
 #LB	PATH
@@ -152,28 +163,30 @@ S5	./S5.bam
 S2	./S2.bam
 S4	./S4.bam
 S3	./S3.bam
-S1	./toy.cram
+S1	./example.cram
 S1	./S1.bam
 .EE
 .IP o 2
-provide two reference sequences with option '-f', print the associated reference for each bam files.
+provide two reference sequences with option '-f', print the associated reference
+for each BAM files.
 .EX 2
-$ samtools  samples  -h -f reference.fa -f toy.fa S*.bam *.sam *.cram
+$ samtools  samples  -h -f reference.fa -f example.fa S*.bam *.sam *.cram
 #SM	PATH	REFERENCE
 S1	S1.bam	reference.fa
 S2	S2.bam	reference.fa
 S3	S3.bam	reference.fa
 S4	S4.bam	reference.fa
 S5	S5.bam	reference.fa
-\&.	toy.sam	toy.fa
-S1	toy.cram	toy.fa
+\&.	example.sam	example.fa
+S1	example.cram	example.fa
 .EE
 .IP o 2
-provide a list of reference sequences with option '-F', print the associated reference for each bam files.
+provide a list of reference sequences with option '-F', print the associated
+reference for each BAM files.
 .EX 2
 $ cat references.list
 reference.fa
-toy.fa
+example.fa
 $ samtools  samples  -h -F references.list S*.bam *.sam *.cram
 #SM	PATH	REFERENCE
 S1	S1.bam	reference.fa
@@ -181,8 +194,8 @@ S2	S2.bam	reference.fa
 S3	S3.bam	reference.fa
 S4	S4.bam	reference.fa
 S5	S5.bam	reference.fa
-\&.	toy.sam	toy.fa
-S1	toy.cram	toy.fa
+\&.	example.sam	example.fa
+S1	example.cram	example.fa
 .EE
 
 .SH AUTHOR

--- a/doc/samtools-samples.1
+++ b/doc/samtools-samples.1
@@ -1,0 +1,95 @@
+'\" t
+.TH samtools-samples 1 "15 July 2021" "samtools-1.13" "Bioinformatics tools"
+.SH NAME
+samtools samples \- prints the samples from an alignment file
+.\"
+.\" Copyright (C) 2021 Genome Research Ltd.
+.\"
+.\" Author: Pierre Lindenbaum <insert@email>
+.\" Author: Valeriu Ohan <vo2@sanger.ac.uk>
+.\"
+.\" Permission is hereby granted, free of charge, to any person obtaining a
+.\" copy of this software and associated documentation files (the "Software"),
+.\" to deal in the Software without restriction, including without limitation
+.\" the rights to use, copy, modify, merge, publish, distribute, sublicense,
+.\" and/or sell copies of the Software, and to permit persons to whom the
+.\" Software is furnished to do so, subject to the following conditions:
+.\"
+.\" The above copyright notice and this permission notice shall be included in
+.\" all copies or substantial portions of the Software.
+.\"
+.\" THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+.\" IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+.\" FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+.\" THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+.\" LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+.\" FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+.\" DEALINGS IN THE SOFTWARE.
+.
+.\" For code blocks and examples (cf groff's Ultrix-specific man macros)
+.de EX
+
+.  in +\\$1
+.  nf
+.  ft CR
+..
+.de EE
+.  ft
+.  fi
+.  in
+
+..
+.
+.SH SYNOPSIS
+.PP
+.B samtools samples
+.RI [ options ]
+.I <input>
+.PP
+.B samtools samples
+.RI [ options ]
+.B -X
+.IR f1.bam " " f2.bam " ... " f1.bam.bai " " f2.bam.bai " ... "
+
+.SH DESCRIPTION
+.PP
+Print the sample names from alignment files.
+
+.SH OPTIONS
+.TP 8
+.B -h
+print help and exit
+.TP
+.B -H
+print a header
+.TP
+.B -i
+test if the file is indexed.
+.TP
+.BI "-T " TAG
+provide the sample tag name from the @RG line [SM].
+.TP
+.BI "-o " FILE
+output file [stdout].
+.TP
+.B -d
+enable multiple samples in one bam
+.TP
+.B -m
+enable missing sample in one bam. A dot ('.') will be used as the default name.
+.TP
+.BI "-f " FILE
+load an indexed fasta file in the collection of references. Can be used multiple times.
+.TP
+.BI "-F " FILE
+read a file containing the paths to indexed fasta files. One path per line.
+.TP
+.B -X
+use a custom index file.
+
+.SH AUTHOR
+.PP
+Written by Pierre Lindenbaum from Institut du Thorax.
+
+.PP
+Samtools website: <http://www.htslib.org/>

--- a/test/test.pl
+++ b/test/test.pl
@@ -963,7 +963,7 @@ sub test_usage
         next if ($subcommand =~ /^(help|version)$/);
         # Under msys the isatty function fails to recognise the terminal.
         # Skip these tests for now.
-        next if ($^O =~ /^msys/ && $subcommand =~ /^(dict|sort|stats|view|fasta|fastq)$/);
+        next if ($^O =~ /^msys/ && $subcommand =~ /^(dict|sort|stats|view|fasta|fastq|samples)$/);
         test_usage_subcommand($opts,%args,subcmd=>$subcommand);
     }
 }


### PR DESCRIPTION
Hi all,

# short description 

a new subcommand "samples"  listing the samples in a set of bam files.

# Motivation

when using a workflow manager, it is often required to provide an input containing the samples in a bam file.

# Example:

## usage:

```
Usage: samtools samples [options] <input> [...]
       find dir1 dir2 -type f \( -name "*.bam" -o -name "*.cram" \) | samtools samples [options]

Options:
  -h              print help and exit
  -H              print a header
  -i              test if the file is indexed.
  -T <tag>        set the TAG in the @RG line [SM].
  -o <file>       output file [stdout].
  -d              enable multiple samples in one bam
  -m              enable missing sample in one bam. "." will be used as the default name.
  -f <file.fa>    add an indexed fasta in the collection of reference. Can be used multiple times.
  -F <file.txt>   read a file containing the path to the indexed fasta references. One path per line.

 Using -f or -F will add a column containing the path to the reference or "." if the reference was not found.
```

## list the samples

```
$ ./samtools samples -H DIR/S*.bam
#SM	PATH
S1	DIR/S1.bam
S2	DIR/S2.bam
S3	DIR/S3.bam
S4	DIR/S4.bam
S5	DIR/S5.bam
```


## list the libraries (tag=LB)

```
$ ./samtools samples -H DIR/S*.bam -T LB
#LB	PATH
L1	DIR/S1.bam
L2	DIR/S2.bam
L3	DIR/S3.bam
L4	DIR/S4.bam
samtools samples: multiple @RG:"LB" in "DIR/S5.bam". Use option -d to enable multiple.
```

```
$ ./samtools samples DIR/S*.bam -H -T LB -d
#LB	PATH
L1	DIR/S1.bam
L2	DIR/S2.bam
L3	DIR/S3.bam
L4	DIR/S4.bam
L5	DIR/S5.bam
L5b	DIR/S5.bam
```

```
$ ./samtools samples DIR/ENCFF331CGL.rnaseq.b38.bam
#SM	PATH
samtools samples: no @RG:SM in "DIR/ENCFF331CGL.rnaseq.b38.bam". Use option -m to enable missing.

$ ./samtools samples DIR/ENCFF331CGL.rnaseq.b38.bam -m
#SM	PATH
.	DIR/ENCFF331CGL.rnaseq.b38.bam
```
#  read the paths from stdin:

```
$ find  DIR -type f -name "*.bam" | ./samtools samples -m  -d 
S3	DIR/S3.bam
.	DIR/ENCFF331CGL.rnaseq.b38.bam
S2	DIR/S2.bam
S1	DIR/S1.bam
.	DIR/FAB23716.nanopore.bam
BruceWayne	DIR/retrocopy01.bwa.bam
HG02260	DIR/HG02260.transloc.chr9.14.bam
S5	DIR/S5.bam
S1	DIR/toy.bam
S4	DIR/S4.bam
```


## test if bams are indexed.

```
$ ./samtools samples -H DIR/*.samDIR/*.bam -m -i 2> /dev/null 
#SM	PATH	INDEX
.	DIR/toy.sam	0
.	DIR/ENCFF331CGL.rnaseq.b38.bam	1
.	DIR/FAB23716.nanopore.bam	1
HG02260	DIR/HG02260.transloc.chr9.14.bam	1
S1	DIR/S1.bam	1
S2	DIR/S2.bam	1
S3	DIR/S3.bam	1
S4	DIR/S4.bam	1
S5	DIR/S5.bam	1
BruceWayne	DIR/retrocopy01.bwa.bam	1
S1	DIR/toy.bam	1
```

##  find the reference

```
$ ./samtools samples DIR/*.bam -m  -d -f DIR/rotavirus_rf.fa 
.	DIR/ENCFF331CGL.rnaseq.b38.bam	.
.	DIR/FAB23716.nanopore.bam	.
HG02260	DIR/HG02260.transloc.chr9.14.bam	.
S1	DIR/S1.bam	DIR/rotavirus_rf.fa
S2	DIR/S2.bam	DIR/rotavirus_rf.fa
S3	DIR/S3.bam	DIR/rotavirus_rf.fa
S4	DIR/S4.bam	DIR/rotavirus_rf.fa
S5	DIR/S5.bam	DIR/rotavirus_rf.fa
BruceWayne	DIR/retrocopy01.bwa.bam	.
S1	DIR/toy.bam	.
```

```
$ cat refs.list  
DIR/rotavirus_rf.fa
DIR/toy.fa

$ ./samtools samples DIR/*.bam -m  -d -F  refs.list  -H
#SM	PATH	REFERENCE
.	DIR/ENCFF331CGL.rnaseq.b38.bam	.
.	DIR/FAB23716.nanopore.bam	.
HG02260	DIR/HG02260.transloc.chr9.14.bam	.
S1	DIR/S1.bam	DIR/rotavirus_rf.fa
S2	DIR/S2.bam	DIR/rotavirus_rf.fa
S3	DIR/S3.bam	DIR/rotavirus_rf.fa
S4	DIR/S4.bam	DIR/rotavirus_rf.fa
S5	DIR/S5.bam	DIR/rotavirus_rf.fa
BruceWayne	DIR/retrocopy01.bwa.bam	.
S1	DIR/toy.bam	DIR/toy.fa
```
