### PR TITLE
Fix unaligned access in dump_ref()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -68,6 +68,9 @@ Bug Fixes:
  * Fix missing RG headers when using samtools merge -r.
    (PR#1683, addresses htslib#1479.  Reported by Alex Leonard)
 
+ * Fix a possible unaligned access in samtools reference.
+   (PR#1696)
+
 Documentation:
 
  * Add documentation on CRAM compression profiles and some of the newer options

--- a/reference.c
+++ b/reference.c
@@ -88,7 +88,10 @@ static int dump_ref(sam_hdr_t *h, hts_itr_t *iter, int ref_id,
     // (was ~20%).
     if (verbose) {
         int n4[8] = {0};
-        for (j = 0; j < (ref_len&~7); j+=8) {
+        for (j = 0; j < ref_len && (((uintptr_t) &ref[j] & 7) != 0); j++)
+            N += ref[j] == 'N';
+        uint64_t fast_end = ((ref_len - j) & ~7) + j;
+        for (; j < fast_end; j+=8) {
             uint64_t i64 = *(uint64_t *)&ref[j];
             if (!haszero(i64 ^ 0x4e4e4e4e4e4e4e4eUL)) // 'N' <-> 0
                 continue;


### PR DESCRIPTION
Found building on SPARC, but it may cause slowdowns even on platforms that allow unaligned access.  Fix by putting in an
initial loop to get to an eight-byte boundary before switching to the fast mode.