### PR TITLE
Rewritten depth cmd: avoid calling fclose() on stdout

### DIFF
--- a/bam2depth.c
+++ b/bam2depth.c
@@ -733,6 +733,7 @@ int main_depth(int argc, char *argv[])
     sam_hdr_t **header;
     int c, has_index_file = 0;
     char *file_list = NULL, **fn = NULL;
+    char *out_file = NULL;
     depth_opt opt = {
         .flag = BAM_FUNMAP | BAM_FSECONDARY | BAM_FDUP | BAM_FQCFAIL,
         .min_qual = 0,
@@ -807,7 +808,7 @@ int main_depth(int argc, char *argv[])
         case 'o':
             if (opt.out != stdout)
                 break;
-            opt.out = fopen(optarg, "w");
+            opt.out = fopen(out_file = optarg, "w");
             if (!opt.out) {
                 print_error_errno("depth", "Cannot open \"%s\" for writing.",
                                   optarg);
@@ -948,7 +949,13 @@ int main_depth(int argc, char *argv[])
     if (opt.bed)
         bed_destroy(opt.bed);
     sam_global_args_free(&ga);
-    if (opt.out != stdout) fclose(opt.out);
+    if (opt.out != stdout) {
+        if (fclose(opt.out) != 0 && ret == 0) {
+            print_error_errno("depth", "error on closing \"%s\"", out_file);
+            ret = 1;
+        }
+    }
+
     return ret;
 }
 

--- a/bam2depth.c
+++ b/bam2depth.c
@@ -948,7 +948,7 @@ int main_depth(int argc, char *argv[])
     if (opt.bed)
         bed_destroy(opt.bed);
     sam_global_args_free(&ga);
-    fclose(opt.out);
+    if (opt.out != stdout) fclose(opt.out);
     return ret;
 }
 


### PR DESCRIPTION
In an exact replay of #1208 :smile:, #1428's rewritten `depth` command now just does a plain `fclose(opt.out)` again. This PR stops `samtools depth` from closing stdout, which was the cause of [these pysam build failures on Linux](https://github.com/jmarshall/pysam/actions/runs/1015160980). Leaving `stdout` open facilitates wrappers such as pysam that call samtools's `main()` and/or `main_depth()` as subroutines.

This is just the minimal change that makes pysam happy. The previous depth code also checked for errors from this `fclose`; at the moment, the rewritten `samtools depth` will be oblivious to losing output due to I/O errors. So instead of this PR, you may wish to reapply something like the previous code, i.e., 0bf3778274746709985d41753ac75969f6f201bc as modified by #1208.