### PR TITLE
[mpielup] Documentation of filtering options

### DIFF
--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -1104,9 +1104,9 @@ static void print_usage(FILE *fp, const mplp_conf_t *mplp)
     fprintf(fp,
 "  -r, --region REG        region in which pileup is generated\n"
 "  -R, --ignore-RG         ignore RG tags (one BAM = one sample)\n"
-"  --rf, --incl-flags STR|INT  required flags: skip reads with mask bits unset [%s]\n", tmp_require);
+"  --rf, --incl-flags STR|INT  required flags: include reads with any of the mask bits set [%s]\n", tmp_require);
     fprintf(fp,
-"  --ff, --excl-flags STR|INT  filter flags: skip reads with mask bits set\n"
+"  --ff, --excl-flags STR|INT  filter flags: skip reads with any of the mask bits set\n"
 "                                            [%s]\n", tmp_filter);
     fprintf(fp,
 "  -x, --ignore-overlaps   disable read-pair overlap detection\n"

--- a/doc/samtools-mpileup.1
+++ b/doc/samtools-mpileup.1
@@ -264,10 +264,10 @@ two requests.
 Ignore RG tags. Treat all reads in one BAM as one sample.
 .TP
 .BI --rf,\ --incl-flags \ STR|INT
-Required flags: skip reads with mask bits unset [null]
+Required flags: include reads with any of the mask bits set [null]
 .TP
 .BI --ff,\ --excl-flags \ STR|INT
-Filter flags: skip reads with mask bits set
+Filter flags: skip reads with any of the mask bits set
 [UNMAP,SECONDARY,QCFAIL,DUP]
 .TP
 .B -x,\ --ignore-overlaps


### PR DESCRIPTION
Document the fact that the filtering options of `mpileup` work with **ANY** rules.
This means that when using `--rf, --incl-flags`, only reads with any of the option flags set are considered.
Also, when using `--ff, --excl-flags`, all the reads with any of the option flags set are discarded. By default, all reads that have at least one of the flags {UNMAP, SECONDARY, QCFAIL, DUP} set are discarded.

Thus, a read can be included if any of its flags are in the `--rf, --incl-flags` set and none are in the `--ff, --excl-flags` set. And it can be discarded if none of its flags are in the `--rf, --incl-flags` set or at least one is in the `--ff, --excl-flags` set.

Fixes #1435 

 