### PR TITLE
Fix coverage documentation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -70,6 +70,9 @@ Bug fixes:
  * Fix "samtools fastq" handling of dual index tags on single-ended
    input. (#1474)
 
+ * Improve "samtools coverage" documentation. (#1521; fixes #1504.
+   Reported by Peter Menzel)
+
 Non user-visible changes and build improvements:
 
  * Replace Curses mvprintw() with va_list-based

--- a/coverage.c
+++ b/coverage.c
@@ -139,7 +139,7 @@ static int usage() {
             "  endpos      End position (or sequence length)\n"
             "  numreads    Number reads aligned to the region (after filtering)\n"
             "  covbases    Number of covered bases with depth >= 1\n"
-            "  coverage    Proportion of covered bases [0..1]\n"
+            "  coverage    Percentage of covered bases [0..100]\n"
             "  meandepth   Mean depth of coverage\n"
             "  meanbaseq   Mean baseQ in covered region\n"
             "  meanmapq    Mean mapQ of selected reads\n"

--- a/doc/samtools-coverage.1
+++ b/doc/samtools-coverage.1
@@ -59,7 +59,7 @@ startpos	Start position
 endpos	End position (or sequence length)
 numreads	Number reads aligned to the region (after filtering)
 covbases	Number of covered bases with depth >= 1
-coverage	Proportion of covered bases [0..1]
+coverage	Percentage of covered bases [0..100]
 meandepth	Mean depth of coverage
 meanbaseq	Mean baseQ in covered region
 meanmapq	Mean mapQ of selected reads


### PR DESCRIPTION
The proportion of bases covered is output as a percentage.

Fixes #1504
