### PR TITLE
Enable `samtools index` to index multiple alignment files at once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ bam_cat.o: bam_cat.c config.h $(htslib_bgzf_h) $(htslib_sam_h) $(htslib_cram_h) 
 bam_color.o: bam_color.c config.h $(htslib_sam_h)
 bam_fastq.o: bam_fastq.c config.h $(htslib_sam_h) $(htslib_klist_h) $(htslib_kstring_h) $(htslib_bgzf_h) $(htslib_thread_pool_h) $(samtools_h) $(sam_opts_h)
 bam_import.o: bam_import.c config.h $(htslib_sam_h) $(htslib_thread_pool_h) $(samtools_h) $(sam_opts_h)
-bam_index.o: bam_index.c config.h $(htslib_hts_h) $(htslib_sam_h) $(htslib_khash_h) $(samtools_h) $(sam_opts_h)
+bam_index.o: bam_index.c config.h $(htslib_hts_h) $(htslib_sam_h) $(htslib_hfile_h) $(htslib_khash_h) $(samtools_h) $(sam_opts_h)
 bam_lpileup.o: bam_lpileup.c config.h $(bam_plbuf_h) $(bam_lpileup_h) splaysort.h
 bam_mate.o: bam_mate.c config.h $(htslib_thread_pool_h) $(sam_opts_h) $(htslib_kstring_h) $(htslib_sam_h) $(samtools_h)
 bam_md.o: bam_md.c config.h $(htslib_faidx_h) $(htslib_sam_h) $(htslib_kstring_h) $(htslib_thread_pool_h) $(sam_opts_h) $(samtools_h)

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,11 @@ Release a.b
  * The dict command can now read BWA's .alt file and add AH:* tags
    indicating reference sequences that represent alternate loci.
 
+ * The "samtools index" command can now accept multiple alignment filenames
+   on the command line, and will index each of them separately. (Specifying
+   the output index filename via out.index or the new -o option is currently
+   only applicable when there is only one alignment file to be indexed.)
+
 
 Release 1.15.1 (7th April 2022)
 -------------------------------

--- a/NEWS
+++ b/NEWS
@@ -5,7 +5,7 @@ Release a.b
    indicating reference sequences that represent alternate loci.
 
  * The "samtools index" command can now accept multiple alignment filenames
-   on the command line, and will index each of them separately. (Specifying
+   with the new -M option, and will index each of them separately. (Specifying
    the output index filename via out.index or the new -o option is currently
    only applicable when there is only one alignment file to be indexed.)
 

--- a/doc/samtools-index.1
+++ b/doc/samtools-index.1
@@ -43,16 +43,12 @@ samtools index \- indexes SAM/BAM/CRAM files
 .
 .SH SYNOPSIS
 .PP
-.B samtools index
+.B samtools index -M
 .RB [ -bc ]
 .RB [ -m
 .IR INT ]
-.RB [ -o
-.IR out.index ]
-.I FILE
+.I FILE FILE
 .RI [ FILE ...]
-.br
-(Samtools 1.16 or later)
 .PP
 .B samtools index
 .RB [ -bc ]
@@ -60,8 +56,6 @@ samtools index \- indexes SAM/BAM/CRAM files
 .IR INT ]
 .IR aln.sam | aln.bam | aln.cram
 .RI [ out.index ]
-.br
-(All versions)
 
 .SH DESCRIPTION
 .PP
@@ -82,18 +76,6 @@ When only one alignment file is being indexed, the output index filename
 can be specified via
 .B -o
 or as shown in the second synopsis.
-
-To be precise: when two filename arguments are given, the second filename
-is interpreted as specifying
-.I out.index
-if that file either does not exist or already contains index data.
-Otherwise the command is interpreted as specifying two alignment files
-to be indexed individually.
-(Samtools versions earlier than 1.16
-.B always
-interpret the second filename as specifying
-.I out.index
-and thus accept only the second synopsis.)
 
 When no output filename is specified, for a CRAM file
 .IR aln.cram ,
