### PR TITLE
Fix minor error in samtools consensus man page.

### DIFF
--- a/doc/samtools-consensus.1
+++ b/doc/samtools-consensus.1
@@ -185,7 +185,7 @@ Enables IUPAC ambiguity codes in the consensus output.  Without this
 the output will be limited to A, C, G, T, N and *.
 
 .TP 0
-The following options apply only to the simple (default) consensus mode:
+The following options apply only to the simple consensus mode:
 
 .TP 10
 .BR "-q" ", " --use-qual


### PR DESCRIPTION
When listing options it claimed the "simple" mode is the default one. Elsewhere it correctly reports "bayesian" as default.