### PR TITLE
Add long options to `samtools view`

### DIFF
--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -381,24 +381,30 @@ is specified in the same was as the
 .B "--add-flag"
 option.
 .TP
-.BI "-s " FLOAT
-Output only a proportion of the input alignments.
+.BI "--subsample " FLOAT
+Output only a proportion of the input alignments, as specified by 0.0 \(<=
+.I FLOAT
+\(<= 1.0, which gives the fraction of templates/pairs to be kept.
 This subsampling acts in the same way on all of the alignment records in
 the same template or read pair, so it never keeps a read but not its mate.
-.IP
-The integer and fractional parts of the
-.BI "-s " INT . FRAC
-option are used separately: the part after the
-decimal point sets the fraction of templates/pairs to be kept,
-while the integer part is used as a seed that influences
+.TP
+.BI "--subsample-seed " INT
+Subsampling seed used to influence
 .I which
 subset of reads is kept.
-.IP
 .\" Reads are retained based on a score computed by hashing their QNAME
 .\" field and the seed value.
 When subsampling data that has previously been subsampled, be sure to use
 a different seed value from those used previously; otherwise more reads
 will be retained than expected.
+[0]
+.TP
+.BI "-s " FLOAT
+Subsampling shorthand option:
+.BI "-s " INT . FRAC
+is equivalent to
+.BI "--subsample-seed " INT " --subsample
+.RI 0. FRAC .
 .TP
 .BI "-@ " INT ", --threads " INT
 Number of BAM compression threads to use in addition to main thread [0].

--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -105,9 +105,9 @@ alignments that match certain criteria.
 The
 .BR -x ,
 .BR -B ,
-.B --add-flag
+.BR --add-flags ,
 and
-.B --remove-flag
+.B --remove-flags
 options modify the data which is contained in each alignment.
 
 The
@@ -367,18 +367,18 @@ Read tag to exclude from output (repeatable) [null]
 .BR -B ", " --remove-B
 Collapse the backward CIGAR operation.
 .TP
-.BI "--add-flag " FLAGS
+.BI "--add-flags " FLAG
 Adds flag(s) to read.
 .I FLAG
 can be specified in hex by beginning with `0x' (i.e. /^0x[0-9A-F]+/),
 in octal by beginning with `0' (i.e. /^0[0-7]+/), as a decimal number
 not beginning with '0' or as a comma-separated list of flag names.
 .TP
-.BI "--remove-flag " FLAG
+.BI "--remove-flags " FLAG
 Remove flag(s) from read.
 .I FLAG
-is specified in the same was as the
-.B "--add-flag"
+is specified in the same way as with the
+.B "--add-flags"
 option.
 .TP
 .BI "--subsample " FLOAT
@@ -501,7 +501,7 @@ samtools view -d RG:grp2 -o /data_folder/data.rg2_only.bam /data_folder/data.bam
 .IP o 2
 Remove the actions of samtools markdup.  Clear the duplicate flag and remove the \fBdt\fR tag, keep the header.
 .EX 2
-samtools view -h --remove-flag DUP -x dt -o /data_folder/dat.no_dup_markings.bam /data_folder/data.bam
+samtools view -h --remove-flags DUP -x dt -o /data_folder/dat.no_dup_markings.bam /data_folder/data.bam
 .EE
 
 .SH AUTHOR

--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -158,27 +158,32 @@ Output all alignments.
 
 .SH OPTIONS
 .TP 10
-.B -b
+.BR -b ", " --bam
 Output in the BAM format.
 .TP
-.B -C
+.BR -C ", " --cram
 Output in the CRAM format (requires -T).
 .TP
-.B -1
+.BR -1 ", " --fast
 Enable fast BAM compression (implies -b).
 .TP
-.B -u
+.BR -u ", " --uncompressed
 Output uncompressed BAM. This option saves time spent on
 compression/decompression and is thus preferred when the output is piped
 to another samtools command.
 .TP
-.B -h
+.BR -h ", " --with-header
 Include the header in the output.
 .TP
-.B -H
+.BR -H ", " --header-only
 Output the header only.
 .TP
-.B -c
+.B --no-header
+When producing SAM format, output alignment records but not headers.
+This is the default; the option can be used to reset the effect of
+.BR -h / -H .
+.TP
+.BR -c ", " --count
 Instead of printing the alignments, only count them and print the
 total number. All filter options, such as
 .BR -f ,
@@ -187,14 +192,14 @@ and
 .BR -q ,
 are taken into account.
 .TP
-.B -?
+.BR -? ", " --help
 Output long help and exit immediately.
 .TP
-.BI "-o " FILE
+.BI "-o " FILE ", --output " FILE
 Output to
 .I FILE [stdout].
 .TP
-.BI "-U " FILE
+.BI "-U " FILE ", --unoutput " FILE ", --output-unselected " FILE
 Write alignments that are
 .I not
 selected by the various filter options to
@@ -203,7 +208,7 @@ When this option is used, all alignments (or all alignments intersecting the
 .I regions
 specified) are written to either the output file or this file, but never both.
 .TP
-.BI "-t " FILE
+.BI "-t " FILE ", --fai-reference " FILE
 A tab-delimited
 .IR FILE .
 Each line must contain the reference name in the first column and the length of
@@ -215,7 +220,7 @@ defines the order of the reference sequences in sorting. If you run:
 can be used as this
 .IR FILE .
 .TP
-.BI "-T " FILE
+.BI "-T " FILE ", --reference " FILE
 A FASTA format reference
 .IR FILE ,
 optionally compressed by
@@ -256,11 +261,11 @@ The usage of a BED file is optional and its path has to be preceded by
 .BR -L
 option.
 .TP
-.BI "-N " FILE
+.BI "-N " FILE ", --qname-file " FILE
 Output only alignments with read names listed in
-.I FILE.
+.IR FILE .
 .TP
-.BI "-r " STR
+.BI "-r " STR ", --read-group " STR
 Output alignments in read group
 .I STR
 [null].
@@ -269,7 +274,7 @@ Note that records with no
 tag will also be output when using this option.
 This behaviour may change in a future release.
 .TP
-.BI "-R " FILE
+.BI "-R " FILE ", --read-group-file " FILE
 Output alignments in read groups listed in
 .I FILE
 [null].
@@ -278,7 +283,7 @@ Note that records with no
 tag will also be output when using this option.
 This behaviour may change in a future release.
 .TP
-.BI "-d " STR1[:STR2]
+.BI "-d " STR1[:STR2] ", --tag " STR1[:STR2]
 Only output alignments with tag
 .I STR1
 and associated value
@@ -286,35 +291,35 @@ and associated value
 which can be a string or an integer [null].
 The value can be omitted, in which case only the tag is considered.
 .TP
-.BI "-D " STR:FILE
+.BI "-D " STR:FILE ", --tag-file " STR:FILE
 Only output alignments with tag
 .I STR
 and associated values listed in
 .I FILE
 [null].
 .TP
-.BI "-q " INT
+.BI "-q " INT ", --min-MQ " INT
 Skip alignments with MAPQ smaller than
 .I INT
 [0].
 .TP
-.BI "-l " STR
+.BI "-l " STR ", --library " STR
 Only output alignments in library
 .I STR
 [null].
 .TP
-.BI "-m " INT
+.BI "-m " INT ", --min-qlen " INT
 Only output alignments with number of CIGAR bases consuming query
 sequence \(>=
 .I INT
 [0]
 .TP
-.BI "-e " STR
+.BI "-e " STR ", --expr " STR
 Only include alignments that match the filter expression \fISTR\fR.
-The syntax for these expressions are in the main samtools(1) man page
+The syntax for these expressions is described in the main samtools(1) man page
 under the FILTER EXPRESSIONS heading.
 .TP
-.BI "-f " FLAG
+.BI "-f " FLAG ", --require-flags " FLAG
 Only output alignments with all bits set in
 .I FLAG
 present in the FLAG field.
@@ -327,7 +332,7 @@ not beginning with '0' or as a comma-separated list of flag names.
 For a list of flag names see
 .IR samtools-flags (1).
 .TP
-.BI "-F " FLAG
+.BI "-F " FLAG ", --excl-flags " FLAG ", --exclude-flags " FLAG
 Do not output alignments with any bits set in
 .I FLAG
 present in the FLAG field.
@@ -346,10 +351,10 @@ can be specified in hex by beginning with `0x' (i.e. /^0x[0-9A-F]+/),
 in octal by beginning with `0' (i.e. /^0[0-7]+/), as a decimal number
 not beginning with '0' or as a comma-separated list of flag names.
 .TP
-.BI "-x " STR
+.BI "-x " STR ", --remove-tag " STR
 Read tag to exclude from output (repeatable) [null]
 .TP
-.B -B
+.BR -B ", " --remove-B
 Collapse the backward CIGAR operation.
 .TP
 .BI "--add-flag " FLAGS
@@ -385,7 +390,7 @@ When subsampling data that has previously been subsampled, be sure to use
 a different seed value from those used previously; otherwise more reads
 will be retained than expected.
 .TP
-.BI "-@ " INT
+.BI "-@ " INT ", --threads " INT
 Number of BAM compression threads to use in addition to main thread [0].
 .TP
 .B -S
@@ -394,7 +399,7 @@ Previously this option was required if input was in SAM format, but now the
 correct format is automatically detected by examining the first few characters
 of input.
 .TP
-.B -X
+.BR -X ", " --customized-index
 Include customized index file as a part of arguments. See
 .B EXAMPLES
 section for sample of usage.

--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -246,12 +246,12 @@ If this method is used to make CRAM files, the cram reader may not be able to
 find the index, and may not be able to decode the file unless it can get
 the references it needs using a different method.
 .TP
-.BI "-L " FILE
+.BI "-L " FILE ", --target-file " FILE ", --targets-file " FILE
 Only output alignments overlapping the input BED
 .I FILE
 [null].
 .TP
-.B "-M "
+.BR -M ", " --use-index
 Use the multi-region iterator on the union of a BED file and
 command-line region arguments.  This avoids re-reading the same regions
 of files so can sometimes be much faster.  Note this also removes
@@ -260,6 +260,16 @@ regions specified on the command line will be reported multiple times.
 The usage of a BED file is optional and its path has to be preceded by
 .BR -L
 option.
+.TP
+.BI "--region-file " FILE ", --regions-file " FILE
+Use an index and multi-region iterator to only output alignments
+overlapping the input BED
+.IR FILE .
+Equivalent to
+.BI "-M -L " FILE
+or
+.B --use-index --target-file
+.IR FILE .
 .TP
 .BI "-N " FILE ", --qname-file " FILE
 Output only alignments with read names listed in

--- a/sam_view.c
+++ b/sam_view.c
@@ -326,7 +326,7 @@ int main_samview(int argc, char *argv[])
 
     static const struct option lopts[] = {
         SAM_OPT_GLOBAL_OPTIONS('-', 0, 'O', 0, 'T', '@'),
-        {"add-flag", required_argument, NULL, LONGOPT('a')},
+        {"add-flags", required_argument, NULL, LONGOPT('a')},
         {"bam", no_argument, NULL, 'b'},
         {"count", no_argument, NULL, 'c'},
         {"cram", no_argument, NULL, 'C'},
@@ -358,7 +358,7 @@ int main_samview(int argc, char *argv[])
         {"region-file", required_argument, NULL, LONGOPT('L')},
         {"regions-file", required_argument, NULL, LONGOPT('L')},
         {"remove-B", no_argument, NULL, 'B'},
-        {"remove-flag", required_argument, NULL, LONGOPT('r')},
+        {"remove-flags", required_argument, NULL, LONGOPT('r')},
         {"remove-tag", required_argument, NULL, 'x'},
         {"require-flags", required_argument, NULL, 'f'},
         {"subsample", required_argument, NULL, LONGOPT('s')},
@@ -967,8 +967,8 @@ static int usage(FILE *fp, int exit_status, int is_long_help)
 "  -s INT.FRAC                Same as --subsample 0.FRAC --subsample-seed INT\n"
 "\n"
 "Processing options:\n"
-"      --add-flag FLAG        Add FLAGs to reads\n"
-"      --remove-flag FLAG     Remove FLAGs from reads\n"
+"      --add-flags FLAG       Add FLAGs to reads\n"
+"      --remove-flags FLAG    Remove FLAGs from reads\n"
 "  -x, --remove-tag STR       Strip tag STR from reads (option may be repeated)\n"
 "  -B, --remove-B             Collapse the backward CIGAR operation\n"
 "\n"

--- a/sam_view.c
+++ b/sam_view.c
@@ -286,6 +286,9 @@ static inline void change_flag(bam1_t *b, samview_settings_t *settings)
         b->core.flag &= ~settings->remove_flag;
 }
 
+// Make mnemonic distinct values for longoption-only options
+#define LONGOPT(c)  ((c) + 128)
+
 int main_samview(int argc, char *argv[])
 {
     int c, is_header = 0, is_header_only = 0, ret = 0, compress_level = -1, is_count = 0, has_index_file = 0, no_pg = 0;
@@ -323,9 +326,44 @@ int main_samview(int argc, char *argv[])
 
     static const struct option lopts[] = {
         SAM_OPT_GLOBAL_OPTIONS('-', 0, 'O', 0, 'T', '@'),
-        {"no-PG", no_argument, NULL, 1},
-        {"remove-flag", required_argument, NULL, 2},
-        {"add-flag", required_argument, NULL, 3},
+        {"add-flag", required_argument, NULL, LONGOPT('a')},
+        {"bam", no_argument, NULL, 'b'},
+        {"count", no_argument, NULL, 'c'},
+        {"cram", no_argument, NULL, 'C'},
+        {"customised-index", no_argument, NULL, 'X'},
+        {"customized-index", no_argument, NULL, 'X'},
+        {"excl-flags", required_argument, NULL, 'F'},
+        {"exclude-flags", required_argument, NULL, 'F'},
+        {"expr", required_argument, NULL, 'e'},
+        {"expression", required_argument, NULL, 'e'},
+        {"fai-reference", required_argument, NULL, 't'},
+        {"fast", no_argument, NULL, '1'},
+        {"header-only", no_argument, NULL, 'H'},
+        {"help", no_argument, NULL, LONGOPT('?')},
+        {"library", required_argument, NULL, 'l'},
+        {"min-mapq", required_argument, NULL, 'q'},
+        {"min-MQ", required_argument, NULL, 'q'},
+        {"min-mq", required_argument, NULL, 'q'},
+        {"min-qlen", required_argument, NULL, 'm'},
+        {"no-header", no_argument, NULL, LONGOPT('H')},
+        {"no-PG", no_argument, NULL, LONGOPT('P')},
+        {"output", required_argument, NULL, 'o'},
+        {"output-unselected", required_argument, NULL, 'U'},
+        {"QNAME-file", required_argument, NULL, 'N'},
+        {"qname-file", required_argument, NULL, 'N'},
+        {"read-group", required_argument, NULL, 'r'},
+        {"read-group-file", required_argument, NULL, 'R'},
+        {"readgroup", required_argument, NULL, 'r'},
+        {"readgroup-file", required_argument, NULL, 'R'},
+        {"remove-B", no_argument, NULL, 'B'},
+        {"remove-flag", required_argument, NULL, LONGOPT('r')},
+        {"remove-tag", required_argument, NULL, 'x'},
+        {"require-flags", required_argument, NULL, 'f'},
+        {"tag", required_argument, NULL, 'd'},
+        {"tag-file", required_argument, NULL, 'D'},
+        {"uncompressed", no_argument, NULL, 'u'},
+        {"unoutput", required_argument, NULL, 'U'},
+        {"with-header", no_argument, NULL, 'h'},
         { NULL, 0, NULL, 0 }
     };
 
@@ -372,6 +410,7 @@ int main_samview(int argc, char *argv[])
         case 't': fn_fai = strdup(optarg); break;
         case 'h': is_header = 1; break;
         case 'H': is_header_only = 1; break;
+        case LONGOPT('H'): is_header = is_header_only = 0; break;
         case 'o': fn_out = strdup(optarg); break;
         case 'U': fn_un_out = strdup(optarg); break;
         case 'X': has_index_file = 1; break;
@@ -469,6 +508,8 @@ int main_samview(int argc, char *argv[])
         //case 'x': out_format = "x"; break;
         //case 'X': out_format = "X"; break;
                  */
+        case LONGOPT('?'):
+            return usage(stdout, EXIT_SUCCESS, 1);
         case '?':
             if (optopt == '?') {  // '-?' appeared on command line
                 return usage(stdout, EXIT_SUCCESS, 1);
@@ -498,15 +539,15 @@ int main_samview(int argc, char *argv[])
             }
             break;
         case 'M': settings.multi_region = 1; break;
-        case 1: no_pg = 1; break;
+        case LONGOPT('P'): no_pg = 1; break;
         case 'e':
             if (!(settings.filter = hts_filter_init(optarg))) {
                 print_error("main_samview", "Couldn't initialise filter");
                 return 1;
             }
             break;
-        case 2: settings.remove_flag |= bam_str2flag(optarg); break;
-        case 3: settings.add_flag |= bam_str2flag(optarg); break;
+        case LONGOPT('r'): settings.remove_flag |= bam_str2flag(optarg); break;
+        case LONGOPT('a'): settings.add_flag |= bam_str2flag(optarg); break;
         default:
             if (parse_sam_global_opt(c, optarg, lopts, &ga) != 0)
                 return usage(stderr, EXIT_FAILURE, 0);
@@ -870,54 +911,51 @@ static int usage(FILE *fp, int exit_status, int is_long_help)
 "\n"
 "Usage: samtools view [options] <in.bam>|<in.sam>|<in.cram> [region ...]\n"
 "\n"
-"Options:\n"
-// output options
-"  -b       output BAM\n"
-"  -C       output CRAM (requires -T)\n"
-"  -1       use fast BAM compression (implies -b)\n"
-"  -u       uncompressed BAM output (implies -b)\n"
-"  -h       include header in SAM output\n"
-"  -H       print SAM header only (no alignments)\n"
-"  -c       print only the count of matching records\n"
-"  -o FILE  output file name [stdout]\n"
-"  -U FILE  output reads not selected by filters to FILE [null]\n"
-// extra input
-"  -t FILE  FILE listing reference names and lengths (see long help) [null]\n"
-"  -X       include customized index file\n"
-// read filters
+"Output options:\n"
+"  -b, --bam                  Output BAM\n"
+"  -C, --cram                 Output CRAM (requires -T)\n"
+"  -1, --fast                 Use fast BAM compression (implies --bam)\n"
+"  -u, --uncompressed         Uncompressed BAM output (implies --bam)\n"
+"  -h, --with-header          Include header in SAM output\n"
+"  -H, --header-only          Print SAM header only (no alignments)\n"
+"      --no-header            Print SAM alignment records only [default]\n"
+"  -c, --count                Print only the count of matching records\n"
+"  -o, --output FILE          Write output to FILE [standard output]\n"
+"  -U, --unoutput FILE, --output-unselected FILE\n"
+"                             Output reads not selected by filters to FILE\n"
+"Input options:\n"
+"  -t, --fai-reference FILE   FILE listing reference names and lengths\n"
+"  -X, --customized-index     Expect extra index file argument after <in.bam>\n"
+"\n"
+"Filtering options (Only include in output reads that...):\n"
 "  -L FILE  only include reads overlapping this BED FILE [null]\n"
-"  -r STR   only include reads in read group STR [null]\n"
-"  -R FILE  only include reads with read group listed in FILE [null]\n"
-"  -N FILE  only include reads with read name listed in FILE [null]\n"
-"  -d STR1[:STR2]\n"
-"           only include reads with tag STR1 and associated value STR2 [null]\n"
-"           The value can be omitted, in which case only the tag is considered\n"
-"  -D STR:FILE\n"
-"           only include reads with tag STR and associated values listed in\n"
-"           FILE [null]\n"
-"  -q INT   only include reads with mapping quality >= INT [0]\n"
-"  -l STR   only include reads in library STR [null]\n"
-"  -m INT   only include reads with number of CIGAR operations consuming\n"
-"           query sequence >= INT [0]\n"
-"  -f FLAG  only include reads with all  of the FLAGs present\n"       //   F&x == x
-"  -F FLAG  only include reads with none of the FLAGs present\n"       //   F&x == 0
-"  -G FLAG  only EXCLUDE reads with all  of the FLAGs present\n"       // !(F&x == x)
-"  -e STR   only include reads matching the filter expression [null]\n"
+"  -r, --read-group STR       ...are in read group STR\n"
+"  -R, --read-group-file FILE ...are in a read group listed in FILE\n"
+"  -N, --qname-file FILE      ...whose read name is listed in FILE\n"
+"  -d, --tag STR1[:STR2]      ...have a tag STR1 (with associated value STR2)\n"
+"  -D, --tag-file STR:FILE    ...have a tag STR whose value is listed in FILE\n"
+"  -q, --min-MQ INT           ...have mapping quality >= INT\n"
+"  -l, --library STR          ...are in library STR\n"
+"  -m, --min-qlen INT         ...cover >= INT query bases (as measured via CIGAR)\n"
+"  -e, --expr STR             ...match the filter expression STR\n"
+"  -f, --require-flags FLAG   ...have all of the FLAGs present\n"             //   F&x == x
+"  -F, --excl[ude]-flags FLAG ...have none of the FLAGs present\n"            //   F&x == 0
+"  -G FLAG                    EXCLUDE reads with all of the FLAGs present\n"  // !(F&x == x)  TODO long option
 "  -s FLOAT subsample reads (given INT.FRAC option value, 0.FRAC is the\n"
 "           fraction of templates/read pairs to keep; INT part sets seed)\n"
 "  -M       use the multi-region iterator (increases the speed, removes\n"
 "           duplicates and outputs the reads as they are ordered in the file)\n"
-// read processing
-"  -x STR   read tag to strip (repeatable) [null]\n"
-"  -B       collapse the backward CIGAR operation\n"
-"  --add-flag FLAG\n"
-"           add FLAGs to reads\n"
-"  --remove-flag FLAG\n"
-"           remove FLAGs from reads\n"
-// general options
-"  -?       print long help, including note about region specification\n"
-"  -S       ignored (input format is auto-detected)\n"
-"  --no-PG  do not add a PG line\n");
+"\n"
+"Processing options:\n"
+"      --add-flag FLAG        Add FLAGs to reads\n"
+"      --remove-flag FLAG     Remove FLAGs from reads\n"
+"  -x, --remove-tag STR       Strip tag STR from reads (option may be repeated)\n"
+"  -B, --remove-B             Collapse the backward CIGAR operation\n"
+"\n"
+"General options:\n"
+"  -?, --help   Print long help, including note about region specification\n"
+"  -S           Ignored (input format is auto-detected)\n"
+"      --no-PG  Do not add a PG line\n");
 
     sam_global_opt_help(fp, "-.O.T@..");
     fprintf(fp, "\n");

--- a/sam_view.c
+++ b/sam_view.c
@@ -355,14 +355,19 @@ int main_samview(int argc, char *argv[])
         {"read-group-file", required_argument, NULL, 'R'},
         {"readgroup", required_argument, NULL, 'r'},
         {"readgroup-file", required_argument, NULL, 'R'},
+        {"region-file", required_argument, NULL, LONGOPT('L')},
+        {"regions-file", required_argument, NULL, LONGOPT('L')},
         {"remove-B", no_argument, NULL, 'B'},
         {"remove-flag", required_argument, NULL, LONGOPT('r')},
         {"remove-tag", required_argument, NULL, 'x'},
         {"require-flags", required_argument, NULL, 'f'},
         {"tag", required_argument, NULL, 'd'},
         {"tag-file", required_argument, NULL, 'D'},
+        {"target-file", required_argument, NULL, 'L'},
+        {"targets-file", required_argument, NULL, 'L'},
         {"uncompressed", no_argument, NULL, 'u'},
         {"unoutput", required_argument, NULL, 'U'},
+        {"use-index", no_argument, NULL, 'M'},
         {"with-header", no_argument, NULL, 'h'},
         { NULL, 0, NULL, 0 }
     };
@@ -421,6 +426,9 @@ int main_samview(int argc, char *argv[])
         case 'u': compress_level = 0; break;
         case '1': compress_level = 1; break;
         case 'l': settings.library = strdup(optarg); break;
+        case LONGOPT('L'):
+            settings.multi_region = 1;
+            // fall through
         case 'L':
             if ((settings.bed = bed_read(optarg)) == NULL) {
                 print_error_errno("view", "Could not read file \"%s\"", optarg);
@@ -925,10 +933,12 @@ static int usage(FILE *fp, int exit_status, int is_long_help)
 "                             Output reads not selected by filters to FILE\n"
 "Input options:\n"
 "  -t, --fai-reference FILE   FILE listing reference names and lengths\n"
+"  -M, --use-index            Use index and multi-region iterator for regions\n"
+"      --region[s]-file FILE  Use index to include only reads overlapping FILE\n"
 "  -X, --customized-index     Expect extra index file argument after <in.bam>\n"
 "\n"
 "Filtering options (Only include in output reads that...):\n"
-"  -L FILE  only include reads overlapping this BED FILE [null]\n"
+"  -L, --target[s]-file FILE  ...overlap (BED) regions in FILE\n"
 "  -r, --read-group STR       ...are in read group STR\n"
 "  -R, --read-group-file FILE ...are in a read group listed in FILE\n"
 "  -N, --qname-file FILE      ...whose read name is listed in FILE\n"
@@ -943,8 +953,6 @@ static int usage(FILE *fp, int exit_status, int is_long_help)
 "  -G FLAG                    EXCLUDE reads with all of the FLAGs present\n"  // !(F&x == x)  TODO long option
 "  -s FLOAT subsample reads (given INT.FRAC option value, 0.FRAC is the\n"
 "           fraction of templates/read pairs to keep; INT part sets seed)\n"
-"  -M       use the multi-region iterator (increases the speed, removes\n"
-"           duplicates and outputs the reads as they are ordered in the file)\n"
 "\n"
 "Processing options:\n"
 "      --add-flag FLAG        Add FLAGs to reads\n"
@@ -995,6 +1003,15 @@ static int usage(FILE *fp, int exit_status, int is_long_help)
 "\n"
 "6. Option `-u' is preferred over `-b' when the output is piped to\n"
 "   another samtools command.\n"
+"\n"
+"7. Option `-M`/`--use-index` causes overlaps with `-L` BED file regions and\n"
+"   command-line region arguments to be computed using the multi-region iterator\n"
+"   and an index. This increases speed, omits duplicates, and outputs the reads\n"
+"   as they are ordered in the input SAM/BAM/CRAM file.\n"
+"\n"
+"8. Options `-L`/`--target[s]-file` and `--region[s]-file` may not be used\n"
+"   together. `--region[s]-file FILE` is simply equivalent to `-M -L FILE`,\n"
+"   so using both causes one of the specified BED files to be ignored.\n"
 "\n");
 
     return exit_status;

--- a/test/test.pl
+++ b/test/test.pl
@@ -2471,7 +2471,7 @@ sub test_view
 
     run_view_test($opts,
                     msg=> "$test: Unset dup flag, remove dt and do tags",
-                    args => ['-h', '--remove-flag', 'DUP', '-x', 'do', '-x', 'dt', '--no-PG', $dup_sam],
+                    args => ['-h', '--remove-flags', 'DUP', '-x', 'do', '-x', 'dt', '--no-PG', $dup_sam],
                     out => sprintf("%s.test%03d.sam", $out, $test),
                     compare => $dup_expected);
 }


