### PR TITLE
bug fix: template coordinate sort when merging in memory

### DIFF
--- a/bam_sort.c
+++ b/bam_sort.c
@@ -1686,7 +1686,7 @@ static inline int heap_add_read(heap1_t *heap, int nfiles, samFile **fp,
         if (in_mem[i - nfiles].from < in_mem[i - nfiles].to) {
             size_t from = in_mem[i - nfiles].from;
             heap->entry.bam_record = buf[from].bam_record;
-            if (g_sam_order == TemplateCoordinate) heap->entry.u.key = template_coordinate_keys_get(keys, from);
+            if (g_sam_order == TemplateCoordinate) heap->entry.u.key = buf[from].u.key;
             in_mem[i - nfiles].from++;
             res = 0;
         } else {
@@ -1742,7 +1742,7 @@ static int bam_merge_simple(SamOrder sam_order, char *sort_tag, const char *out,
     heap = (heap1_t*)calloc(heap_size, sizeof(heap1_t));
     if (!heap) goto mem_fail;
 
-    // Make sure that there's enough memory for template coordinate keys
+    // Make sure that there's enough memory for template coordinate keys, one per file to read
     if (keys && keys->n + n >= keys->m * keys->buffer_size) {
         if (template_coordinate_keys_realloc(keys, keys->n + n) < 0) goto mem_fail;
     }


### PR DESCRIPTION
_this pertains to template coordinate sorting introduced in #1605 only_

The current implementation succeeds when the full file can be sorted in memory using only one thread.  It fails when more than one thread (so merging in memory), or when spilling to disk (so there's a last block in memory that's merged with the reads on disk) .

I have tested this on a 250MB BAM by tweaking the `-@` and `-m` options (threads and memory) to vary if we're merging blocks in memory only, or we also merge blocks previously spilled to disk.  I have taken all the sorted BAMs and run them through `fgbio GroupReadsByUmi`, which fails on the current implementation.   I compared their results to the results from using a sorted BAM file produced by `fgbio SortBam` in template-coordinate order to `samtools sort --template-coordinate`.  I checked the "family size histogram" to ensure summary level statistics were the same.  I also ensured that the same # of source molecules were being assigned (# of unique MI tags).   I have asked another group to validate this fix on a larger dataset and will report back here with results. 

I am sincerely sorry that I did not catch this earlier, and hopefully this quick fix can make it out to folks before there's further harm. 