### PR TITLE
Remove unnecessary #include [minor]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ bam_mate.o: bam_mate.c config.h $(htslib_thread_pool_h) $(sam_opts_h) $(htslib_k
 bam_md.o: bam_md.c config.h $(htslib_faidx_h) $(htslib_sam_h) $(htslib_kstring_h) $(htslib_thread_pool_h) $(sam_opts_h) $(samtools_h)
 bam_plbuf.o: bam_plbuf.c config.h $(htslib_hts_h) $(htslib_sam_h) $(bam_plbuf_h)
 bam_consensus.o: bam_consensus.c config.h $(htslib_sam_h) $(samtools_h) $(sam_opts_h) $(bam_plbuf_h) $(consensus_pileup_h)
-bam_plcmd.o: bam_plcmd.c config.h $(htslib_sam_h) $(htslib_faidx_h) $(htslib_kstring_h) $(htslib_klist_h) $(htslib_khash_str2int_h) $(samtools_h) $(bedidx_h) $(sam_opts_h) $(bam2bcf_h) $(sample_h) $(htslib_cram_h) $(bam_plbuf_h)
+bam_plcmd.o: bam_plcmd.c config.h $(htslib_sam_h) $(htslib_faidx_h) $(htslib_kstring_h) $(htslib_klist_h) $(htslib_khash_str2int_h) $(samtools_h) $(bedidx_h) $(sam_opts_h) $(sample_h) $(htslib_cram_h) $(bam_plbuf_h)
 bam_quickcheck.o: bam_quickcheck.c config.h $(htslib_hts_h) $(htslib_sam_h)
 bam_reheader.o: bam_reheader.c config.h $(htslib_bgzf_h) $(htslib_sam_h) $(htslib_hfile_h) $(htslib_cram_h) $(samtools_h)
 bam_rmdup.o: bam_rmdup.c config.h $(htslib_sam_h) $(sam_opts_h) $(samtools_h) $(bam_h) $(htslib_khash_h)

--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -162,8 +162,6 @@ int pileup_seq(FILE *fp, const bam_pileup1_t *p, hts_pos_t pos,
     return 0;
 }
 
-#include <assert.h>
-#include "bam2bcf.h"
 #include "sample.h"
 
 #define MPLP_NO_COMP    (1<<2)


### PR DESCRIPTION
Since VCF/BCF ouptut was culled in PR #1523, _bam_plcmd.c_ no longer uses _bam2bcf.h_'s functionality. (Nor does it contain any asserts.)

(This makes a difference for pysam: as pysam does not include `tview`, it will omit _bam2bcf.*_ along with _bam_tview*_. So _bam_plcmd.c_ trying to `#include "bam2bcf.h"` would be bad…)