### PR TITLE
Fixes a bug detected by clang 13 with -Wformat-security.

### DIFF
--- a/bam_tview_curses.c
+++ b/bam_tview_curses.c
@@ -208,9 +208,8 @@ static void tv_win_listref(curses_tview_t *tv, int* matches, int num_matches,
             mvwprintw(tv->wlistref, i+1, 1, ">");
         }
         snprintf(str, TV_MAX_GOTO, "%s  length: %d", ref, len);
-        mvwprintw(tv->wlistref, i+1, 2, str);
-
-    }
+        mvwprintw(tv->wlistref, i+1, 2, "%s", str);
+   }
 
     if (upper_bound < num_matches) {
         mvwprintw(tv->wlistref, TV_MAX_LISTREF-1, TV_MAX_GOTO+8, "|");


### PR DESCRIPTION
The mvwprintw message needs to be an argument to a "%s" format, to
avoid the str itself containing % rules.  In particular a reference
containing %n will cause it to write to illegal (or worse, legal)
addresses.