### PR TITLE
Replace Curses `mvprintw()` with `va_list`-based equivalent

### DIFF
--- a/bam_tview_curses.c
+++ b/bam_tview_curses.c
@@ -78,15 +78,11 @@ static void curses_destroy(tview_t* base) {
 */
 
 static void curses_mvprintw(struct AbstractTview* tv,int y ,int x,const char* fmt,...) {
-    unsigned int size=tv->mcol+2;
-    char* str=malloc(size);
-    if(str==0) exit(EXIT_FAILURE);
     va_list argptr;
     va_start(argptr, fmt);
-    vsnprintf(str,size, fmt, argptr);
+    if (wmove(stdscr, y, x) != ERR)
+        vw_printw(stdscr, fmt, argptr);
     va_end(argptr);
-    mvprintw(y,x,str);
-    free(str);
 }
 
 static void curses_mvaddch(struct AbstractTview* tv,int y,int x,int ch) {


### PR DESCRIPTION
As observed by @tillea in [this samtools-0.1.19 patch](https://salsa.debian.org/med-team/samtools-legacy/-/commit/f2e1cdea0ea41f50e6de1f231eb8091a36602cde), the curses code uses potentially user-supplied data as a printf-style format:

```
$ make CFLAGS='-DGCC_PRINTF -Wall -Wformat-security' bam_tview_curses.o
clang -DGCC_PRINTF -Wall -Wformat-security -I. -I../htslib -I./lz4  -c -o bam_tview_curses.o bam_tview_curses.c
bam_tview_curses.c:88:18: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
    mvprintw(y,x,str);

```

(At present, _bam_tview.c_ only uses this to print numbers, so fortunately presumably it will never actually contain a `%` character.)

Rather than adding `"%s"` as appropriate, we can use another curses function that takes a `va_list` directly to avoid allocating a buffer and `sprintf`-ing into it here. Build tested on ~~Solaris~~OpenIndiana (which disappointingly uses a form of ncurses rather than some other vendor curses) and OpenBSD as well as the usual platforms.