@@ -132,6 +114,12 @@ as the fixed value used by the BAI format.
 .BI "-m " INT
 Create a CSI index, with a minimum interval size of 2^INT.
 .TP
+.B -M
+Interpret all filename arguments as alignment files to be indexed individually.
+(Without
+.BR -M ,
+filename arguments are interpreted solely as per the second synopsis.)
+.TP
 .BI "-o " FILE
 Write the output index to
 .IR FILE .
@@ -139,19 +127,6 @@ Write the output index to
 .TP
 .BI "-@, --threads " INT
 Number of input/output compression threads to use in addition to main thread [0].
-
-.SH CAVEATS
-
-Allowing more than one alignment file to be specified was added in Samtools 1.16.
-Earlier versions understood only the second synopsis and did not check that exactly
-one or two filename arguments are provided. Thus using
-.B samtools index ex1.bam ex2.bam
-or
-.B samtools index *.bam
-with earlier versions will result in
-.BR "loss of data" ,
-as the second BAM filename is misinterpreted as the output index filename and
-its contents will be overwritten.
 
 .SH AUTHOR
 .PP

--- a/doc/samtools-index.1
+++ b/doc/samtools-index.1
@@ -43,7 +43,16 @@ samtools index \- indexes SAM/BAM/CRAM files
 .
 .SH SYNOPSIS
 .PP
-samtools index
+.B samtools index
+.RB [ -bc ]
+.RB [ -m
+.IR INT ]
+.RB [ -o
+.IR out.index ]
+.I FILE
+.RI [ FILE ...]
+.PP
+.B samtools index
 .RB [ -bc ]
 .RB [ -m
 .IR INT ]
@@ -52,7 +61,7 @@ samtools index
 
 .SH DESCRIPTION
 .PP
-Index a coordinate-sorted BGZIP-compressed SAM, BAM or CRAM file for fast
+Index coordinate-sorted BGZIP-compressed SAM, BAM or CRAM files for fast
 random access.
 Note for SAM this only works if the file has been BGZF compressed first.
 
@@ -62,9 +71,18 @@ arguments are used to limit
 .B samtools view
 and similar commands to particular regions of interest.
 
-If an output filename is given, the index file will be written to
-.IR out.index .
-Otherwise, for a CRAM file
+When only one alignment file is being indexed, the output index filename
+can be specified via
+.B -o
+or as shown in the second synopsis.
+(To be precise: when two filename arguments are given, the second filename
+is interpreted as specifying
+.I out.index
+if that file either does not exist or already contains index data.
+Otherwise the command is interpreted as specifying two alignment files
+to be indexed individually.)
+
+When no output filename is specified, for a CRAM file
 .IR aln.cram ,
 index file
 .IB aln.cram .crai
@@ -100,6 +118,11 @@ as the fixed value used by the BAI format.
 .TP
 .BI "-m " INT
 Create a CSI index, with a minimum interval size of 2^INT.
+.TP
+.BI "-o " FILE
+Write the output index to
+.IR FILE .
+(Currently may only be used when exactly one alignment file is being indexed.)
 .TP
 .BI "-@, --threads " INT
 Number of input/output compression threads to use in addition to main thread [0].

--- a/doc/samtools-index.1
+++ b/doc/samtools-index.1
@@ -51,6 +51,8 @@ samtools index \- indexes SAM/BAM/CRAM files
 .IR out.index ]
 .I FILE
 .RI [ FILE ...]
+.br
+(Samtools 1.16 or later)
 .PP
 .B samtools index
 .RB [ -bc ]
@@ -58,12 +60,17 @@ samtools index \- indexes SAM/BAM/CRAM files
 .IR INT ]
 .IR aln.sam | aln.bam | aln.cram
 .RI [ out.index ]
+.br
+(All versions)
 
 .SH DESCRIPTION
 .PP
 Index coordinate-sorted BGZIP-compressed SAM, BAM or CRAM files for fast
 random access.
 Note for SAM this only works if the file has been BGZF compressed first.
