### PR TITLE
Fixes the documentation for mpileup --output-BP-5.

### DIFF
--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -1100,14 +1100,8 @@ int bam_mpileup(int argc, char *argv[])
         case '6': mplp.flag |= MPLP_ILLUMINA13; break;
         case 'R': mplp.flag |= MPLP_IGNORE_RG; break;
         case 's': mplp.flag |= MPLP_PRINT_MAPQ_CHAR; break;
-        case 'O':
-            if (!(mplp.flag & MPLP_PRINT_QPOS5))
-                mplp.flag |= MPLP_PRINT_QPOS;
-            break;
-        case  14:
-            mplp.flag |=  MPLP_PRINT_QPOS5;
-            mplp.flag &= ~MPLP_PRINT_QPOS;
-            break;
+        case 'O': mplp.flag |= MPLP_PRINT_QPOS; break;
+        case  14: mplp.flag |= MPLP_PRINT_QPOS5; break;
         case 'M': mplp.flag |= MPLP_PRINT_MODS; break;
         case 'C': mplp.capQ_thres = atoi(optarg); break;
         case 'q': mplp.min_mq = atoi(optarg); break;

--- a/doc/samtools-mpileup.1
+++ b/doc/samtools-mpileup.1
@@ -146,11 +146,11 @@ Base qualities, encoded as ASCII characters.
 Alignment mapping qualities, encoded as ASCII characters.
 (Column only present when \fB-s\fR/\fB--output-MQ\fR is used.)
 .IP \(ci 2
-Comma-separated 1-based positions within the alignments, e.g., 5 indicates
+Comma-separated 1-based positions within the alignments, in the
+orientation shown in the input file.  E.g., 5 indicates
 that it is the fifth base of the corresponding read that is mapped to this
 genomic position.
-(Column only present when \fB-O\fR/\fB--output-BP\fR or
-\fB--output-BP-5\fR is used.)
+(Column only present when \fB-O\fR/\fB--output-BP\fR is used.)
 .IP \(ci 2
 Additional comma-separated read field columns,
 as selected via \fB--output-extra\fR.
@@ -163,6 +163,12 @@ The fields selected appear in the same order as in SAM:
 (displayed numerically),
 .BR RNEXT ,
 .BR PNEXT .
+.IP \(ci 2
+Comma-separated 1-based positions within the alignments, in 5' to 3'
+orientation.  E.g., 5 indicates that it is the fifth base of the
+corresponding read as produced by the sequencing instrument, that is
+mapped to this genomic position. (Column only present when \fB--output-BP-5\fR is used.)
+
 .IP \(ci 2
 Additional read tag field columns, as selected via \fB--output-extra\fR.
 These columns are formatted as determined by \fB--output-sep\fR and
@@ -295,11 +301,10 @@ or
 .TP
 .B -O, --output-BP
 Output base positions on reads in orientation listed in the SAM file
-(left to right). This is mutually exclusive with \fB--output-BP-5\fR.
+(left to right).
 .TP
 .B --output-BP-5
 Output base positions on reads in their original 5' to 3' orientation.
-This is mutually exclusive with \fB--output-BP\fR.
 .TP
 .B -s, --output-MQ
 Output mapping qualities encoded as ASCII characters.


### PR DESCRIPTION
The original intention of this was to modify the orientation of the `--output-BP` field, as originally requested.  Due to lack of research into the original code, sadly this was moved to the end of the list of columns.  We didn't test in conjunction with everything else turned on.

It was decided that we should not fix this as it would become incompatible with the previous release, so it's now been documented.

However given it's now its own column instead of modifying the existing column, `--output-BP-5` is no longer mutually exclusive with `--output-BP`.

Fixes #1534 (albeit not in the ideal way)