### PR TITLE
Sort temporary file improvements

### DIFF
--- a/bam_sort.c
+++ b/bam_sort.c
@@ -2752,8 +2752,13 @@ int bam_sort(int argc, char *argv[])
     if (level >= 0) sprintf(strchr(modeout, '\0'), "%d", level < 9? level : 9);
 
     if (tmpprefix.l == 0) {
-        if (strcmp(fnout, "-") != 0) ksprintf(&tmpprefix, "%s.tmp", fnout);
-        else kputc('.', &tmpprefix);
+        if (strcmp(fnout, "-") != 0) {
+            char *idx = strstr(fnout, HTS_IDX_DELIM);
+            kputsn(fnout, idx ? idx - fnout : strlen(fnout), &tmpprefix);
+            kputs(".tmp", &tmpprefix);
+        } else {
+            kputc('.', &tmpprefix);
+        }
     }
     if (stat(tmpprefix.s, &st) == 0 && S_ISDIR(st.st_mode)) {
         unsigned t = ((unsigned) time(NULL)) ^ ((unsigned) clock());


### PR DESCRIPTION
This makes three main improvements, without changing the way sort operates too much:

1. Make sort deal with existing temporary files that have the name it wants to use.  Fixes #1035.  It already used exclusive access to avoid clobbering files; this makes it try different names until it gets a free one.  The method used to get a new name is just a counter so not very clever, but it should work well enough.  Adjustments are made so the name chosen is passed back from sorting threads and stored for the merge stage to use.  As a bonus, it will also try to do a better job of cleaning up temporary files if the sort fails.  Note that this will no longer try to write temporary files as CRAM when long CIGARs are present - BAM can do long CIGARs now, and it makes for a simpler retry loop as `write_buffer()` is only called in one place.
2. Remove anything after a `##idx##` delimiter when making the temporary file prefix.  Fixes #1503.  This delimiter can be used with `--write-index` to change the name and/or location where the index is written.  If the index part includes path elements (e.g. `samtools sort -o /data/out.bam##idx##/indexes/out.csi`) then it has to be removed to get something that's likely to work.
3. Detect files with large (> INT32_MAX) references and switch to writing temporary files in `.sam.gz` format.  Detection is done by looking for long reference lengths in the header.  This makes it possible to sort files alignments against long references without having to keep the whole file in memory.  It will also check that the output format is compatible with long references before sorting starts, which seems better than waiting until the output file is actually opened (in the merge stage).