+(The first synopsis with multiple input
+.IR FILE s
+is only available with Samtools 1.16 or later.)
 
 This index is needed when
 .I region
@@ -75,12 +82,18 @@ When only one alignment file is being indexed, the output index filename
 can be specified via
 .B -o
 or as shown in the second synopsis.
-(To be precise: when two filename arguments are given, the second filename
+
+To be precise: when two filename arguments are given, the second filename
 is interpreted as specifying
 .I out.index
 if that file either does not exist or already contains index data.
 Otherwise the command is interpreted as specifying two alignment files
-to be indexed individually.)
+to be indexed individually.
+(Samtools versions earlier than 1.16
+.B always
+interpret the second filename as specifying
+.I out.index
+and thus accept only the second synopsis.)
 
 When no output filename is specified, for a CRAM file
 .IR aln.cram ,
@@ -126,6 +139,19 @@ Write the output index to
 .TP
 .BI "-@, --threads " INT
 Number of input/output compression threads to use in addition to main thread [0].
+
+.SH CAVEATS
+
+Allowing more than one alignment file to be specified was added in Samtools 1.16.
+Earlier versions understood only the second synopsis and did not check that exactly
+one or two filename arguments are provided. Thus using
+.B samtools index ex1.bam ex2.bam
+or
+.B samtools index *.bam
+with earlier versions will result in
+.BR "loss of data" ,
+as the second BAM filename is misinterpreted as the output index filename and
+its contents will be overwritten.
 
 .SH AUTHOR
 .PP

--- a/doc/samtools.1
+++ b/doc/samtools.1
@@ -233,6 +233,8 @@ samtools index
 
 Index a coordinate-sorted SAM, BAM or CRAM file for fast random access.
 Note for SAM this only works if the file has been BGZF compressed first.
+(Starting from Samtools 1.16, this command can also be given several
+alignment filenames, which are indexed individually.)
 
 This index is needed when
 .I region

--- a/test/test.pl
+++ b/test/test.pl
@@ -843,6 +843,14 @@ sub test_index
     test_cmd($opts,out=>'dat/test_input_1_b.X.expected',cmd=>"$$opts{bin}/samtools view${threads} -X $$opts{path}/dat/test_input_1_b.bam $$opts{tmp}/test_input_1_b.bam.bai ref2");
     test_cmd($opts,out=>'dat/test_input_1_ab.X.expected', ignore_pg_header => 1, cmd=>"$$opts{bin}/samtools merge${threads} -O sam - -X -cp -R ref2 $$opts{path}/dat/test_input_1_a.bam $$opts{path}/dat/test_input_1_b.bam $$opts{path}/dat/test_input_1_a.bam.bai $$opts{tmp}/test_input_1_b.bam.bai");
 
+    # Check -o option
+    cmd("$$opts{bin}/samtools index${threads} -o $$opts{tmp}/test_input_1_b_opt.bam.bai $$opts{path}/dat/test_input_1_b.bam");
+    test_cmd($opts,out=>'dat/test_input_1_b.X.expected',cmd=>"$$opts{bin}/samtools view${threads} -X $$opts{path}/dat/test_input_1_b.bam $$opts{tmp}/test_input_1_b_opt.bam.bai ref2");
+
+    # Check indexing multiple alignment files
+    test_cmd($opts,out=>'dat/test_input_1_a.bam.bai.expected',cmd=>"$$opts{bin}/samtools index${threads} $$opts{path}/dat/test_input_1_a.bam $$opts{path}/dat/test_input_1_b.bam && cat $$opts{path}/dat/test_input_1_a.bam.bai",binary=>1);
+    test_cmd($opts,out=>'dat/test_input_1_b.X.expected',cmd=>"$$opts{bin}/samtools view${threads} -X $$opts{path}/dat/test_input_1_b.bam $$opts{path}/dat/test_input_1_b.bam.bai ref2");
+
     # Check auto-indexing
     cmd("$$opts{bin}/samtools view${threads} --write-index -o $$opts{path}/dat/auto_indexed.tmp.bam $$opts{path}/dat/mpileup.1.sam");
     test_cmd($opts,out=>"dat/auto_indexed.tmp.bam.csi", cmd=>"$$opts{bin}/samtools index${threads} -c $$opts{path}/dat/auto_indexed.tmp.bam $$opts{tmp}/auto_indexed.csi && cat $$opts{tmp}/auto_indexed.csi", binary=>1);

