### PR TITLE
Fix missing `@RG` headers when using `samtools merge -r`

### DIFF
--- a/bam_sort.c
+++ b/bam_sort.c
@@ -630,7 +630,7 @@ static klist_t(hdrln) * trans_rg_pg(bool is_rg, sam_hdr_t *translate,
     }
 
     // If there are no RG lines in the file and we are overriding add one
-    if (is_rg && override && kl_begin(hdr_lines) == NULL) {
+    if (is_rg && override && hdr_lines->size == 0) {
         kstring_t new_id = {0, 0, NULL};
         kstring_t line = {0, 0, NULL};
         kstring_t empty = {0, 0, NULL};

--- a/test/merge/rg_from_r_mode.expected.sam
+++ b/test/merge/rg_from_r_mode.expected.sam
@@ -1,0 +1,21 @@
+@HD	VN:1.4
+@SQ	SN:insert	LN:599
+@SQ	SN:ref1	LN:45
+@SQ	SN:ref2	LN:40
+@SQ	SN:ref3	LN:4
+@RG	ID:test_no_pg_rg_co
+r000	99	insert	50	30	10M	=	80	30	ATTTAGCTAC	AAAAAAAAAA	RG:Z:test_no_pg_rg_co
+r000	211	insert	80	30	10M	=	50	-30	CCCAATCATT	AAAAAAAAAA	RG:Z:test_no_pg_rg_co
+r001	163	ref1	7	30	8M4I4M1D3M	=	37	39	TTAGATAAAGAGGATACTG	*	XX:B:S,12561,2,20,112	YY:i:100	RG:Z:test_no_pg_rg_co
+r002	0	ref1	9	30	1S2I6M1P1I1P1I4M2I	*	0	0	AAAAGATAAGGGATAAA	*	XA:Z:abc	XB:i:-10	RG:Z:test_no_pg_rg_co
+r003	0	ref1	9	30	5H6M	*	0	0	AGCTAA	*	RG:Z:test_no_pg_rg_co
+r004	0	ref1	16	30	6M14N1I5M	*	0	0	ATAGCTCTCAGC	*	RG:Z:test_no_pg_rg_co
+r003	16	ref1	29	30	6H5M	*	0	0	TAGGC	*	RG:Z:test_no_pg_rg_co
+r001	83	ref1	37	30	9M	=	7	-39	CAGCGCCAT	*	RG:Z:test_no_pg_rg_co
+x1	0	ref2	1	30	20M	*	0	0	AGGTTTTATAAAACAAATAA	*	RG:Z:test_no_pg_rg_co
+x2	0	ref2	2	30	21M	*	0	0	GGTTTTATAAAACAAATAATT	?????????????????????	RG:Z:test_no_pg_rg_co
+x3	0	ref2	6	30	9M4I13M	*	0	0	TTATAAAACAAATAATTAAGTCTACA	??????????????????????????	RG:Z:test_no_pg_rg_co
+x4	0	ref2	10	30	25M	*	0	0	CAAATAATTAAGTCTACAGAGCAAC	?????????????????????????	RG:Z:test_no_pg_rg_co
+x5	0	ref2	12	30	24M	*	0	0	AATAATTAAGTCTACAGAGCAACT	????????????????????????	RG:Z:test_no_pg_rg_co
+x6	0	ref2	14	30	23M	*	0	0	TAATTAAGTCTACAGAGCAACTA	???????????????????????	RG:Z:test_no_pg_rg_co
+u1	4	*	0	30	23M	*	0	0	TAATTAAGTCTACAGAAAAAAAA	???????????????????????	RG:Z:test_no_pg_rg_co

--- a/test/test.pl
+++ b/test/test.pl
@@ -3166,6 +3166,10 @@ sub test_merge
     system("$$opts{bin}/samtools index $$opts{tmp}/merge.bed.1.bam") == 0 or die "failed to index merge.bed.1.bam: $?";
     system("$$opts{bin}/samtools index $$opts{tmp}/merge.bed.2.bam") == 0 or die "failed to index merge.bed.2.bam: $?";
     test_cmd($opts, out=>'merge/merge.bed.expected.sam', cmd => "$$opts{bin}/samtools merge${threads} --no-PG -O SAM -L $$opts{path}/merge/merge.bed - $$opts{tmp}/merge.bed.1.bam $$opts{tmp}/merge.bed.2.bam");
+
+    # -r (RG from filename) option with no initial RG header
+    test_cmd($opts, out=>'merge/rg_from_r_mode.expected.sam', cmd => "$$opts{bin}/samtools merge${threads} --no-PG -r -O SAM - $$opts{path}/merge/test_no_pg_rg_co.sam");
+
 }
 
 sub test_sort


### PR DESCRIPTION
Caused by a broken test for an empty klist.  Fix by checking the size stored in the klist struct.  It's not clear if it's an officially supported way of testing for an empty klist (there is currently no macro to expose size), but it works for now.

Adds a test, as the case of no @RG headers in the inputs was previously not covered.

See samtools/htslib#1479
