### PR TITLE
Fix man page `.EX` usage [minor]

### DIFF
--- a/doc/samtools-ampliconstats.1
+++ b/doc/samtools-ampliconstats.1
@@ -369,10 +369,10 @@ Number of BAM/CRAM (de)compression threads to use in addition to main thread [0]
 To run ampliconstats on a directory full of CRAM files and then
 produce a series of PNG images named "mydata*.png":
 
-.EE 2
+.EX 2
 samtools ampliconstats V3/nCoV-2019.bed /path/*.cram > astats
 plot-ampliconstats -size 1200,900 mydata astats
-.EX
+.EE
 
 .SH AUTHOR
 .PP

--- a/doc/samtools-flagstat.1
+++ b/doc/samtools-flagstat.1
@@ -156,7 +156,7 @@ For the default format,
 shows the count as a percentage of the total number of QC-passed or QC-failed
 reads after the category name.
 For example:
-.EX
+.EX 4
 32 + 0 mapped (94.12% : N/A)
 .EE
 

--- a/doc/samtools-markdup.1
+++ b/doc/samtools-markdup.1
@@ -189,22 +189,22 @@ They can optionally be marked as duplicates if they have a primary that is also
 a duplicate.    
 .SH EXAMPLES
 This first collate command can be omitted if the file is already name ordered or collated:
-.EX
+.EX 4
 samtools collate -o namecollate.bam example.bam
 .EE
 
 Add ms and MC tags for markdup to use later:
-.EX
+.EX 4
 samtools fixmate -m namecollate.bam fixmate.bam
 .EE
 
 Markdup needs position order:
-.EX
+.EX 4
 samtools sort -o positionsort.bam fixmate.bam
 .EE
 
 Finally mark duplicates:
-.EX
+.EX 4
 samtools markdup positionsort.bam markdup.bam
 .EE
 


### PR DESCRIPTION
Add missing `.EX` arguments. Some of the more recent man pages (import, fasta) use `.EX 4` to set off the examples more clearly than `.EX 2` does, so I've followed that precedent.