### PR TITLE
Fix crash triggered by combining view --unmap and -c options

### DIFF
--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -202,6 +202,7 @@ total number. All filter options, such as
 and
 .BR -q ,
 are taken into account.
+.RB "The " -p " option is ignored in this mode."
 .TP
 .BR -? ", " --help
 Output long help and exit immediately.

--- a/sam_view.c
+++ b/sam_view.c
@@ -1206,6 +1206,7 @@ int main_samview(int argc, char *argv[])
                 goto view_end;
             }
         }
+        settings.unmap = 0;  // Not valid in counting mode
     }
 
     if (ga.nthreads > 1) {

--- a/test/test.pl
+++ b/test/test.pl
@@ -2501,6 +2501,14 @@ sub test_view
                     out => sprintf("%s.test%03d.sam", $out, $test),
                     compare => $unmapped_expected);
 
+    $test++;
+
+    run_view_test($opts,
+                    msg=> "$test: Unmap dup flagged reads.",
+                    args => ['-c', '-F', 'DUP', '-p', '--no-PG', $dup_sam],
+                    out => sprintf("%s.test%03d.sam", $out, $test),
+                    compare_count => 2);
+
 
     # retrieve reads from a region including their mates
     my $bam = 'test/dat/view.fetch-pairs.bam';


### PR DESCRIPTION
Reads not passing filters would result in an attempt to write a NULL bam record in the path that handles the unmap case.

The solution to mixing these options is to disable the --unmap part, so the count returned is for the number of records that passed any filters.