### PR DESCRIPTION
[Another PR that's been gestating for rather too long…]

This adds long option equivalents for all of `view`'s command-line options. The added expressiveness of the long names I think clarifies some of the usage explanations (while staying within 80 characters!).

It also adds `‑‑region-file` and `‑‑regions-file` as synonyms for the `-M -L` combination. Along with the `‑‑target-file`/`‑‑targets-file` long forms for plain `-L`, this means `samtools view` has the same long options for jump-to-region and stream-filtering-by-region as bcftools. And hopefully highlighting `‑‑region-file` as an option will help raise the visibility of `-M`.

Also `-s` subsampling is split into two long options, thus finally fixing #217.

Proposed usage display:

```
Usage: samtools view [options] <in.bam>|<in.sam>|<in.cram> [region ...]

Output options:
  -b, --bam                  Output BAM
  -C, --cram                 Output CRAM (requires -T)
  -1, --fast                 Use fast BAM compression (implies --bam)
  -u, --uncompressed         Uncompressed BAM output (implies --bam)
  -h, --with-header          Include header in SAM output
  -H, --header-only          Print SAM header only (no alignments)
      --no-header            Print SAM alignment records only [default]
  -c, --count                Print only the count of matching records
  -o, --output FILE          Write output to FILE [standard output]
  -U, --unoutput FILE, --output-unselected FILE
                             Output reads not selected by filters to FILE
Input options:
  -t, --fai-reference FILE   FILE listing reference names and lengths
  -M, --use-index            Use index and multi-region iterator for regions
      --region[s]-file FILE  Use index to include only reads overlapping FILE
  -X, --customized-index     Expect extra index file argument after <in.bam>

Filtering options (Only include in output reads that...):
  -L, --target[s]-file FILE  ...overlap (BED) regions in FILE
  -r, --read-group STR       ...are in read group STR
  -R, --read-group-file FILE ...are in a read group listed in FILE
  -N, --qname-file FILE      ...whose read name is listed in FILE
  -d, --tag STR1[:STR2]      ...have a tag STR1 (with associated value STR2)
  -D, --tag-file STR:FILE    ...have a tag STR whose value is listed in FILE
  -q, --min-MQ INT           ...have mapping quality >= INT
  -l, --library STR          ...are in library STR
  -m, --min-qlen INT         ...cover >= INT query bases (as measured via CIGAR)
  -e, --expr STR             ...match the filter expression STR
  -f, --all-flags INT        ...have all of the FLAGs in INT present
  -F, --excl[ude]-flags INT  ...have none of the FLAGs in INT present
  -G, --no-all-flags INT     EXCLUDE reads with all of the FLAGs in INT present
      --subsample FLOAT      Keep only FLOAT fraction of templates/read pairs
      --subsample-seed INT   Influence WHICH reads are kept in subsampling [0]
  -s INT.FRAC                Same as --subsample 0.FRAC --subsample-seed INT

Processing options:
  -x, --remove-tag STR       Strip tag STR from reads (option may be repeated)
  -B, --remove-B             Collapse the backward CIGAR operation

General options:
  -?, --help   Print long help, including note about region specification
  -S           Ignored (input format is auto-detected)
      --no-PG  Do not add a PG line
      --input-fmt-option OPT[=VAL]
               Specify a single input file format option in the form
               of OPTION or OPTION=VALUE
  -O, --output-fmt FORMAT[,OPT[=VAL]]...
               Specify output format (SAM, BAM, CRAM)
      --output-fmt-option OPT[=VAL]
               Specify a single output file format option in the form
               of OPTION or OPTION=VALUE
  -T, --reference FILE
               Reference sequence FASTA FILE [null]
  -@, --threads INT
               Number of additional threads to use [0]
      --write-index
               Automatically index the output files [off]
      --verbosity INT
               Set level of verbosity

Notes:

1. This command now auto-detects the input format (BAM/CRAM/SAM).
   Further control over the CRAM format can be specified by using the
   --output-fmt-option, e.g. to specify the number of sequences per slice
   and to use avoid reference based compression:

	samtools view -C --output-fmt-option seqs_per_slice=5000 \
	   --output-fmt-option no_ref -o out.cram in.bam

   Options can also be specified as a comma separated list within the
   --output-fmt value too.  For example this is equivalent to the above

	samtools view --output-fmt cram,seqs_per_slice=5000,no_ref \
	   -o out.cram in.bam

2. The file supplied with `-t' is SPACE/TAB delimited with the first
   two fields of each line consisting of the reference name and the
   corresponding sequence length. The `.fai' file generated by 
   `samtools faidx' is suitable for use as this file. This may be an
   empty file if reads are unaligned.

3. SAM->BAM conversion:  samtools view -bT ref.fa in.sam.gz

4. BAM->SAM conversion:  samtools view -h in.bam

5. A region should be presented in one of the following formats:
   `chr1', `chr2:1,000' and `chr3:1000-2,000'. When a region is
   specified, the input alignment file must be a sorted and indexed
   alignment (BAM/CRAM) file.

6. Option `-u' is preferred over `-b' when the output is piped to
   another samtools command.

7. Option `-M`/`--use-index` causes overlaps with `-L` BED file regions and
   command-line region arguments to be computed using the multi-region iterator
   and an index. This increases speed, omits duplicates, and outputs the reads
   as they are ordered in the input SAM/BAM/CRAM file.

8. Options `-L`/`--target[s]-file` and `--region[s]-file` may not be used
   together. `--region[s]-file FILE` is simply equivalent to `-M -L FILE`,
   so using both causes one of the specified BED files to be ignored.
```