### PR TITLE
Reenable --reference option for samtools depth.

### DIFF
--- a/bam2depth.c
+++ b/bam2depth.c
@@ -724,7 +724,7 @@ static void usage_exit(FILE *fp, int exit_status)
     fprintf(fp, "  -H           Print a file header\n");
     fprintf(fp, "  -J           Include reads with deletions in depth computation\n");
     fprintf(fp, "  -s           Do not count overlapping reads within a template\n");
-    sam_global_opt_help(fp, "-.---@-.");
+    sam_global_opt_help(fp, "-.--.@-.");
     exit(exit_status);
 }
 
@@ -756,7 +756,7 @@ int main_depth(int argc, char *argv[])
         {"min-mq", required_argument, NULL, 'Q'},
         {"min-BQ", required_argument, NULL, 'q'},
         {"min-bq", required_argument, NULL, 'q'},
-        SAM_OPT_GLOBAL_OPTIONS('-', 0, '-', '-', '-', '@'),
+        SAM_OPT_GLOBAL_OPTIONS('-', 0, '-', '-', 0, '@'),
         {NULL, 0, NULL, 0}
     };
 


### PR DESCRIPTION
This has no effect as the reference isn't needed, but it was present in earlier releases so needs to cope with the option for compatibility.

Fixes #1643