### PR TITLE
Make inplace samtools reheader use maximum compression on CRAM.

### DIFF
--- a/bam_reheader.c
+++ b/bam_reheader.c
@@ -380,7 +380,7 @@ int cram_reheader_inplace3(cram_fd *fd, sam_hdr_t *h, const char *arg_list,
     cram_block_append(b, (void *)sam_hdr_str(cram_h), header_len);
     cram_block_update_size(b);
 
-    cram_compress_block(fd, b, NULL, -1, -1);
+    cram_compress_block(fd, b, NULL, -1, 9);
 
     if (hseek(cram_fd_get_fp(fd), 26, SEEK_SET) != 26)
         goto err;


### PR DESCRIPTION
There is a slight unfortunate series of events that makes inplace
reheader fail.  If we use high compression level when building the
initial CRAM ("scramble -7" was used locally, but "samtools view -O
cram,level=7" would equally apply), then we get a well compressed
header.

We deliberately leave an additional 50% or 10KB (whatever is biggest)
to allow for further expansion with inline header replacement.

However, samtools reheader doesn't have the option to alter
compression level and hence even attempting to replace a header by
itself sometimes doesn't fit!

This solution is a trivial one.  Reheader always compresses to the
max.  It's generally such a fast operation that we don't care greatly
about the extra overheads of taking a bit longer to compress. It could
attempt to compress and if it doesn't fit uncompress it and recompress
again with a new level, but it hardly feels worth it.