### PR TITLE
Allow '*' for -T to write all tags to fastq

### DIFF
--- a/bam_fastq.c
+++ b/bam_fastq.c
@@ -349,7 +349,7 @@ void set_sam_opts(samFile *fp, bam2fq_state_t *state,
 
     hts_set_opt(fp, FASTQ_OPT_BARCODE, opts->barcode_tag);
 
-    if (opts->extra_tags && *opts->extra_tags == '*')
+    if (opts->extra_tags && (*opts->extra_tags == '*' || *opts->extra_tags == '\0'))
         hts_set_opt(fp, FASTQ_OPT_AUX, NULL);
     else {
         kstring_t tag_list = {0,0};

--- a/doc/samtools-fasta.1
+++ b/doc/samtools-fasta.1
@@ -141,6 +141,9 @@ Copy RG, BC and QT tags to the FASTQ header line, if they exist.
 .B -T TAGLIST
 Specify a comma-separated list of tags to copy to the FASTQ header line, if
 they exist.
+\fBTAGLIST\fR can be blank or \fB*\fR to indicate all tags should be copied to
+the output.
+If using \fB*\fR, be careful to quote it to avoid unwanted shell expansion.
 .TP 8
 .B -1 FILE
 Write reads with the READ1 FLAG set (and READ2 not set) to FILE instead of

--- a/test/bam2fq/15.fq.expected
+++ b/test/bam2fq/15.fq.expected
@@ -1,0 +1,144 @@
+@ref1_grp1_p001/1	MD:Z:10	NM:i:0	RG:Z:grp1	BC:Z:ACGT	H0:i:1	aa:A:!	ab:A:~	fa:f:3.14159	za:Z:Hello world!	ha:H:DEADBEEF	ba:B:c,-128,0,127	bb:B:C,0,127,255	bc:B:s,-32768,0,32767	bd:B:S,0,32768,65535	be:B:i,-2147483648,0,2147483647	bf:B:I,0,2147483648,4294967295	bg:B:f,2.71828,6.626e-34,2.9979e+09
+CGAGCTCGGT
++
+!!!!!!!!!!
+@ref1_grp1_p001/2	MD:Z:10	NM:i:0	RG:Z:grp1
+GTCGACTCTA
++
+----------
+@ref1_grp1_p002/1	MD:Z:10	NM:i:0	RG:Z:grp1	BC:Z:AATTCCGG	H0:i:1	aa:A:a	ab:A:z	fa:f:4.3597e-18	za:Z:Another string	ha:H:2000AD
+CTCGGTACCC
++
+##########
+@ref1_grp1_p002/2	MD:Z:10	NM:i:0	RG:Z:grp1
+GCAGGTCGAC
++
+//////////
+@ref1_grp1_p003/1	MD:Z:10	NM:i:0	fa:f:1.66e-27	RG:Z:grp1
+GTACCCGGGG
++
+%%%%%%%%%%
+@ref1_grp1_p003/2	MD:Z:10	NM:i:0	RG:Z:grp1
+GCCTGCAGGT
++
+1111111111
+@ref1_grp1_p004/1	MD:Z:10	NM:i:0	fa:f:1.38e-23	za:Z:xRG:Z:grp2	RG:Z:grp1
+CCGGGGATCC
++
+''''''''''
+@ref1_grp1_p004/2	MD:Z:10	NM:i:0	RG:Z:grp1
+GCATGCCTGC
++
+3333333333
+@ref1_grp1_p005/1	MD:Z:10	NM:i:0	RG:Z:grp1	ia:i:40000
+GGATCCTCTA
++
+))))))))))
+@ref1_grp1_p005/2	MD:Z:10	NM:i:0	RG:Z:grp1
+GCTTGCATGC
++
+5555555555
+@ref1_grp1_p006/1	MD:Z:10	NM:i:0	RG:Z:grp1	ia:i:255
+CCTCTAGAGT
++
+++++++++++
+@ref1_grp1_p006/2	MD:Z:10	NM:i:0	RG:Z:grp1
+TCAAGCTTGC
++
+7777777777
+@ref1_grp2_p001/1	MD:Z:8	NM:i:0	RG:Z:grp2	BC:Z:TGCA	H0:i:1	aa:A:A	ab:A:Z	fa:f:6.67e-11	za:Z:!"$%^&*()	ha:H:CAFE
+AGCTCGGTAC
++
+""""""""""
+@ref1_grp2_p001/2	MD:Z:10	NM:i:0	RG:Z:grp2
+AGGTCGACTC
++
+..........
+@ref1_grp2_p002/1	MD:Z:10	NM:i:0	fa:f:6.022e+23	RG:Z:grp2
+CGGTACCCGG
++
+$$$$$$$$$$
+@ref1_grp2_p002/2	MD:Z:10	NM:i:0	RG:Z:grp2
+CTGCAGGTCG
++
+0000000000
+@ref1_grp2_p003/1	MD:Z:10	NM:i:0	RG:Z:grp2	ia:i:4294967295
+ACCCGGGGAT
++
+&&&&&&&&&&
+@ref1_grp2_p003/2	MD:Z:10	NM:i:0	RG:Z:grp2
+ATGCCTGCAG
++
+2222222222
+@ref1_grp2_p004/1	MD:Z:10	NM:i:0	RG:Z:grp2	ia:i:-2147483648
+GGGGATCCTC
++
+((((((((((
+@ref1_grp2_p004/2	MD:Z:10	NM:i:0	RG:Z:grp2
+TTGCATGCCT
++
+4444444444
+@ref1_grp2_p005/1	MD:Z:10	NM:i:0	RG:Z:grp2	ia:i:-1000
+ATCCTCTAGA
++
+**********
+@ref1_grp2_p005/2	MD:Z:10	NM:i:0	RG:Z:grp2
+AAGCTTGCAT
++
+6666666666
+@ref1_grp2_p006/1	MD:Z:10	NM:i:0	RG:Z:grp2	ia:i:-1
+TCTAGAGTCG
++
+,,,,,,,,,,
+@ref1_grp2_p006/2	MD:Z:10	NM:i:0	RG:Z:grp2
+ACTCAAGCTT
++
+8888888888
+@ref2_grp3_p001/1	MD:Z:15	NM:i:0	RG:Z:grp3
+GTGACACTATAGAAT
++
+~~~~~~~~~~~~~~~
+@ref2_grp3_p001/2	MD:Z:0T0A0A1C0A0T0G0G0T0C0A1A0G0	NM:i:13	RG:Z:grp3
+CTGTTTCCTGTGTGA
++
+|||||||||||||||
+@ref2_grp3_p002/1	MD:Z:15	NM:i:0	RG:Z:grp3
+CTGTTTCCTGTGTGA
++
+{{{{{{{{{{{{{{{
+@ref2_grp3_p002/2	MD:Z:15	NM:i:0	RG:Z:grp3
+CGCCAAGCTATTTAG
++
+}}}}}}}}}}}}}}}
+@ref2_grp3_p003/1	MD:Z:1T0T0C0T0A0T0A0G0T0G0T0C0A0C0	NM:i:14	RG:Z:grp3
+ACGTMRWSYKVHDBN
++
+0123456789abcd!
+@ref2_grp3_p003/2	MD:Z:0A0T0T0C0T0A0T0A0G0T0G0T1A0C0	NM:i:14	RG:Z:grp3
+ACGTMRWSYKVHDBN
++
+0123456789abcd!
+@ref12_grp1_p001/1	MD:Z:10	NM:i:0	RG:Z:grp1
+TGCAGGCATG
++
+AAAAAAAAAA
+@ref12_grp1_p001/2	MD:Z:10	NM:i:0	RG:Z:grp1
+CACTATAGAA
++
+BBBBBBBBBB
+@ref12_grp2_p001/1	MD:Z:10	NM:i:0	RG:Z:grp2
+CAAGCTTGAG
++
+AAAAAAAAAA
+@ref12_grp2_p001/2	MD:Z:10	NM:i:0	RG:Z:grp2
+ATTTAGGTGA
++
+BBBBBBBBBB
+@unaligned_grp3_p001/1	RG:Z:grp3
+CACTCGTTCATGACG
++
+0123456789abcde
+@unaligned_grp3_p001/2	RG:Z:grp3
+GAAAGTGAGGAGGTG
++
+edcba9876543210

--- a/test/test.pl
+++ b/test/test.pl
@@ -3007,6 +3007,11 @@ sub test_bam2fq
 
     # Test single ended output with dual-indexing
     test_cmd($opts, out=>'dat/empty.expected', out_map=>{'0.fq' => 'bam2fq/14.0.fq.expected', 'i1.fq' => 'bam2fq/14.i1.fq.expected', 'i2.fq' => 'bam2fq/14.i2.fq.expected', '0.fq' => 'bam2fq/14.0.fq.expected'}, cmd=>"$$opts{bin}/samtools fastq @$threads --index-format 'i8n1i8' --i1 $$opts{path}/i1.fq --i2 $$opts{path}/i2.fq -0 $$opts{path}/0.fq $$opts{path}/dat/bam2fq.014.sam");
+
+    # -T flag, all tags mode
+    test_cmd($opts, out=>'bam2fq/15.fq.expected', cmd=>"$$opts{bin}/samtools fastq @$threads -N -T '*' $$opts{path}/dat/bam2fq.001.sam");
+    test_cmd($opts, out=>'bam2fq/15.fq.expected', cmd=>"$$opts{bin}/samtools fastq @$threads -N -T '' $$opts{path}/dat/bam2fq.001.sam");
+    test_cmd($opts, out=>'bam2fq/15.fq.expected', cmd=>"$$opts{bin}/samtools fastq @$threads -N -t -T '*' $$opts{path}/dat/bam2fq.001.sam");
 }
 
 sub test_depad


### PR DESCRIPTION
The command `samtools import` allows `-T "*"` to read all aux data from fastq headers. This PR makes `samtools fastq` symmetric by allowing all tags from SAM records to be written to fastq headers.

The motivation for this was for use with minimap2 to align reads with modified base data stored in unaligned SAM files (and not burden the user with knowing all tags).