### PR TITLE
Add new `samtools head` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ padding.o: padding.c config.h $(htslib_kstring_h) $(htslib_sam_h) $(htslib_faidx
 phase.o: phase.c config.h $(htslib_hts_h) $(htslib_sam_h) $(htslib_kstring_h) $(sam_opts_h) $(samtools_h) $(htslib_hts_os_h) $(htslib_kseq_h) $(htslib_khash_h) $(htslib_ksort_h)
 sam_opts.o: sam_opts.c config.h $(sam_opts_h)
 sam_utils.o: sam_utils.c config.h $(samtools_h)
-sam_view.o: sam_view.c config.h $(htslib_sam_h) $(htslib_faidx_h) $(htslib_khash_h) $(htslib_thread_pool_h) $(htslib_hts_expr_h) $(samtools_h) $(sam_opts_h) $(bam_h) $(bedidx_h)
+sam_view.o: sam_view.c config.h $(htslib_sam_h) $(htslib_faidx_h) $(htslib_khash_h) $(htslib_kstring_h) $(htslib_thread_pool_h) $(htslib_hts_expr_h) $(samtools_h) $(sam_opts_h) $(bam_h) $(bedidx_h)
 sample.o: sample.c config.h $(sample_h) $(htslib_khash_h)
 stats_isize.o: stats_isize.c config.h $(stats_isize_h) $(htslib_khash_h)
 stats.o: stats.c config.h $(htslib_faidx_h) $(htslib_sam_h) $(htslib_hts_h) $(htslib_hts_defs_h) $(samtools_h) $(htslib_khash_h) $(htslib_kstring_h) $(stats_isize_h) $(sam_opts_h) $(bedidx_h)

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,12 @@
 Release a.b
 -----------
 
+ * New "samtools head" subcommand for conveniently displaying the headers
+   of a SAM, BAM, or CRAM file. Without options, this is equivalent to
+   `samtools view --header-only --no-PG` but more succinct and memorable.
+   (#1517; thanks to John Marshall)
+
+
 Release 1.14 (22nd October 2021)
 --------------------------------
 

--- a/bamtk.c
+++ b/bamtk.c
@@ -47,6 +47,7 @@ int bam_fillmd(int argc, char *argv[]);
 int bam_idxstats(int argc, char *argv[]);
 int bam_markdup(int argc, char *argv[]);
 int main_samview(int argc, char *argv[]);
+int main_head(int argc, char *argv[]);
 int main_reheader(int argc, char *argv[]);
 int main_cut_target(int argc, char *argv[]);
 int main_phase(int argc, char *argv[]);
@@ -189,6 +190,7 @@ static void usage(FILE *fp)
 "\n"
 "  -- Viewing\n"
 "     flags          explain BAM flags\n"
+"     head           header viewer\n"
 "     tview          text alignment viewer\n"
 "     view           SAM<->BAM<->CRAM conversion\n"
 "     depad          convert padded BAM to unpadded BAM\n"
@@ -242,6 +244,7 @@ int main(int argc, char *argv[])
     else if (strcmp(argv[1], "faidx") == 0)     ret = faidx_main(argc-1, argv+1);
     else if (strcmp(argv[1], "fqidx") == 0)     ret = fqidx_main(argc-1, argv+1);
     else if (strcmp(argv[1], "dict") == 0)      ret = dict_main(argc-1, argv+1);
+    else if (strcmp(argv[1], "head") == 0)      ret = main_head(argc-1, argv+1);
     else if (strcmp(argv[1], "fixmate") == 0)   ret = bam_mating(argc-1, argv+1);
     else if (strcmp(argv[1], "rmdup") == 0)     ret = bam_rmdup(argc-1, argv+1);
     else if (strcmp(argv[1], "markdup") == 0)   ret = bam_markdup(argc-1, argv+1);

--- a/doc/samtools-head.1
+++ b/doc/samtools-head.1
@@ -1,0 +1,66 @@
+'\" t
+.TH samtools-head 1 "5 October 2021" "samtools-1.13" "Bioinformatics tools"
+.SH NAME
+samtools head \- view SAM/BAM/CRAM file headers
+.\"
+.\" Copyright (C) 2021 University of Glasgow.
+.\"
+.\" Author: John Marshall <jmarshall@hey.com>
+.\"
+.\" Permission is hereby granted, free of charge, to any person obtaining a
+.\" copy of this software and associated documentation files (the "Software"),
+.\" to deal in the Software without restriction, including without limitation
+.\" the rights to use, copy, modify, merge, publish, distribute, sublicense,
+.\" and/or sell copies of the Software, and to permit persons to whom the
+.\" Software is furnished to do so, subject to the following conditions:
+.\"
+.\" The above copyright notice and this permission notice shall be included in
+.\" all copies or substantial portions of the Software.
+.\"
+.\" THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+.\" IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+.\" FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+.\" THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+.\" LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+.\" FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+.\" DEALINGS IN THE SOFTWARE.
+
+.SH SYNOPSIS
+.B samtools head
+.RB [ -h
+.IR INT ]
+.RB [ -n
+.IR INT ]
+.RI [ FILE ]
+
+.SH DESCRIPTION
+By default, prints all headers from the specified input file to standard output
+in SAM format.
+The input alignment file may be in SAM, BAM, or CRAM format; if no \fIFILE\fR
+is specified, standard input will be read.
+With appropriate options, only some of the headers and/or additionally some
+of the alignment records will be printed.
+.P
+The \fBsamtools head\fR command outputs SAM headers exactly as they appear
+in the input file; in particular, it never adds an @PG header itself.
+(Other \fBsamtools\fR commands add such @PG headers to facilitate provenance
+tracking in analysis pipelines, but because \fBsamtools head\fR never outputs
+more than a handful of alignment records it is unsuitable for use in such
+contexts anyway.)
+
+.SH OPTIONS
+.TP 4n
+.BI "-h, --headers " INT
+Display only the first \fIINT\fR header lines.
+By default, all header lines are displayed.
+.TP
+.BI "-n, --records " INT
+Also display the first \fIINT\fR alignment records.
+By default, no alignment records are displayed.
+
+.SH AUTHOR
+Written by John Marshall from the University of Glasgow.
+
+.SH SEE ALSO
+.IR samtools (1),
+.IR samtools-view (1)

--- a/doc/samtools.1
+++ b/doc/samtools.1
@@ -49,6 +49,8 @@ samtools tview aln.sorted.bam ref.fasta
 .PP
 samtools quickcheck in1.bam in2.cram
 .PP
+samtools head in.bam
+.PP
 samtools index aln.sorted.bam
 .PP
 samtools sort -T /tmp/aln.sorted -o aln.sorted.bam aln.bam
@@ -203,6 +205,16 @@ intensive tasks on them.
 This command will exit with a non-zero exit code if any input files don't have a
 valid header or are missing an EOF block. Otherwise it will exit successfully
 (with a zero exit code).
+
+.TP \"-------- head
+.B head
+samtools head
+.RI [ options ]
+.IR in.sam | in.bam | in.cram
+
+Prints the input file's headers and optionally also its first few alignment
+records. This command always displays the headers as they are in the file,
+never adding an extra @PG header itself.
 
 .TP \"-------- index
 .B index
@@ -1194,6 +1206,7 @@ for further authorship.
 .IR samtools-flags (1),
 .IR samtools-flagstat (1),
 .IR samtools-fqidx (1),
+.IR samtools-head (1),
 .IR samtools-idxstats (1),
 .IR samtools-import (1),
 .IR samtools-index (1),


### PR DESCRIPTION
Sadly this has been gestating since January 2020… but [here it is finally](https://twitter.com/jomarnz/status/1420393439535960064). To be followed by a bcftools PR to add a similar `bcftools head` command.

`samtools head` prints the input file's headers and optionally also its first few alignment records. (This command always displays the headers as they are in the file, never adding an extra `@PG` header itself.)