### PR TITLE
Flush output samFiles before printing error messages

### DIFF
--- a/bam_fastq.c
+++ b/bam_fastq.c
@@ -480,6 +480,7 @@ static bool init_state(const bam2fq_opts_t* opts, bam2fq_state_t** state_out)
                     return false;
                 }
                 set_sam_opts(state->hstdout, state, opts);
+                autoflush_if_stdout(state->hstdout, "-");
             }
             state->fpr[i] = state->hstdout;
         }
@@ -546,6 +547,7 @@ static bool destroy_state(const bam2fq_opts_t *opts, bam2fq_state_t *state, int*
         }
     }
     if (state->hstdout) {
+        release_autoflush(state->hstdout);
         if (sam_close(state->hstdout) < 0) {
             print_error_errno("bam2fq", "Error closing STDOUT");
             valid = false;
@@ -787,7 +789,7 @@ static bool bam2fq_mainloop(bam2fq_state_t *state, bam2fq_opts_t* opts)
     while (true) {
         int res = sam_read1(state->fp, state->h, b[n]);
         if (res < -1) {
-            fprintf(stderr, "[bam2fq_mainloop] Failed to read bam record.\n");
+            print_error("bam2fq", "Failed to read bam record");
             goto err;
         }
         at_eof = res < 0;

--- a/bam_import.c
+++ b/bam_import.c
@@ -228,6 +228,7 @@ static int import_fastq(int argc, char **argv, opts_t *opts) {
         perror(opts->fn_out);
         goto err;
     }
+    autoflush_if_stdout(fp_out, opts->fn_out);
     if (opts->p.pool)
         hts_set_thread_pool(fp_out, &opts->p);
 
@@ -378,6 +379,7 @@ err:
     ks_free(&index_str);
     ks_free(&read_str);
     if (fp_out) {
+        release_autoflush(fp_out);
         if (sam_close(fp_out) < 0) {
             perror(opts->fn_out);
             ret |= -1;

--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -609,6 +609,7 @@ static int mpileup(mplp_conf_t *conf, int n, char **fn, char **fn_idx)
             fprintf(stderr, "[%s] failed to write to %s: %s\n", __func__, conf->output_fname? conf->output_fname : "standard output", strerror(errno));
             exit(EXIT_FAILURE);
         }
+        autoflush_if_stdout(bcf_fp, conf->output_fname);
 
         // BCF header creation
         bcf_hdr = bcf_hdr_init("w");
@@ -1048,6 +1049,7 @@ fail:
     bcf_destroy1(bcf_rec);
     if (bcf_fp)
     {
+        release_autoflush(bcf_fp);
         hts_close(bcf_fp);
         bcf_hdr_destroy(bcf_hdr);
         bcf_call_destroy(bca);

--- a/sam_view.c
+++ b/sam_view.c
@@ -748,6 +748,7 @@ int main_samview(int argc, char *argv[])
                 goto view_end;
             }
         }
+        autoflush_if_stdout(out, fn_out);
 
         if (!no_pg) {
             if (!(arg_list = stringify_argv(argc+1, argv-1))) {
@@ -795,6 +796,7 @@ int main_samview(int argc, char *argv[])
                     goto view_end;
                 }
             }
+            autoflush_if_stdout(un_out, fn_un_out);
             if (*out_format || is_header ||
                 out_un_mode[1] == 'b' || out_un_mode[1] == 'c' ||
                 (ga.out.format != sam && ga.out.format != unknown_format))  {
@@ -887,7 +889,7 @@ int main_samview(int argc, char *argv[])
                             }
                         }
                         if (result < -1) {
-                            fprintf(stderr, "[main_samview] retrieval of region %d failed due to truncated file or corrupt BAM index file\n", iter->curr_tid);
+                            print_error("view", "retrieval of region %d failed due to truncated file or corrupt BAM index file", iter->curr_tid);
                             ret = 1;
                         }
 
@@ -963,7 +965,7 @@ int main_samview(int argc, char *argv[])
                 }
                 hts_itr_destroy(iter);
                 if (result < -1) {
-                    fprintf(stderr, "[main_samview] retrieval of region \"%s\" failed due to truncated file or corrupt BAM index file\n", argv[i]);
+                    print_error("view", "retrieval of region \"%s\" failed due to truncated file or corrupt BAM index file", argv[i]);
                     ret = 1;
                     break;
                 }

--- a/samtools.h
+++ b/samtools.h
@@ -37,6 +37,16 @@ void print_error_errno(const char *subcommand, const char *format, ...) CHECK_PR
 
 void check_sam_close(const char *subcmd, samFile *fp, const char *fname, const char *null_fname, int *retp);
 
+/* Utility functions to register an output htsFile/samFile/vcfFile that
+ * might be stdout. If FNAME is "-" or NULL, records FP so that print_error()
+ * et al can automatically flush it before printing an error message.
+ */
+void autoflush_if_stdout(htsFile *fp, const char *fname);
+
+/* Call this before closing FP; check_sam_close() does this automatically.
+ */
+void release_autoflush(htsFile *fp);
+
 /*
  * Utility function to add an index to a file we've opened for write.
  * NB: Call this after writing the header and before writing sequences.


### PR DESCRIPTION
When output is to the terminal (common when e.g. `samtools view` is used to view SAM), flush it to ensure error messages are not obscured by buffered output that is printed later when the output stream is closed.

For example, with samtools 1.13 on an intentionally corrupted BAM file:

```
$ samtools-1.13 view ex2_corrupt.bam
EAS56_57:6:190:289:82   73      chr1    100     73      35M     =       100     0       AGGGGTGCAGAGCCGAGTCACGGGGTTGCCAGCAC     <<<<<<;<<<<<<<<<<;<<;<<<<;8<6;9;;2;     MF:i:64 Aq:i:0  NM:i:0  UQ:i:0  H0:i:1  H1:i:0
[…]
EAS56_61:1:119:880:781  147     chr2    1312    99      35M     =       1157    -190    ACAAsamtools view: error reading file "ex2_corrupt.bam"
ATCTGCGCTTGTACTTCTAAATCTATAACAA ;8<<;<<<<:<84<<<<:<<<<<<<<<<<<<5<<<     MF:i:18 Aq:i:45 NM:i:1  UQ:i:27 H0:i:0  H1:i:1
[…
 …approx 170 more lines of SAM output…
 …]
EAS114_26:7:37:79:581   83      chr2    1533    68      35M     =       1349    -219    TTTTTTTTTTTTTTTTTTTTTTTCATGCCAGAAAA     3,,,===6===<===<;=====-============     MF:i:18 Aq:i:27 NM:i:2  UQ:i:23 H0:i:0  H1:i:1
$
```

With this patch (which requires PR samtools/htslib#1326) the error message appears after all the SAM output, prominently just before the following `$` prompt.

This PR fixes the issue for a couple of likely candidate subcommands, `samtools view` in particular.

(`vprint_error_core()` is able to flush `stdout` itself because there is a well-known global variable referring to standard output's `FILE *`. So if _sam_utils.c_ (or another source file) provided a `samFile *sam_stdout` global variable that the various subcommands could set to their output handles that point to standard output, `vprint_error_core()` would be able to `sam_flush()` it itself too. But this is probably more trouble than it's worth, as care would have to be taken to set the global to NULL when the subcommand's output handle was closed.)