### PR TITLE
add mapq histogram to samtools stats

### DIFF
--- a/doc/samtools-stats.1
+++ b/doc/samtools-stats.1
@@ -82,11 +82,11 @@ IS	Insert sizes
 RL	Read lengths
 FRL	Read lengths for first fragments only
 LRL	Read lengths for last fragments only
+MAPQ	Mapping qualities
 ID	Indel size distribution
 IC	Indels per cycle
 COV	Coverage (depth) distribution
 GCD	GC-depth
-MAPQ    Mapping qualities
 .TE
 
 Not all sections will be reported as some depend on the data being
@@ -336,6 +336,9 @@ observed length (up to the maximum specified by the \fB-l\fR option).
 Columns are read length and frequency.  FRL and LRL contains the same
 information separated into first and last fragments.
 
+MAPQ reports the mapping qualities for the mapped reads, ignoring the
+duplicates, supplementary, secondary and failing quality reads.
+
 ID reports the distribution of indel sizes, with one row per observed
 size. The columns are size, frequency of insertions at that size and
 frequency of deletions at that size.
@@ -368,9 +371,6 @@ of GC content.  Subsequent columns list the coverage depth at 10th,
 25th, 50th, 75th and 90th GC percentiles for this specific GC
 percentage, revealing any GC bias in mapping.  These columns are
 averaged depths, so are floating point with no maximum value.
-
-MAPQ reports the mapping qualities for the mapped reads, ignoring the
-duplicates, supplementary, secondary and failing quality reads.
 
 .SH OPTIONS
 .TP 8

--- a/doc/samtools-stats.1
+++ b/doc/samtools-stats.1
@@ -86,6 +86,7 @@ ID	Indel size distribution
 IC	Indels per cycle
 COV	Coverage (depth) distribution
 GCD	GC-depth
+MAPQ    Mapping qualities
 .TE
 
 Not all sections will be reported as some depend on the data being
@@ -367,6 +368,9 @@ of GC content.  Subsequent columns list the coverage depth at 10th,
 25th, 50th, 75th and 90th GC percentiles for this specific GC
 percentage, revealing any GC bias in mapping.  These columns are
 averaged depths, so are floating point with no maximum value.
+
+MAPQ reports the mapping qualities for the mapped reads, ignoring the
+duplicates, supplementary, secondary and failing quality reads.
 
 .SH OPTIONS
 .TP 8

--- a/stats.c
+++ b/stats.c
@@ -180,6 +180,7 @@ typedef struct
     uint64_t *insertions, *deletions;
     uint64_t *ins_cycles_1st, *ins_cycles_2nd, *del_cycles_1st, *del_cycles_2nd;
     isize_t *isize;
+    uint64_t* mapping_qualities;
 
     // The extremes encountered
     int max_len;            // Maximum read length
@@ -1199,6 +1200,8 @@ void collect_stats(bam1_t *bam_line, stats_t *stats, khash_t(qn2pair) *read_pair
     if ( order == READ_ORDER_LAST && stats->max_len_2nd < read_len )
         stats->max_len_2nd = read_len;
 
+    stats->mapping_qualities[bam_line->core.qual]++;
+
     int i;
     int gc_count = 0;
 
@@ -1768,6 +1771,13 @@ void output_stats(FILE *to, stats_t *stats, int sparse)
             fprintf(to, "LRL\t%d\t%ld\n", ilen+1, (long)stats->read_lengths_2nd[ilen+1]);
     }
 
+    fprintf(to, "# Mapping qualities. Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count\n");
+    for (ilen=0; ilen < 256; ilen++)
+    {
+        if ( stats->mapping_qualities[ilen]>0 )
+            fprintf(to, "MAPQ\t%d\t%ld\n", ilen, (long)stats->mapping_qualities[ilen]);
+    }
+
     fprintf(to, "# Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions\n");
 
     for (ilen=0; ilen<stats->nindels; ilen++)
@@ -2128,6 +2138,7 @@ void cleanup_stats(stats_t* stats)
     destroy_regions(stats);
     if ( stats->rg_hash ) kh_destroy(rg, stats->rg_hash);
     free(stats->split_name);
