### PR TITLE
Replace fopen with stat for file exists check.

### DIFF
--- a/bam_sort.c
+++ b/bam_sort.c
@@ -33,6 +33,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
+#include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <getopt.h>
@@ -1506,9 +1507,8 @@ int bam_merge(int argc, char *argv[])
 
     hts_srand48(random_seed);
     if (!(flag & MERGE_FORCE) && strcmp(fnout, "-") != 0) {
-        FILE *fp = fopen(fnout, "rb");
-        if (fp != NULL) {
-            fclose(fp);
+        struct stat sbuf;
+        if (stat(fnout, &sbuf) == 0 && S_ISREG(sbuf.st_mode)) {
             fprintf(stderr, "[%s] File '%s' exists. Please apply '-f' to overwrite. Abort.\n", __func__, fnout);
             ret = 1;
             goto end;


### PR DESCRIPTION
Access is already used in sam.c, so hopefully this won't have any impact on compatibility (access is POSIX rather than C).

This fixes an issue where the check for file existence when file is a named pipe causes a hang.  Fixes #1437