### PR TITLE
Add view --rf option

### DIFF
--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -97,8 +97,9 @@ The
 .BR -m ,
 .BR -f ,
 .BR -F ,
+.BR -G ,
 and
-.B -G
+.B --rf
 options filter the alignments that will be included in the output to only those
 alignments that match certain criteria.
 
@@ -344,6 +345,15 @@ For a list of flag names see
 .TP
 .BI "-F " FLAG ", --excl-flags " FLAG ", --exclude-flags " FLAG
 Do not output alignments with any bits set in
+.I FLAG
+present in the FLAG field.
+.I FLAG
+can be specified in hex by beginning with `0x' (i.e. /^0x[0-9A-F]+/),
+in octal by beginning with `0' (i.e. /^0[0-7]+/), as a decimal number
+not beginning with '0' or as a comma-separated list of flag names.
+.TP
+.BI "--rf " FLAG " , --incl-flags " FLAG ", --include-flags " FLAG
+Only output alignments with any bit set in
 .I FLAG
 present in the FLAG field.
 .I FLAG


### PR DESCRIPTION
This keeps reads if ANY bit is set rather than the -f which needs ALL set.

Fixes #1470

I improved the documentation in the code, but in doing so it raises questions over the naming of the `flag_alloff` variable.  I haven't changed it, but I wonder whether the original author meant something different.  (I reviewed it so this one is partly on me.)

The logic for `-G` is basically reject if `(FLAG & N) == N`.  I can't grasp how that is "all off".

If we're looking at it from a rejection viewpoint, then we're rejecting records where all bits are present - ie all on.
If we're looking at it from a keep viewpoint (ie keep if `(FLAG & N) != N`) then we're retaining records where any of the bits are off.

I documented it in the code as "anyoff", but as that one test is the only one documented in the usage statement as exclude while all others are include (even the one starting `--exclude`!) then it's already an outlier.  I'm tempted to rename the variable to be `flag_anyoff` though and document it in the options struct as "keep if" for consistency.