+    free(stats->mapping_qualities);
     free(stats);
 }
 
@@ -2317,6 +2328,8 @@ static void init_stat_structs(stats_t* stats, stats_info_t* info, const char* gr
     if (!stats->del_cycles_1st) goto nomem;
     stats->del_cycles_2nd = calloc(stats->nbases+1,sizeof(uint64_t));
     if (!stats->del_cycles_2nd) goto nomem;
+    stats->mapping_qualities = calloc(256,sizeof(uint64_t));
+    if(!stats->mapping_qualities) goto nomem;
     if (init_barcode_tags(stats) < 0)
         goto nomem;
     realloc_rseq_buffer(stats);

--- a/stats.c
+++ b/stats.c
@@ -1199,9 +1199,9 @@ void collect_stats(bam1_t *bam_line, stats_t *stats, khash_t(qn2pair) *read_pair
         stats->max_len_1st = read_len;
     if ( order == READ_ORDER_LAST && stats->max_len_2nd < read_len )
         stats->max_len_2nd = read_len;
-
-    stats->mapping_qualities[bam_line->core.qual]++;
-
+    if ( ( bam_line->core.flag & (BAM_FUNMAP|BAM_FSECONDARY|BAM_FSUPPLEMENTARY|BAM_FQCFAIL|BAM_FDUP) ) == 0 ) {
+        stats->mapping_qualities[bam_line->core.qual]++;
+        }
     int i;
     int gc_count = 0;
 
@@ -1463,7 +1463,7 @@ float gcd_percentile(gc_depth_t *gcd, int N, int p)
 void output_stats(FILE *to, stats_t *stats, int sparse)
 {
     // Calculate average insert size and standard deviation (from the main bulk data only)
-    int isize, ibulk=0, icov;
+    int isize, ibulk=0, icov, imapq=0;
     uint64_t nisize=0, nisize_inward=0, nisize_outward=0, nisize_other=0, cov_sum=0;
     double bulk=0, avg_isize=0, sd_isize=0;
     for (isize=0; isize<stats->isize->nitems(stats->isize->data); isize++)
@@ -1771,11 +1771,11 @@ void output_stats(FILE *to, stats_t *stats, int sparse)
             fprintf(to, "LRL\t%d\t%ld\n", ilen+1, (long)stats->read_lengths_2nd[ilen+1]);
     }
 
-    fprintf(to, "# Mapping qualities. Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count\n");
-    for (ilen=0; ilen < 256; ilen++)
+    fprintf(to, "# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count\n");
+    for (imapq=0; imapq < 256; imapq++)
     {
-        if ( stats->mapping_qualities[ilen]>0 )
-            fprintf(to, "MAPQ\t%d\t%ld\n", ilen, (long)stats->mapping_qualities[ilen]);
+        if ( stats->mapping_qualities[imapq]>0 )
+            fprintf(to, "MAPQ\t%d\t%ld\n", imapq, (long)stats->mapping_qualities[imapq]);
     }
 
     fprintf(to, "# Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions\n");

--- a/stats.c
+++ b/stats.c
@@ -1199,9 +1199,9 @@ void collect_stats(bam1_t *bam_line, stats_t *stats, khash_t(qn2pair) *read_pair
         stats->max_len_1st = read_len;
     if ( order == READ_ORDER_LAST && stats->max_len_2nd < read_len )
         stats->max_len_2nd = read_len;
-    if ( ( bam_line->core.flag & (BAM_FUNMAP|BAM_FSECONDARY|BAM_FSUPPLEMENTARY|BAM_FQCFAIL|BAM_FDUP) ) == 0 ) {
+    if ( ( bam_line->core.flag & (BAM_FUNMAP|BAM_FSECONDARY|BAM_FSUPPLEMENTARY|BAM_FQCFAIL|BAM_FDUP) ) == 0 )
         stats->mapping_qualities[bam_line->core.qual]++;
-        }
+
     int i;
     int gc_count = 0;
 

--- a/test/stat/1.stats.expected
+++ b/test/stat/1.stats.expected
@@ -416,6 +416,8 @@ RL	35	2
 FRL	35	1
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	35	1
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	40	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)
 # Coverage distribution. Use `grep ^COV | cut -f 2-` to extract this part.

--- a/test/stat/1.stats.large.expected
+++ b/test/stat/1.stats.large.expected
@@ -377,6 +377,8 @@ RL	35	2
 FRL	35	1
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	35	1
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	40	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)
 # Coverage distribution. Use `grep ^COV | cut -f 2-` to extract this part.

--- a/test/stat/10.stats.expected
+++ b/test/stat/10.stats.expected
@@ -416,6 +416,8 @@ RL	35	4
 FRL	35	2
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	35	2
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	40	4
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)
 # Coverage distribution. Use `grep ^COV | cut -f 2-` to extract this part.

