### PR TITLE
Added --min-BQ and --min-MQ options to depth.

### DIFF
--- a/bam2depth.c
+++ b/bam2depth.c
@@ -717,8 +717,10 @@ static void usage_exit(FILE *fp, int exit_status)
     fprintf(fp, "  -H           Print a file header line\n");
     fprintf(fp, "  -l INT       Minimum read length [0]\n");
     fprintf(fp, "  -o FILE      Write output to FILE [stdout]\n");
-    fprintf(fp, "  -q INT       Minimum base quality [0]\n");
-    fprintf(fp, "  -Q INT       Minimum mapping quality [0]\n");
+    fprintf(fp, "  -q, --min-BQ INT\n"
+                "               Filter bases with base quality smaller than INT [0]\n");
+    fprintf(fp, "  -Q, --min-MQ INT\n"
+                "               Filter alignments with mapping quality smaller than INT [0]\n");
     fprintf(fp, "  -H           Print a file header\n");
     fprintf(fp, "  -J           Include reads with deletions in depth computation\n");
     fprintf(fp, "  -s           Do not count overlapping reads within a template\n");
@@ -750,6 +752,10 @@ int main_depth(int argc, char *argv[])
 
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
     static const struct option lopts[] = {
+        {"min-MQ", required_argument, NULL, 'Q'},
+        {"min-mq", required_argument, NULL, 'Q'},
+        {"min-BQ", required_argument, NULL, 'q'},
+        {"min-bq", required_argument, NULL, 'q'},
         SAM_OPT_GLOBAL_OPTIONS('-', 0, '-', '-', '-', '@'),
         {NULL, 0, NULL, 0}
     };

--- a/bedcov.c
+++ b/bedcov.c
@@ -81,6 +81,8 @@ int main_bedcov(int argc, char *argv[])
 
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
     static const struct option lopts[] = {
+        {"min-MQ", required_argument, NULL, 'Q'},
+        {"min-mq", required_argument, NULL, 'Q'},
         SAM_OPT_GLOBAL_OPTIONS('-', 0, '-', '-', 0, '-'),
         { NULL, 0, NULL, 0 }
     };
@@ -116,7 +118,7 @@ int main_bedcov(int argc, char *argv[])
     if (usage || optind + 2 > argc) {
         fprintf(stderr, "Usage: samtools bedcov [options] <in.bed> <in1.bam> [...]\n\n");
         fprintf(stderr, "Options:\n");
-        fprintf(stderr, "      -Q <int>            mapping quality threshold [0]\n");
+        fprintf(stderr, "      -Q, --min-MQ <int>  mapping quality threshold [0]\n");
         fprintf(stderr, "      -X                  use customized index files\n");
         fprintf(stderr, "      -g <flags>          remove the specified flags from the set used to filter out reads\n");
         fprintf(stderr, "      -G <flags>          add the specified flags to the set used to filter out reads\n"

--- a/doc/samtools-bedcov.1
+++ b/doc/samtools-bedcov.1
@@ -57,8 +57,8 @@ Counts for each alignment file supplied are reported in separate columns.
 
 .SH OPTIONS
 .TP
-.BI "-Q " INT
-.RI "Only count reads with mapping quality greater than " INT
+.BI "-Q,\ --min-MQ " INT
+.RI "Only count reads with mapping quality greater than or equal to " INT
 .TP
 .BI "-g " FLAGS
 By default, reads that have any of the flags UNMAP, SECONDARY, QCFAIL,

--- a/doc/samtools-depth.1
+++ b/doc/samtools-depth.1
@@ -97,10 +97,10 @@ is identical to
 .RI "Write output to " FILE ".  Using \*(lq-\*(rq for " FILE
 will send the output to stdout (also the default if this option is not used).
 .TP
-.BI "-q " INT
+.BI "-q,\ --min-BQ " INT
 .RI "Only count reads with base quality greater than or equal to " INT
 .TP
-.BI "-Q " INT
+.BI "-Q,\ --min-MQ " INT
 .RI "Only count reads with mapping quality greater than or equal to " INT
 .TP
 .BI "-r " CHR ":" FROM "-" TO

--- a/doc/samtools-phase.1
+++ b/doc/samtools-phase.1
@@ -82,7 +82,7 @@ Maximum length for local phasing. [13]
 .BI -q \ INT
 Minimum Phred-scaled LOD to call a heterozygote. [40]
 .TP
-.BI -Q \ INT
+.BI "-Q,\ --min-BQ " INT
 Minimum base quality to be used in het calling. [13]
 .TP
 .BI --no-PG

--- a/phase.c
+++ b/phase.c
@@ -597,6 +597,8 @@ int main_phase(int argc, char *argv[])
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
     static const struct option lopts[] = {
         SAM_OPT_GLOBAL_OPTIONS('-', 0, 0, 0, 0, '-'),
+        {"min-BQ", required_argument, NULL, 'Q'},
+        {"min-bq", required_argument, NULL, 'Q'},
         {"no-PG", no_argument, NULL, 1},
         { NULL, 0, NULL, 0 }
     };
@@ -630,7 +632,8 @@ int main_phase(int argc, char *argv[])
         fprintf(stderr, "Options: -k INT    block length [%d]\n", g.k);
         fprintf(stderr, "         -b STR    prefix of BAMs to output [null]\n");
         fprintf(stderr, "         -q INT    min het phred-LOD [%d]\n", g.min_varLOD);
-        fprintf(stderr, "         -Q INT    min base quality in het calling [%d]\n", g.min_baseQ);
+        fprintf(stderr, "         -Q, --min-BQ INT\n"
+                        "                   min base quality in het calling [%d]\n", g.min_baseQ);
         fprintf(stderr, "         -D INT    max read depth [%d]\n", g.max_depth);
 //      fprintf(stderr, "         -l FILE   list of sites to phase [null]\n");
         fprintf(stderr, "         -F        do not attempt to fix chimeras\n");


### PR DESCRIPTION
These match the equivalent long options found in samtools mpileup,
which gives a consistent way of specifying the base and mapping
quality filters.  This is in contrast to the short options, -q and -Q,
which are reversed between the two subcommands (historic).

Also updated the rarely used phase and bedcov commands, with --min-BQ
and/or --min-MQ as appropriate.

Fixes #1580