### PR TITLE
Remove unused variable [trivial]

### DIFF
--- a/coverage.c
+++ b/coverage.c
@@ -55,8 +55,6 @@ DEALINGS IN THE SOFTWARE.  */
 #include "samtools.h"
 #include "sam_opts.h"
 
-const char *VERSION = "0.1";
-
 typedef struct {  // auxiliary data structure to hold stats on coverage
     unsigned long long n_covered_bases;
     unsigned long long summed_coverage;


### PR DESCRIPTION
Remove unused variable that should have been removed along with the code that would have used it (see https://github.com/samtools/samtools/pull/992#discussion_r250730876).

Trivial, but `VERSION` does leap out at you when you're examining `nm` output… :smile: