### PR TITLE
Improve the speed of samtools sort

### DIFF
--- a/doc/samtools-merge.1
+++ b/doc/samtools-merge.1
@@ -88,6 +88,18 @@ order will be undefined.  See
 .B sort
 for information about record ordering.
 
+Problems may arise when attempting to merge thousands of files
+together.  The operating system may impose a limit on the maximum
+number of simultaneously open files.  See \fBulimit -n\fR for more
+information.  Additionally many files being read from simultaneously
+may cause a certain amount of "disk thrashing".  To partially
+alleviate this the merge command will load 1MB of data at a time from
+each file, but this in turn adds to the overal merge program memory
+usage.  Please take this into account when setting memory limits.
+
+In extreme cases, it may be necessary to reduce the problem to fewer
+files by successively merging subsets before a second round of merging.
+
 .TP 8
 .B -1
 Use Deflate compression level 1 to compress the output.


### PR DESCRIPTION
This is predominantly Rob Davies work from 3 years ago, but based on joint ideas from assessments both then and during the last week.

Sorting large files consists of a first phase of reading blocks of data, sorting them, and spilling to disk, followed by a second phase to merge the temporary files back together again.  This can lead to many files and consequentially lots of disk thrashing.  The best way to handle this is using `-m` to specify large memory usage, which reduces the number of files.  Another improvement is to increase the size of the blocks being read from the default 32KB used by htslib's hfile to 1MB.

Unfortunately the memory is per thread, so if we go from 1 thread to 16 threads then we need to reduce the block size by 16 to compensate.  That gives us 16 times more temporary files and a 16 fold bigger disk thrashing experience.  This PR merges the parallel sorted data together before writing to disk, dramatically reducing this.  It makes the sorting phase slower, but the merge stage considerably faster.

It's not perfect and there are more things that can be done (see below), but it's already a 3 fold speed increase for 16 threads on huge files (see commit message for lustre results).

Potential future work.

- The sort bit is parallel, but the merge step is in the main thread.  This is weak and causes the main thread to become the bottleneck so the overall parallelism is still poor.  We need a parallel merge (eg a naive recursive one) to remove this bottleneck.

- Even without being parallel, the merge is based on `ks_heapsort` which is quite poor performing.  A naive implementation just tracking the next N bam records was about 10% faster for `samtools merge`.  There is potential to speed that up further using a tree instead of a brute force search for the next lowest record.

- There are distinct phases of I/O bound and CPU bound during sort.  Ideally the I/O bit would be asynchronous and overlapping the CPU stage.  Using the thread-pool would work here, but it still needs a parallel merge too.

- Htslib: the `fdatasync` in hfile.c can be a slow down at times.  We should have a way to disable it as we don't need it for temporary files.  (It doesn't matter if the data is still in the disk cache provided we can process it and it ends correctly.)

- Htslib: the `qsize = nthreads*2` equation in bgzf blocks isn't optimal. `*10` gave better performance (about 10% when combined with the fsync change), but uses more memory.  Given the I/O in bgzf is asynchronous, boosting the queue size gives more potential for running I/O and CPU stages in parallel.  We need a better API for controlling this so we can increase it where helpful, without incurring higher memory costs across the board.