### PR TITLE
Fix/stats memory fail read header

### DIFF
--- a/stats.c
+++ b/stats.c
@@ -1063,6 +1063,7 @@ static void remove_overlaps(bam1_t *bam_line, khash_t(qn2pair) *read_pairs, stat
         pc->chunks = calloc(pc->m, sizeof(hts_pair_pos_t));
         if ( !pc->chunks ) {
             fprintf(stderr, "Error allocating memory\n");
+            free(pc);
             return;
         }
 

--- a/stats.c
+++ b/stats.c
@@ -2453,13 +2453,13 @@ int main_stats(int argc, char *argv[])
     }
 
     if (init_stat_info_fname(info, bam_fname, &ga.in)) {
-        free(info);
+        cleanup_stats_info(info);
         return 1;
     }
 
     if (has_index_file && !(bam_idx_fname = argv[optind++])) {
         fprintf(stderr, "No index file provided\n");
-        free(info);
+        cleanup_stats_info(info);
         return 1;
     }
 


### PR DESCRIPTION
Some blocks weren't freed when stats failed to read the header of a file.