### PR TITLE
Make sam view read error messages more generic.

### DIFF
--- a/sam_view.c
+++ b/sam_view.c
@@ -727,6 +727,7 @@ static int stream_view(samview_settings_t *conf) {
         print_error_errno("view", "could not allocate bam record");
         return 1;
     }
+    errno = 0; // prevent false error messages.
     while ((r = sam_read1(conf->in, conf->header, b)) >= 0) {
         if (process_one_record(conf, b, &write_error) < 0) break;
     }
@@ -754,7 +755,7 @@ static int multi_region_view(samview_settings_t *conf, hts_itr_multi_t *iter)
     bam_destroy1(b);
 
     if (result < -1) {
-        print_error("view", "retrieval of region %d failed due to truncated file or corrupt BAM index file", iter->curr_tid);
+        print_error("view", "retrieval of region #%d failed", iter->curr_tid);
         return 1;
     }
     return write_error;


### PR DESCRIPTION
When doing a range query, assuming that all errors are due to
"truncated file or corrupt BAM index file" seems somewhat odd.
Mpileup etc don't make such bold claims.

Also for stream_view we reset errno.  Without this the
"print_error_errno" due to some other condition (such as CRAM
reference mismatch) gives confusing errors such as "No such file or
directory". See #1640 for an example of this.