--- a/test/stat/10_map_cigar.sam_s1_a_1.expected.bamstat
+++ b/test/stat/10_map_cigar.sam_s1_a_1.expected.bamstat
@@ -416,6 +416,8 @@ RL	35	2
 FRL	35	1
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	35	1
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	40	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)
 # Coverage distribution. Use `grep ^COV | cut -f 2-` to extract this part.

--- a/test/stat/10_map_cigar.sam_s1_b_1.expected.bamstat
+++ b/test/stat/10_map_cigar.sam_s1_b_1.expected.bamstat
@@ -416,6 +416,8 @@ RL	35	2
 FRL	35	1
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	35	1
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	40	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)
 # Coverage distribution. Use `grep ^COV | cut -f 2-` to extract this part.

--- a/test/stat/11.stats.expected
+++ b/test/stat/11.stats.expected
@@ -169,6 +169,32 @@ RL	10	26
 FRL	10	14
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	10	12
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	0	1
+MAPQ	1	1
+MAPQ	2	1
+MAPQ	3	1
+MAPQ	4	1
+MAPQ	5	1
+MAPQ	6	1
+MAPQ	7	1
+MAPQ	8	1
+MAPQ	9	1
+MAPQ	10	1
+MAPQ	11	1
+MAPQ	12	1
+MAPQ	13	1
+MAPQ	14	1
+MAPQ	15	1
+MAPQ	16	1
+MAPQ	17	1
+MAPQ	18	1
+MAPQ	19	1
+MAPQ	20	1
+MAPQ	21	1
+MAPQ	22	1
+MAPQ	23	1
+MAPQ	50	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)
 # Coverage distribution. Use `grep ^COV | cut -f 2-` to extract this part.

--- a/test/stat/11.stats.g4.expected
+++ b/test/stat/11.stats.g4.expected
@@ -169,6 +169,32 @@ RL	10	26
 FRL	10	14
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	10	12
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	0	1
+MAPQ	1	1
+MAPQ	2	1
+MAPQ	3	1
+MAPQ	4	1
+MAPQ	5	1
+MAPQ	6	1
+MAPQ	7	1
+MAPQ	8	1
+MAPQ	9	1
+MAPQ	10	1
+MAPQ	11	1
+MAPQ	12	1
+MAPQ	13	1
+MAPQ	14	1
+MAPQ	15	1
+MAPQ	16	1
+MAPQ	17	1
+MAPQ	18	1
+MAPQ	19	1
+MAPQ	20	1
+MAPQ	21	1
+MAPQ	22	1
+MAPQ	23	1
+MAPQ	50	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)
 # Coverage distribution. Use `grep ^COV | cut -f 2-` to extract this part.

--- a/test/stat/12.2reads.nooverlap.expected
+++ b/test/stat/12.2reads.nooverlap.expected
@@ -852,6 +852,9 @@ RL	100	2
 FRL	100	1
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	100	1
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	7	1
+MAPQ	37	1
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 ID	2	0	1
 ID	3	1	0

--- a/test/stat/12.2reads.overlap.expected
+++ b/test/stat/12.2reads.overlap.expected
@@ -852,6 +852,9 @@ RL	100	2
 FRL	100	1
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	100	1
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	7	1
+MAPQ	37	1
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 ID	2	0	1
 ID	3	1	0

--- a/test/stat/12.3reads.nooverlap.expected
+++ b/test/stat/12.3reads.nooverlap.expected
@@ -869,6 +869,9 @@ RL	100	3
 FRL	100	1
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	100	2
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	37	1
+MAPQ	60	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 ID	1	1	2
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)

