### PR TITLE
Add `samtools merge -o FILE` option as an optional alternative to the current oddball merge syntax

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,11 @@ Release a.b
  * samtools flags now accepts any number of command line arguments,
    allowing multiple SAM flag combinations to be converted at once. (PR #1401)
 
+ * samtools merge now accepts a `-o FILE` option specifying the output file,
+   similarly to most other subcommands. The existing way of specifying it
+   (as the first non-option argument, alongside the input file arguments)
+   remains supported. (PR #1434, thanks to David McGaughey and John Marshall)
+
  * samtools addreplacerg now allows for updating (replacing) an existing
    `@RG` line in the output header, if a new `@RG` line is provided in the
    command line, via the -r argument. The update still requires the user's

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -1396,7 +1396,8 @@ int bam_merge_core(int by_qname, const char *out, const char *headers, int n, ch
 static void merge_usage(FILE *to)
 {
     fprintf(to,
-"Usage: samtools merge [-nurlf] [-h inh.sam] [-b <bamlist.fofn>] <out.bam> <in1.bam> [<in2.bam> ... <inN.bam>]\n"
+"Usage: samtools merge [options] -o <out.bam> [options] <in1.bam> ... <inN.bam>\n"
+"   or: samtools merge [options] <out.bam> <in1.bam> ... <inN.bam>\n"
 "\n"
 "Options:\n"
 "  -n         Input files are sorted by read name\n"

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -1404,6 +1404,7 @@ static void merge_usage(FILE *to)
 "  -r         Attach RG tag (inferred from file names)\n"
 "  -u         Uncompressed BAM output\n"
 "  -f         Overwrite the output BAM if exist\n"
+"  -o FILE    Specify output file via option instead of <out.bam> argument\n"
 "  -1         Compress level 1\n"
 "  -l INT     Compression level, from 0 to 9 [-1]\n"
 "  -R STR     Merge file in the specified region STR [all]\n"
@@ -1422,7 +1423,7 @@ int bam_merge(int argc, char *argv[])
 {
     int c, is_by_qname = 0, flag = 0, ret = 0, level = -1, has_index_file = 0;
     char *fn_headers = NULL, *reg = NULL, mode[12];
-    char *sort_tag = NULL, *arg_list = NULL;
+    char *sort_tag = NULL, *fnout = NULL, *arg_list = NULL;
     long random_seed = (long)time(NULL);
     char** fn = NULL;
     char** fn_idx = NULL, *fn_bed = NULL;
@@ -1441,12 +1442,13 @@ int bam_merge(int argc, char *argv[])
         return 0;
     }
 
-    while ((c = getopt_long(argc, argv, "h:nru1R:f@:l:cps:b:O:t:XL:", lopts, NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "h:nru1R:o:f@:l:cps:b:O:t:XL:", lopts, NULL)) >= 0) {
         switch (c) {
         case 'r': flag |= MERGE_RG; break;
         case 'f': flag |= MERGE_FORCE; break;
         case 'h': fn_headers = optarg; break;
         case 'n': is_by_qname = 1; break;
+        case 'o': fnout = optarg; break;
         case 't': sort_tag = optarg; break;
         case '1': flag |= MERGE_LEVEL1; level = 1; break;
         case 'u': flag |= MERGE_UNCOMP; level = 0; break;
@@ -1485,7 +1487,12 @@ int bam_merge(int argc, char *argv[])
         case '?': merge_usage(stderr); return 1;
         }
     }
-    if ( argc - optind < 1 ) {
+
+    if (fnout == NULL && argc - optind >= 1) {
+        fnout = argv[optind];
+        optind++;
+    }
+    if (fnout == NULL) {
         print_error("merge", "You must at least specify the output file");
         merge_usage(stderr);
         return 1;
@@ -1497,11 +1504,11 @@ int bam_merge(int argc, char *argv[])
     }
 
     hts_srand48(random_seed);
-    if (!(flag & MERGE_FORCE) && strcmp(argv[optind], "-")) {
-        FILE *fp = fopen(argv[optind], "rb");
+    if (!(flag & MERGE_FORCE) && strcmp(fnout, "-") != 0) {
+        FILE *fp = fopen(fnout, "rb");
         if (fp != NULL) {
             fclose(fp);
-            fprintf(stderr, "[%s] File '%s' exists. Please apply '-f' to overwrite. Abort.\n", __func__, argv[optind]);
+            fprintf(stderr, "[%s] File '%s' exists. Please apply '-f' to overwrite. Abort.\n", __func__, fnout);
             ret = 1;
             goto end;
         }
@@ -1509,26 +1516,26 @@ int bam_merge(int argc, char *argv[])
 
     int nargcfiles = 0;
     if (has_index_file) { // Calculate # of input BAM files
-        if ((argc - optind - 1) % 2 != 0) {
+        if ((argc - optind) % 2 != 0) {
             fprintf(stderr, "Odd number of filenames detected! Each BAM file should have an index file\n");
             ret = 1;
             goto end;
         }
-        nargcfiles = (argc - optind - 1) / 2;
+        nargcfiles = (argc - optind) / 2;
     } else {
-        nargcfiles = argc - optind - 1;
+        nargcfiles = argc - optind;
     }
 
     if (nargcfiles > 0) {
         // Add argc files to end of array
         fn = realloc(fn, (fn_size+nargcfiles) * sizeof(char*));
         if (fn == NULL) { ret = 1; goto end; }
-        memcpy(fn+fn_size, argv + (optind+1), nargcfiles * sizeof(char*));
+        memcpy(fn+fn_size, argv + optind, nargcfiles * sizeof(char*));
 
         if(has_index_file) {
             fn_idx = realloc(fn_idx, nargcfiles * sizeof(char*));
             if (fn_idx == NULL) { ret = 1; goto end; }
-            memcpy(fn_idx+fn_size, argv + nargcfiles + (optind+1), nargcfiles * sizeof(char*));
+            memcpy(fn_idx+fn_size, argv + nargcfiles + optind, nargcfiles * sizeof(char*));
         }
     }
     if (fn_size+nargcfiles < 1) {
@@ -1544,9 +1551,9 @@ int bam_merge(int argc, char *argv[])
         goto end;
     }
     strcpy(mode, "wb");
-    sam_open_mode(mode+1, argv[optind], NULL);
+    sam_open_mode(mode+1, fnout, NULL);
     if (level >= 0) sprintf(strchr(mode, '\0'), "%d", level < 9? level : 9);
-    if (bam_merge_core2(is_by_qname, sort_tag, argv[optind], mode, fn_headers,
+    if (bam_merge_core2(is_by_qname, sort_tag, fnout, mode, fn_headers,
                         fn_size+nargcfiles, fn, fn_idx, fn_bed, flag, reg, ga.nthreads,
                         "merge", &ga.in, &ga.out, ga.write_index, arg_list, no_pg) < 0)
         ret = 1;

--- a/doc/samtools-merge.1
+++ b/doc/samtools-merge.1
@@ -1,7 +1,7 @@
 '\" t
 .TH samtools-merge 1 "17 March 2021" "samtools-1.12" "Bioinformatics tools"
 .SH NAME
-samtools merge \- merges multiple sorted input files into a single output.
+samtools merge \- merges multiple sorted files into a single file
 .\"
 .\" Copyright (C) 2008-2011, 2013-2019 Genome Research Ltd.
 .\" Portions copyright (C) 2010, 2011 Broad Institute.
@@ -43,22 +43,29 @@ samtools merge \- merges multiple sorted input files into a single output.
 .
 .SH SYNOPSIS
 .PP
-.B merge
-samtools merge
-.RB [ -nur1f ]
-.RB [ -h
-.IR inh.sam ]
-.RB [ -t
-.IR tag ]
-.RB [ -R
-.IR reg ]
-.RB [ -b
-.IR list "] " out.bam " " in1.bam " [" in2.bam " " in3.bam " ... " inN.bam ]
+.B samtools merge
+.RI [ options ]
+.B -o
+.I out.bam
+.RI [ options ]
+.IR in1.bam " ... " inN.bam
+.PP
+.B samtools merge
+.RI [ options ]
+.I out.bam
+.IR in1.bam " ... " inN.bam
 
 .SH DESCRIPTION
 .PP
 Merge multiple sorted alignment files, producing a single sorted output file
 that contains all the input records and maintains the existing sort order.
+
+The output file can be specified via \fB-o\fP as shown in the first synopsis.
+Otherwise the first non-option filename argument is taken to be \fIout.bam\fP
+rather than an input file, as in the second synopsis.
+There is no default; to write to standard output (or to a pipe), use either
+\(lq\fB-o -\fP\(rq or the equivalent using \(lq\fB-\fP\(rq as the first
+filename argument.
 
 If
 .BR -h
@@ -113,11 +120,6 @@ specifying the filename via an option rather than as the first filename
 argument.
 When \fB-o\fP is used, all non-option filename arguments specify input
 files to be merged.
-Otherwise, as shown in the synopsis, the first filename argument specifies
-the output file and the remainder give the input files.
-
-To write to standard output (or to a pipe), use either \fB-o -\fP or the
-equivalent using \fB-\fP as the first filename argument.
 .TP
 .B -t TAG
 The input alignments have been sorted by the value of TAG, then by either

--- a/doc/samtools-merge.1
+++ b/doc/samtools-merge.1
@@ -106,6 +106,19 @@ are ignored.)
 The input alignments are sorted by read names rather than by chromosomal
 coordinates
 .TP
+.BI -o \ FILE
+Write merged output to
+.IR FILE ,
+specifying the filename via an option rather than as the first filename
+argument.
+When \fB-o\fP is used, all non-option filename arguments specify input
+files to be merged.
+Otherwise, as shown in the synopsis, the first filename argument specifies
+the output file and the remainder give the input files.
+
+To write to standard output (or to a pipe), use either \fB-o -\fP or the
+equivalent using \fB-\fP as the first filename argument.
+.TP
 .B -t TAG
 The input alignments have been sorted by the value of TAG, then by either
 position or name (if \fB-n\fP is given).

--- a/doc/samtools-tview.1
+++ b/doc/samtools-tview.1
@@ -43,8 +43,7 @@ samtools tview \- display alignments in a curses-based interactive viewer.
 .
 .SH SYNOPSIS
 .PP
-.B tview
-samtools tview
+.B samtools tview
 .RB [ -p
 .IR chr:pos ]
 .RB [ -s

--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -43,8 +43,7 @@ samtools view \- views and converts SAM/BAM/CRAM files
 .
 .SH SYNOPSIS
 .PP
-.B view
-samtools view
+.B samtools view
 .RI [ options ]
 .IR in.sam | in.bam | in.cram
 .RI [ region ...]

--- a/test/test.pl
+++ b/test/test.pl
@@ -2921,6 +2921,8 @@ sub test_merge
     test_cmd($opts,out=>'merge/6.merge.expected.sam', ignore_pg_header => 1, cmd=>"$$opts{bin}/samtools merge${threads} -cp -s 1 -O sam - $$opts{path}/dat/test_input_1_a.sam $$opts{path}/dat/test_input_1_b.sam");
     # Merge 7 - ID and SN with regex in them
     test_cmd($opts,out=>'merge/7.merge.expected.sam', ignore_pg_header => 1, cmd=>"$$opts{bin}/samtools merge${threads} -s 1 -O sam - $$opts{path}/dat/test_input_1_a_regex.sam $$opts{path}/dat/test_input_1_b_regex.sam");
+    # Merge 8 - Standard 3 file SAM merge, output file specified via option
+    test_cmd($opts,out=>'merge/2.merge.expected.sam', ignore_pg_header => 1, cmd=>"$$opts{bin}/samtools merge${threads} -o - -s 1 -O sam $$opts{path}/dat/test_input_1_a.sam $$opts{path}/dat/test_input_1_b.sam $$opts{path}/dat/test_input_1_c.sam");
 
     # Sort inputs by PG, then merge
     system("$$opts{bin}/samtools sort -o $$opts{tmp}/merge.tag.1.bam -t PG -m 10M $$opts{path}/dat/test_input_1_b.sam") == 0 or die "failed to create sort BAM: $?";


### PR DESCRIPTION
The transition of `samtools sort [-o] in.bam out.prefix` to the typical Unix-style
```
samtools sort [-o out.bam] in.bam
```
is long since complete. As I recall, it was intended to transition `samtools merge out.bam in1.bam in2.bam…` similarly, but this was comparatively easy (no conflicting meaning for `-o` to deal with!) hence it never quite actually happened.

This PR adds support for
```
samtools merge [options…] -o out.bam [options…] in1.bam in2.bam…
```
which is easy to support unambiguously alongside the existing syntax. This means that `merge` can be used with the same familiar Unix-style `-o` output file control as `view`, `sort`, etc, avoiding [reasonable complaints like this one](https://twitter.com/David_McGaughey/status/1394331493820817408).

Add an `fnout` variable and increment `optind` past it for old-style command lines. As `optind` has been incremented, replace `optind+1` with `optind` in all the filename-list calculations.

The difficult additional transition here would be to default to writing to standard output, and this PR does not attempt to do that. As the existing syntax is quite entrenched, it would not be feasible to move to that more typical default without a long transition period, so for now (and for the foreseeable) `-o -` remains required in pipelines.