--- a/test/test.pl
+++ b/test/test.pl
@@ -848,7 +848,8 @@ sub test_index
     test_cmd($opts,out=>'dat/test_input_1_b.X.expected',cmd=>"$$opts{bin}/samtools view${threads} -X $$opts{path}/dat/test_input_1_b.bam $$opts{tmp}/test_input_1_b_opt.bam.bai ref2");
 
     # Check indexing multiple alignment files
-    test_cmd($opts,out=>'dat/test_input_1_a.bam.bai.expected',cmd=>"$$opts{bin}/samtools index${threads} $$opts{path}/dat/test_input_1_a.bam $$opts{path}/dat/test_input_1_b.bam && cat $$opts{path}/dat/test_input_1_a.bam.bai",binary=>1);
+    test_cmd($opts,out=>'dat/empty.expected',cmd=>"$$opts{bin}/samtools index${threads} $$opts{path}/dat/test_input_1_a.bam $$opts{path}/dat/test_input_1_b.bam",want_fail=>1);
+    test_cmd($opts,out=>'dat/test_input_1_a.bam.bai.expected',cmd=>"$$opts{bin}/samtools index${threads} -M $$opts{path}/dat/test_input_1_a.bam $$opts{path}/dat/test_input_1_b.bam && cat $$opts{path}/dat/test_input_1_a.bam.bai",binary=>1);
     test_cmd($opts,out=>'dat/test_input_1_b.X.expected',cmd=>"$$opts{bin}/samtools view${threads} -X $$opts{path}/dat/test_input_1_b.bam $$opts{path}/dat/test_input_1_b.bam.bai ref2");
 
     # Check auto-indexing


### PR DESCRIPTION
Given a directory containing three BAM files, _sampleA.bam_,  _sampleB.bam_,  and _sampleC.bam_, one might expect the following to index the three of them individually:

```
samtools index sample*.bam
```

Instead it will overwrite _sampleB.bam_ with A's index, and ignore its third argument — as reported [here](https://twitter.com/_nicoromano_/status/1496859773727301633), [here](https://twitter.com/AbigailRamsoe/status/1511666622502785035), and in https://github.com/samtools/samtools/issues/1569#issuecomment-1000201931, in at least two cases likely from bitter experience.

It would be easy to catch this case (i.e., to detect that the arguments are not the expected `<in.bam> [out.index]` and fail with an error message) by actually validating `argc`. However if there were only two files matching `sample*.bam` it would be harder as `argc` would have its expected value and you would need to check whether the second filename actually referred to an extant BAM/CRAM file. If you were going to do that, it's equally easy to implement the `*.bam` behaviour that these users are expecting.

Hence this PR, which regularises `samtools index` to follow the usual Unix conventions (in addition, for compatibility reasons, to its existing baroque command line syntax):

Accept either `FILE [FILE]...` or `FILE [OUTINDEX]`. When exactly two filenames are given, interpret the second as OUTINDEX if it does not exist or if it already contains index data. In particular, do not interpret an existing BAM/CRAM file as an output index filename!

Add optional `-o OUTINDEX` option that can be used instead of OUTINDEX, to align this subcommand with others that use `-o` to specify output files. At present this can only be used when 1 input file is given. In future, it could include expansion metacharacters similarly to the split subcommand.

In principle, we could use a thread pool to index multiple input files in parallel (as well as multi-threading the input reading). This would be a larger change and, at least initially, probably not worthwhile.