--- a/test/stat/12.3reads.overlap.expected
+++ b/test/stat/12.3reads.overlap.expected
@@ -869,6 +869,9 @@ RL	100	3
 FRL	100	1
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	100	2
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	37	1
+MAPQ	60	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 ID	1	1	2
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)

--- a/test/stat/13.barcodes.bc.ok.expected
+++ b/test/stat/13.barcodes.bc.ok.expected
@@ -196,6 +196,9 @@ RL	11	2696
 FRL	11	1348
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	11	1348
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	25	267
+MAPQ	37	69
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 ID	1	36	1
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)

--- a/test/stat/13.barcodes.ox.ok.expected
+++ b/test/stat/13.barcodes.ox.ok.expected
@@ -231,6 +231,9 @@ RL	11	2696
 FRL	11	1348
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	11	1348
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	25	267
+MAPQ	37	69
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 ID	1	36	1
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)

--- a/test/stat/14.rg.Sample.expected
+++ b/test/stat/14.rg.Sample.expected
@@ -167,6 +167,32 @@ RL	10	26
 FRL	10	14
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	10	12
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	0	1
+MAPQ	1	1
+MAPQ	2	1
+MAPQ	3	1
+MAPQ	4	1
+MAPQ	5	1
+MAPQ	6	1
+MAPQ	7	1
+MAPQ	8	1
+MAPQ	9	1
+MAPQ	10	1
+MAPQ	11	1
+MAPQ	12	1
+MAPQ	13	1
+MAPQ	14	1
+MAPQ	15	1
+MAPQ	16	1
+MAPQ	17	1
+MAPQ	18	1
+MAPQ	19	1
+MAPQ	20	1
+MAPQ	21	1
+MAPQ	22	1
+MAPQ	23	1
+MAPQ	50	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)
 # Coverage distribution. Use `grep ^COV | cut -f 2-` to extract this part.

--- a/test/stat/14.rg.grp2.expected
+++ b/test/stat/14.rg.grp2.expected
@@ -168,6 +168,20 @@ RL	10	13
 FRL	10	7
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	10	6
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	1	1
+MAPQ	3	1
+MAPQ	5	1
+MAPQ	7	1
+MAPQ	9	1
+MAPQ	11	1
+MAPQ	13	1
+MAPQ	15	1
+MAPQ	17	1
+MAPQ	19	1
+MAPQ	21	1
+MAPQ	23	1
+MAPQ	50	1
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)
 # Coverage distribution. Use `grep ^COV | cut -f 2-` to extract this part.

--- a/test/stat/14.rg.grp3.expected
+++ b/test/stat/14.rg.grp3.expected
@@ -59,6 +59,7 @@ LTC	0	0	0	0	0
 # Read lengths. Use `grep ^RL | cut -f 2-` to extract this part. The columns are: read length, count
 # Read lengths - first fragments. Use `grep ^FRL | cut -f 2-` to extract this part. The columns are: read length, count
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)
 # Coverage distribution. Use `grep ^COV | cut -f 2-` to extract this part.

--- a/test/stat/14.rg.s1.expected
+++ b/test/stat/14.rg.s1.expected
@@ -377,6 +377,8 @@ RL	35	2
 FRL	35	1
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	35	1
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	40	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)
 # Coverage distribution. Use `grep ^COV | cut -f 2-` to extract this part.

--- a/test/stat/1_map_cigar.sam_s1_a_1.expected.bamstat
+++ b/test/stat/1_map_cigar.sam_s1_a_1.expected.bamstat
@@ -416,6 +416,8 @@ RL	35	2
 FRL	35	1
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	35	1
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	40	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)
 # Coverage distribution. Use `grep ^COV | cut -f 2-` to extract this part.

--- a/test/stat/2.stats.expected
+++ b/test/stat/2.stats.expected
@@ -416,6 +416,8 @@ RL	35	2
 FRL	35	1
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	35	1
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	40	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)
 # Coverage distribution. Use `grep ^COV | cut -f 2-` to extract this part.

