### PR TITLE
Fix divide by zero in plot-bamstats -m, on unmapped data

### DIFF
--- a/misc/plot-bamstats
+++ b/misc/plot-bamstats
@@ -413,7 +413,8 @@ sub parse_bamcheck1
     }
     if ( $i==0 ) { return; }
 
-    $$opts{dat}{SN}{'error rate:'} = sprintf "%e", get_value($opts,'SN','mismatches:') / get_value($opts,'SN','bases mapped (cigar):');
+    my $bases_mapped_cigar = get_value($opts,'SN','bases mapped (cigar):');
+    $$opts{dat}{SN}{'error rate:'} = $bases_mapped_cigar ? sprintf "%e", get_value($opts,'SN','mismatches:') / $bases_mapped_cigar : 0;
     update_average_length($opts);
     update_average_quality($opts);
     update_average_isize($opts);


### PR DESCRIPTION
It's not a good idea to divide by $bases_mapped_cigar when nothing has been mapped.  samtools stats outputs zero for the error rate in this case, so do the same in plot-bamstats.

Thanks to Shane McCarthy for the fix.

Fixes #1675 