### PR TITLE
Add `samtools head -e EXPR` header filtering option [DRAFT]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ padding.o: padding.c config.h $(htslib_kstring_h) $(htslib_sam_h) $(htslib_faidx
 phase.o: phase.c config.h $(htslib_hts_h) $(htslib_sam_h) $(htslib_kstring_h) $(sam_opts_h) $(samtools_h) $(htslib_hts_os_h) $(htslib_kseq_h) $(htslib_khash_h) $(htslib_ksort_h)
 sam_opts.o: sam_opts.c config.h $(sam_opts_h)
 sam_utils.o: sam_utils.c config.h $(samtools_h)
-sam_view.o: sam_view.c config.h $(htslib_sam_h) $(htslib_faidx_h) $(htslib_khash_h) $(htslib_thread_pool_h) $(htslib_hts_expr_h) $(samtools_h) $(sam_opts_h) $(bam_h) $(bedidx_h)
+sam_view.o: sam_view.c config.h $(htslib_sam_h) $(htslib_faidx_h) $(htslib_khash_h) $(htslib_kstring_h) $(htslib_thread_pool_h) $(htslib_hts_expr_h) $(samtools_h) $(sam_opts_h) $(bam_h) $(bedidx_h)
 sample.o: sample.c config.h $(sample_h) $(htslib_khash_h)
 stats_isize.o: stats_isize.c config.h $(stats_isize_h) $(htslib_khash_h)
 stats.o: stats.c config.h $(htslib_faidx_h) $(htslib_sam_h) $(htslib_hts_h) $(htslib_hts_defs_h) $(samtools_h) $(htslib_khash_h) $(htslib_kstring_h) $(stats_isize_h) $(sam_opts_h) $(bedidx_h)

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,12 @@
 Release a.b
 -----------
 
+ * New "samtools head" subcommand for conveniently displaying the headers
+   of a SAM, BAM, or CRAM file. Without options, this is equivalent to
+   `samtools view --header-only --no-PG` but more succinct and memorable.
+   (#1517; thanks to John Marshall)
+
+
 Release 1.14 (22nd October 2021)
 --------------------------------
 

--- a/bamtk.c
+++ b/bamtk.c
@@ -47,6 +47,7 @@ int bam_fillmd(int argc, char *argv[]);
 int bam_idxstats(int argc, char *argv[]);
 int bam_markdup(int argc, char *argv[]);
 int main_samview(int argc, char *argv[]);
+int main_head(int argc, char *argv[]);
 int main_reheader(int argc, char *argv[]);
 int main_cut_target(int argc, char *argv[]);
 int main_phase(int argc, char *argv[]);
@@ -189,6 +190,7 @@ static void usage(FILE *fp)
 "\n"
 "  -- Viewing\n"
 "     flags          explain BAM flags\n"
+"     head           header viewer\n"
 "     tview          text alignment viewer\n"
 "     view           SAM<->BAM<->CRAM conversion\n"
 "     depad          convert padded BAM to unpadded BAM\n"
@@ -242,6 +244,7 @@ int main(int argc, char *argv[])
     else if (strcmp(argv[1], "faidx") == 0)     ret = faidx_main(argc-1, argv+1);
     else if (strcmp(argv[1], "fqidx") == 0)     ret = fqidx_main(argc-1, argv+1);
     else if (strcmp(argv[1], "dict") == 0)      ret = dict_main(argc-1, argv+1);
+    else if (strcmp(argv[1], "head") == 0)      ret = main_head(argc-1, argv+1);
     else if (strcmp(argv[1], "fixmate") == 0)   ret = bam_mating(argc-1, argv+1);
     else if (strcmp(argv[1], "rmdup") == 0)     ret = bam_rmdup(argc-1, argv+1);
     else if (strcmp(argv[1], "markdup") == 0)   ret = bam_markdup(argc-1, argv+1);

--- a/doc/samtools-head.1
+++ b/doc/samtools-head.1
@@ -1,0 +1,66 @@
+'\" t
+.TH samtools-head 1 "5 October 2021" "samtools-1.13" "Bioinformatics tools"
+.SH NAME
+samtools head \- view SAM/BAM/CRAM file headers
+.\"
+.\" Copyright (C) 2021 University of Glasgow.
+.\"
+.\" Author: John Marshall <jmarshall@hey.com>
+.\"
+.\" Permission is hereby granted, free of charge, to any person obtaining a
+.\" copy of this software and associated documentation files (the "Software"),
+.\" to deal in the Software without restriction, including without limitation
+.\" the rights to use, copy, modify, merge, publish, distribute, sublicense,
+.\" and/or sell copies of the Software, and to permit persons to whom the
+.\" Software is furnished to do so, subject to the following conditions:
+.\"
+.\" The above copyright notice and this permission notice shall be included in
+.\" all copies or substantial portions of the Software.
+.\"
+.\" THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+.\" IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+.\" FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+.\" THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+.\" LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+.\" FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+.\" DEALINGS IN THE SOFTWARE.
+
+.SH SYNOPSIS
+.B samtools head
+.RB [ -h
+.IR INT ]
+.RB [ -n
+.IR INT ]
+.RI [ FILE ]
+
+.SH DESCRIPTION
+By default, prints all headers from the specified input file to standard output
+in SAM format.
+The input alignment file may be in SAM, BAM, or CRAM format; if no \fIFILE\fR
+is specified, standard input will be read.
+With appropriate options, only some of the headers and/or additionally some
+of the alignment records will be printed.
+.P
+The \fBsamtools head\fR command outputs SAM headers exactly as they appear
+in the input file; in particular, it never adds an @PG header itself.
+(Other \fBsamtools\fR commands add such @PG headers to facilitate provenance
+tracking in analysis pipelines, but because \fBsamtools head\fR never outputs
+more than a handful of alignment records it is unsuitable for use in such
+contexts anyway.)
+
+.SH OPTIONS
+.TP 4n
+.BI "-h, --headers " INT
+Display only the first \fIINT\fR header lines.
+By default, all header lines are displayed.
+.TP
+.BI "-n, --records " INT
+Also display the first \fIINT\fR alignment records.
+By default, no alignment records are displayed.
+
+.SH AUTHOR
+Written by John Marshall from the University of Glasgow.
+
+.SH SEE ALSO
+.IR samtools (1),
+.IR samtools-view (1)

--- a/doc/samtools.1
+++ b/doc/samtools.1
@@ -49,6 +49,8 @@ samtools tview aln.sorted.bam ref.fasta
 .PP
 samtools quickcheck in1.bam in2.cram
 .PP
+samtools head in.bam
+.PP
 samtools index aln.sorted.bam
 .PP
 samtools sort -T /tmp/aln.sorted -o aln.sorted.bam aln.bam
@@ -203,6 +205,16 @@ intensive tasks on them.
 This command will exit with a non-zero exit code if any input files don't have a
 valid header or are missing an EOF block. Otherwise it will exit successfully
 (with a zero exit code).
+
+.TP \"-------- head
+.B head
+samtools head
+.RI [ options ]
+.IR in.sam | in.bam | in.cram
+
+Prints the input file's headers and optionally also its first few alignment
+records. This command always displays the headers as they are in the file,
+never adding an extra @PG header itself.
 
 .TP \"-------- index
 .B index
@@ -1194,6 +1206,7 @@ for further authorship.
 .IR samtools-flags (1),
 .IR samtools-flagstat (1),
 .IR samtools-fqidx (1),
+.IR samtools-head (1),
 .IR samtools-idxstats (1),
 .IR samtools-import (1),
 .IR samtools-index (1),

--- a/doc/samtools.1
+++ b/doc/samtools.1
@@ -993,12 +993,12 @@ Boolean:	&&, ||	Logical AND / OR
 Expressions are computed using floating point mathematics, so "10 / 4"
 evaluates to 2.5 rather than 2.  They may be written as integers in
 decimal or "0x" plus hexadecimal, and floating point with or without
-exponents.However operations that require integers first do an
+exponents.  However operations that require integers first do an
 implicit type conversion, so "7.9 % 5" is 2 and "7.9 & 4.1" is
 equivalent to "7 & 4", which is 4.  Strings are always specified using
 double quotes.  To get a double quote in a string, use backslash.
 Similarly a double backslash is used to get a literal backslash.  For
-example \fBab\\"c\\\\d\fR is the string \fBab"c\\d\fR.
+example \fB"ab\\"c\\\\d"\fR is the string \fBab"c\\d\fR.
 
 Comparison operators are evaluated as a match being 1 and a mismatch
 being 0, thus "(2 > 1) + (3 < 5)" evaluates as 2.
@@ -1093,6 +1093,19 @@ strings.  This means that "avg(qual)" does not produce an error for
 records that have both seq and qual of "*".  This value will fail any
 conditional checks, so e.g. "avg(qual) > 20" works and will not report
 these records.
+
+.SS HEADER FILTER EXPRESSIONS
+
+Headers can be filtered using the same operators and the following variables:
+
+.TS
+lb l l .
+type	str	Header type code (HD/SQ/etc)
+@HD/etc	int	True if the header is of the specified type
+[XX]	str	Value of the XX-tagged field
+[XX:i]	int	Integer value of the XX-tagged field
+[XX:f]	float	Floating point value of the XX-tagged field
+.TE
 
 .PP
 .SH ENVIRONMENT VARIABLES

--- a/sam_view.c
+++ b/sam_view.c
@@ -1201,6 +1201,7 @@ static int head_usage(FILE *fp, int exit_status)
     fprintf(fp,
 "Usage: samtools head [OPTION]... [FILE]\n"
 "Options:\n"
+"  -e, --expr STR      Show only header lines matching the filter expression STR\n"
 "  -h, --headers INT   Display INT header lines [all]\n"
 "  -n, --records INT   Display INT alignment record lines [none]\n"
 );
@@ -1212,20 +1213,23 @@ int main_head(int argc, char *argv[])
 {
     static const struct option lopts[] = {
         SAM_OPT_GLOBAL_OPTIONS('-', 0, '-', '-', 'T', '@'),
+        { "expr", required_argument, NULL, 'e' },
+        { "expression", required_argument, NULL, 'e' },
         { "headers", required_argument, NULL, 'h' },
         { "records", required_argument, NULL, 'n' },
         { NULL, 0, NULL, 0 }
     };
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
 
-    int all_headers = 1;
-    uint64_t nheaders = 0;
+    uint64_t nheaders = UINT64_MAX;
     uint64_t nrecords = 0;
+    const char *filter_expr = NULL;
 
     int c, nargs;
-    while ((c = getopt_long(argc, argv, "h:n:T:@:", lopts, NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "e:h:n:T:@:", lopts, NULL)) >= 0)
         switch (c) {
-        case 'h': all_headers = 0; nheaders = strtoull(optarg, NULL, 0); break;
+        case 'e': filter_expr = optarg; break;
+        case 'h': nheaders = strtoull(optarg, NULL, 0); break;
         case 'n': nrecords = strtoull(optarg, NULL, 0); break;
         default:
             if (parse_sam_global_opt(c, optarg, lopts, &ga) == 0) break;
@@ -1244,6 +1248,7 @@ int main_head(int argc, char *argv[])
     sam_hdr_t *hdr = NULL;
     kstring_t str = KS_INITIALIZE;
     bam1_t *b = NULL;
+    hts_filter_t *filter = NULL;
 
     const char *fname = (nargs == 1)? argv[optind] : "-";
     fp = sam_open_format(fname, "r", &ga.in);
@@ -1257,6 +1262,14 @@ int main_head(int argc, char *argv[])
 
     if (ga.nthreads > 0) hts_set_threads(fp, ga.nthreads);
 
+    if (filter_expr) {
+        filter = hts_filter_init(filter_expr);
+        if (filter == NULL) {
+            print_error("head", "failed to initialise filter");
+            goto err;
+        }
+    }
+
     hdr = sam_hdr_read(fp);
     if (hdr == NULL) {
         if (strcmp(fname, "-") != 0)
@@ -1266,25 +1279,21 @@ int main_head(int argc, char *argv[])
         goto err;
     }
 
-    if (all_headers) {
-        fputs(sam_hdr_str(hdr), stdout);
-    }
-    else if (nheaders > 0) {
-        const char *text = sam_hdr_str(hdr);
-        const char *lim = text;
-        uint64_t n;
-        for (n = 0; n < nheaders; n++) {
-            lim = strchr(lim, '\n');
-            if (lim) lim++;
-            else break;
+    uint64_t n = 0;
+    sam_hdr_line_itr_t *iter;
+    for (iter = sam_hdr_line_itr_first(hdr); iter && n < nheaders; iter = sam_hdr_line_itr_next(hdr, iter)) {
+        if (filter && !sam_hdr_passes_filter(hdr, iter, filter)) continue;
+
+        if (sam_hdr_find_line_iter(iter, &str) < 0) {
+            print_error("head", "couldn't format header line");
+            goto err;
         }
-        if (lim) fwrite(text, lim - text, 1, stdout);
-        else fputs(text, stdout);
+        puts(ks_str(&str));
+        n++;
     }
 
     if (nrecords > 0) {
         b = bam_init1();
-        uint64_t n;
         int r;
         for (n = 0; n < nrecords && (r = sam_read1(fp, hdr, b)) >= 0; n++) {
             if (sam_format1(hdr, b, &str) < 0) {
@@ -1298,16 +1307,18 @@ int main_head(int argc, char *argv[])
             goto err;
         }
         bam_destroy1(b);
-        ks_free(&str);
     }
 
+    hts_filter_free(filter);
     sam_hdr_destroy(hdr);
     sam_close(fp);
+    ks_free(&str);
     sam_global_args_free(&ga);
 
     return EXIT_SUCCESS;
 
 err:
+    hts_filter_free(filter);
     if (fp) sam_close(fp);
     sam_hdr_destroy(hdr);
     bam_destroy1(b);


### PR DESCRIPTION
A draft PR on top of #1517 that adds a `-e, --expr EXPR` option to the `samtools head` command, to allow arbitrary filtering of which headers to display.

Requires PR samtools/htslib#1351, and adds draft documentation of that PR's proposed header filter variables to _doc/samtools.1_.

This enables useful functionality such as:

```sh
# View only read groups
samtools head -e 'type == "RG"' foo.bam

# View only "interesting" chromosomes
samtools head -e '@SQ && [SN] !~ "^GL"' bar.bam
samtools head -e '@SQ && [LN:i] > 1000000' baz.bam
```