### PR TITLE
Improve automatic file type detection with view -u / -1.

### DIFF
--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -171,12 +171,17 @@ Output in the BAM format.
 Output in the CRAM format (requires -T).
 .TP
 .BR -1 ", " --fast
-Enable fast BAM compression (implies -b).
+Enable fast compression.  This also changes the default output format to
+BAM, but this can be overridden by the explicit format options or
+using a filename with a known suffix.
 .TP
 .BR -u ", " --uncompressed
-Output uncompressed BAM. This option saves time spent on
-compression/decompression and is thus preferred when the output is piped
-to another samtools command.
+Output uncompressed data. This also changes the default output format to
+BAM, but this can be overridden by the explicit format options or
+using a filename with a known suffix.
+
+This option saves time spent on compression/decompression and is thus
+preferred when the output is piped to another samtools command.
 .TP
 .BR -h ", " --with-header
 Include the header in the output.


### PR DESCRIPTION
Previously `-u` and `-1` were documented to also enable BAM mode. When they were written this made sense.  There were two choices - uncompressed SAM or BAM (uncompressed or otherwise).  Specifying the compression level inevitably meant BAM.

Since then we've gained the ability to output SAM.gz and CRAM, and even compressed fasta and fastq.  Plus we've also gained automatic file type selection by output filename. Hence it really doesn't make much sense for

    samtools view -o out.cram -1 in.bam

to output a BAM file named out.cram.

To ensure compatibility, the default output format is still SAM, or BAM when `-1` / `-u` are used, but if and only if a filename is used and it doesn't indicate otherwise.  This means the recommended pipe method of `samtools view -u foo.bam | ...` still does the same thing.

In the process of doing this I also fixed some bug in `--write-index` when used in conjunction with `-U`.