### PR TITLE
Collected minor manual page formatting improvements

### DIFF
--- a/doc/samtools-ampliconstats.1
+++ b/doc/samtools-ampliconstats.1
@@ -75,76 +75,75 @@ primer choices, only the innermost primer locations are used.
 A summary of output sections is listed below, followed by more
 detailed descriptions.
 
-.TS
-lb lx .
-SS	T{
+.PD 0
+.TP 12
+.B SS
 Amplicon and file counts.  Always comes first
-T}
-AMPLICON	T{
+.TP
+.B AMPLICON
 Amplicon primer locations
-T}
-FSS	T{
+.TP
+.B FSS
 File specific: summary stats
-T}
-FRPERC	T{
+.TP
+.B FRPERC
 File specific: read percentage distribution between amplicons
-T}
-FDEPTH	T{
+.TP
+.B FDEPTH
 File specific: average read depth per amplicon
-T}
-FVDEPTH	T{
+.TP
+.B FVDEPTH
 File specific: average read depth per amplicon, full length only
-T}
-FREADS	T{
+.TP
+.B FREADS
 File specific: numbers of reads per amplicon
-T}
-FPCOV	T{
+.TP
+.B FPCOV
 File specific: percent coverage per amplicon
-T}
-FTCOORD	T{
+.TP
+.B FTCOORD
 File specific: template start,end coordinate frequencies per amplicon
-T}
-FAMP	T{
+.TP
+.B FAMP
 File specific: amplicon correct / double / treble length counts
-T}
-FDP_ALL	T{
+.TP
+.B FDP_ALL
 File specific: template depth per reference base, all templates
-T}
-FDP_VALID	T{
+.TP
+.B FDP_VALID
 File specific: template depth per reference base, valid templates only
-T}
-CSS	T{
+.TP
+.B CSS
 Combined  summary stats
-T}
-CRPERC	T{
+.TP
+.B CRPERC
 Combined: read percentage distribution between amplicons
-T}
-CDEPTH	T{
+.TP
+.B CDEPTH
 Combined: average read depth per amplicon
-T}
-CVDEPTH	T{
+.TP
+.B CVDEPTH
 Combined: average read depth per amplicon, full length only
-T}
-CREADS	T{
+.TP
+.B CREADS
 Combined: numbers of reads per amplicon
-T}
-CPCOV	T{
+.TP
+.B CPCOV
 Combined: percent coverage per amplicon
-T}
-CTCOORD	T{
+.TP
+.B CTCOORD
 Combined: template coordinates per amplicon
-T}
-CAMP	T{
+.TP
+.B CAMP
 Combined: amplicon correct / double / treble length counts
-T}
-CDP_ALL	T{
+.TP
+.B CDP_ALL
 Combined: template depth per reference base, all templates
-T}
-CDP_VALID	T{
+.TP
+.B CDP_VALID
 Combined: template depth per reference base, valid templates only
-T}
-.TE
-
+.PD
+.PP
 File specific sections start with both the section key and the
 filename basename (minus directory and .sam, .bam or .cram suffix).
 

--- a/doc/samtools-collate.1
+++ b/doc/samtools-collate.1
@@ -59,15 +59,15 @@ The output from this command should be suitable for any operation that
 requires all reads from the same template to be grouped together.
 
 If present, <prefix> is used to name the temporary files that collate
-uses when sorting the data.  If neither the '-O' nor '-o' options are used,
+uses when sorting the data.  If neither the \fB-O\fR nor \fB-o\fR options are used,
 <prefix> must be present and collate will use it to make an output file name
 by appending a suffix depending on the format written (.bam by default).
 
-If either the -O or -o option is used, <prefix> is optional.  If <prefix>
+If either the \fB-O\fR or \fB-o\fR option is used, <prefix> is optional.  If <prefix>
 is absent, collate will write the temporary files to a system-dependent
 location (/tmp on UNIX).
 
-Using -f for fast mode will output \fBonly\fR primary alignments that have
+Using \fB-f\fR for fast mode will output \fBonly\fR primary alignments that have
 either the READ1 \fBor\fR READ2 flags set (but not both).
 Any other alignment records will be filtered out.
 The collation will only work correctly if there are no more than two reads
@@ -78,7 +78,7 @@ most pairs as soon as they are found instead of storing them in temporary
 files.
 This allows collate to avoid some work and so finish more quickly compared
 to the standard mode.
-The number of alignments held can be changed using -r, storing more alignments
+The number of alignments held can be changed using \fB-r\fR, storing more alignments
 uses more memory but increases the number of pairs that can be written early.
 
 While collate normally randomises the ordering of read pairs, fast mode

--- a/doc/samtools-flagstat.1
+++ b/doc/samtools-flagstat.1
@@ -71,7 +71,7 @@ quality controls"
 
 Following this, additional categories are given for reads which are:
 
-.RS 18
+.RS 4
 .TP
 primary
 neither 0x100 nor 0x800 bit set
@@ -113,12 +113,11 @@ singletons
 both 0x1 and 0x8 bits set and bit 0x4 not set
 .RE
 
-.RS 10
+.PP
 And finally, two rows are given that additionally filter on the reference
 name (RNAME), mate reference name (MRNM), and mapping quality (MAPQ) fields:
-.RE
 
-.RS 18
+.RS 4
 .TP
 with mate mapped to a different chr
 0x1 bit set and neither 0x4 nor 0x8 bits set and MRNM not equal to RNAME


### PR DESCRIPTION
samtools-ampliconstats.1: Due to Apple's ongoing GPLv3 phobia, macOS ships GNU tbl 1.19.2 from ten years ago, which does not support the `x` tbl column specifier. This resulted in the entire table being omitted from the man page viewer (with the error `unrecognised format '{' … giving up on this table`). Rewrite the table as a `.TP` list instead, suppressing vertical space between the paragraphs with `.PD`. The appearance is identical, except that a spurious blank line added in the table version is prevented.

samtools-collate.1: Use bold for option names.

samtools-flagstat.1: Reduce the excessive indentation.