### PR TITLE
Minor fixes to cullage of mpileup vcf/bcf output.

### DIFF
--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -1054,7 +1054,7 @@ int bam_mpileup(int argc, char *argv[])
         {NULL, 0, NULL, 0}
     };
 
-    while ((c = getopt_long(argc, argv, "Agf:r:l:q:Q:uRC:Bd:b:o:EG:6OsVvxXaM",lopts,NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "Af:r:l:q:Q:RC:Bd:b:o:EG:6OsxXaM",lopts,NULL)) >= 0) {
         switch (c) {
         case 'x': mplp.flag &= ~MPLP_SMART_OVERLAPS; break;
         case  1 :

--- a/doc/samtools-mpileup.1
+++ b/doc/samtools-mpileup.1
@@ -278,20 +278,6 @@ Write pileup output to
 .IR FILE ,
 rather than the default of standard output.
 
-(The same short option is used for both the deprecated
-.BR --open-prob
-option and
-.BR --output .
-If
-.BR -o 's
-argument contains any non-digit characters other than a leading + or - sign,
-it is interpreted as
-.BR --output .
-Usually the filename extension will take care of this, but to write to an
-entirely numeric filename use
-.B -o ./123
-or
-.BR "--output 123" .)
 .TP
 .B -O, --output-BP
 Output base positions on reads in orientation listed in the SAM file


### PR DESCRIPTION
- The -g, -u and -v options are no longer in the getopt_long option  list.

- The man page no longer mentions the two uses of -o (`--output` vs `--open_prob`).

Fixes comments originally raised in #1523.