--- a/test/stat/2.stats.large.expected
+++ b/test/stat/2.stats.large.expected
@@ -377,6 +377,8 @@ RL	35	2
 FRL	35	1
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	35	1
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	40	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)
 # Coverage distribution. Use `grep ^COV | cut -f 2-` to extract this part.

--- a/test/stat/3.stats.expected
+++ b/test/stat/3.stats.expected
@@ -274,6 +274,8 @@ RL	35	2
 FRL	35	1
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	35	1
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	40	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)
 # Coverage distribution. Use `grep ^COV | cut -f 2-` to extract this part.

--- a/test/stat/3.stats.large.expected
+++ b/test/stat/3.stats.large.expected
@@ -235,6 +235,8 @@ RL	35	2
 FRL	35	1
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	35	1
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	40	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)
 # Coverage distribution. Use `grep ^COV | cut -f 2-` to extract this part.

--- a/test/stat/4.stats.expected
+++ b/test/stat/4.stats.expected
@@ -416,6 +416,8 @@ RL	35	2
 FRL	35	1
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	35	1
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	40	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)
 # Coverage distribution. Use `grep ^COV | cut -f 2-` to extract this part.

--- a/test/stat/4.stats.large.expected
+++ b/test/stat/4.stats.large.expected
@@ -377,6 +377,8 @@ RL	35	2
 FRL	35	1
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	35	1
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	40	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)
 # Coverage distribution. Use `grep ^COV | cut -f 2-` to extract this part.

--- a/test/stat/5.stats.expected
+++ b/test/stat/5.stats.expected
@@ -416,6 +416,8 @@ RL	35	2
 FRL	35	1
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	35	1
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	40	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 ID	1	1	0
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)

--- a/test/stat/5.stats.large.expected
+++ b/test/stat/5.stats.large.expected
@@ -377,6 +377,8 @@ RL	35	2
 FRL	35	1
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	35	1
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	40	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 ID	1	1	0
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)

--- a/test/stat/6.stats.expected
+++ b/test/stat/6.stats.expected
@@ -416,6 +416,8 @@ RL	35	2
 FRL	35	1
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	35	1
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	40	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 ID	1	1	0
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)

--- a/test/stat/7.stats.expected
+++ b/test/stat/7.stats.expected
@@ -416,6 +416,8 @@ RL	35	2
 FRL	35	1
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	35	1
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	40	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 ID	1	2	0
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)

--- a/test/stat/7.stats.large.expected
+++ b/test/stat/7.stats.large.expected
@@ -377,6 +377,8 @@ RL	35	2
 FRL	35	1
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	35	1
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	40	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 ID	1	2	0
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)

--- a/test/stat/8.stats.expected
+++ b/test/stat/8.stats.expected
@@ -416,6 +416,8 @@ RL	35	2
 FRL	35	1
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	35	1
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	40	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 ID	1	1	0
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)

--- a/test/stat/8.stats.large.expected
+++ b/test/stat/8.stats.large.expected
@@ -377,6 +377,8 @@ RL	35	2
 FRL	35	1
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	35	1
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	40	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 ID	1	1	0
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)

--- a/test/stat/9.stats.expected
+++ b/test/stat/9.stats.expected
@@ -416,6 +416,8 @@ RL	35	2
 FRL	35	1
 # Read lengths - last fragments. Use `grep ^LRL | cut -f 2-` to extract this part. The columns are: read length, count
 LRL	35	1
+# Mapping qualities for reads !(UNMAP|SECOND|SUPPL|QCFAIL|DUP). Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
+MAPQ	40	2
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)
 # Coverage distribution. Use `grep ^COV | cut -f 2-` to extract this part.


### PR DESCRIPTION
Hi all,
unless I'm wrong, there is no histogram for the mapping qualities in `samtools stats`. This small PR adds a histogram(mapq,count).

Thanks.

example:
```
./samtools stats HG02260.transloc.chr9.14.bam | grep MAPQ 
# Mapping qualities. Use `grep ^MAPQ | cut -f 2-` to extract this part. The columns are: mapq, count
MAPQ	0	3
MAPQ	7	1
MAPQ	25	2
MAPQ	29	25
MAPQ	37	42
MAPQ	60	398
MAPQ	70	6
```