### PR TITLE
Rename mpileup --ignore-overlaps option.

### DIFF
--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -946,7 +946,8 @@ static void print_usage(FILE *fp, const mplp_conf_t *mplp)
 "  --ff, --excl-flags STR|INT  filter flags: skip reads with any of the mask bits set\n"
 "                                            [%s]\n", tmp_filter);
     fprintf(fp,
-"  -x, --ignore-overlaps   disable read-pair overlap detection\n"
+"  -x, --ignore-overlaps-removal, --disable-overlap-removal\n"
+"                          disable read-pair overlap detection and removal\n"
 "  -X, --customized-index  use customized index files\n" // -X flag for index filename
 "\n"
 "Output options:\n"
@@ -1032,7 +1033,9 @@ int bam_mpileup(int argc, char *argv[])
         {"min-mq", required_argument, NULL, 'q'},
         {"min-BQ", required_argument, NULL, 'Q'},
         {"min-bq", required_argument, NULL, 'Q'},
-        {"ignore-overlaps", no_argument, NULL, 'x'},
+        // NB: old "--ignore-overlaps" auto-completes to this
+        {"ignore-overlaps-removal",  no_argument, NULL, 'x'},
+        {"disable-overlap-removal",  no_argument, NULL, 'x'},
         {"output-mods", no_argument, NULL, 'M'},
         {"output-BP", no_argument, NULL, 'O'},
         {"output-bp", no_argument, NULL, 'O'},

--- a/doc/samtools-mpileup.1
+++ b/doc/samtools-mpileup.1
@@ -256,9 +256,9 @@ Minimum mapping quality for an alignment to be used [0]
 Minimum base quality for a base to be considered. [13]
 
 Note base-quality 0 is used as a filtering mechanism for overlap
-removal.  Hence using \fB--min-BQ 0\fR will disable the overlap
-removal code and act as if the \fB--ignore-overlaps\fR option has
-been set.
+removal which marks bases as having quality zero and lets the base
+quality filter remove them.  Hence using \fB--min-BQ 0\fR will make
+the overlapping bases reappear, albeit with quality zero.
 .TP
 .BI -r,\ --region \ STR
 Only generate pileup in region. Requires the BAM files to be indexed.
@@ -277,8 +277,19 @@ Required flags: include reads with any of the mask bits set [null]
 Filter flags: skip reads with any of the mask bits set
 [UNMAP,SECONDARY,QCFAIL,DUP]
 .TP
-.B -x,\ --ignore-overlaps
-Disable read-pair overlap detection.
+.B -x,\ --ignore-overlaps-removal, --disable-overlap-removal
+Overlap detection and removal is enabled by default.  This option
+turns it off.
+
+When enabled, where the ends of a read-pair overlap the overlapping
+region will have one base selected and the duplicate base nullified by
+setting its phred score to zero.  It will then be discarded by the
+\fB--min-BQ\fR option unless this is zero.
+
+The quality values of the retained base within an overlap will be the
+summation of the two bases if they agree, or 0.8 times the higher of
+the two bases if they disagree, with the base nucleotide also being
+the higher confident call.
 .TP
 .B -X
 Include customized index file as a part of arguments. See


### PR DESCRIPTION
This is now --ignore-overlaps-removal or --disable-overlap-removal.
The previous name is ambiguous and is often read as an option to
enable removal of overlapping bases, while in reality this is on by
default and the option turns off the abiltiy to remove overlapping
bases.

Note the addition of "-removal" and retaining of overlaps plural is to
permit the existing "--ignore-overlaps" option to continue working as
GNU getopt long has always permitted shortened versions of long options.

Also added --disable-overlap-removal as an (IMO) better synonym, but I
am open to removing this if it is considered unnecessary.

Fixes #1663