### PR TITLE
Work around PacBio HiFi quality induced biases.

### DIFF
--- a/consensus_pileup.c
+++ b/consensus_pileup.c
@@ -186,7 +186,7 @@ static int get_next_base(pileup_t *p, hts_pos_t pos, int nth, int *is_insert) {
         p->base4 = 16;
         p->padding = 1;
         if (p->seq_offset < b->core.l_qseq)
-            p->qual = (p->qual + p->b_qual[p->seq_offset+1])/2;
+            p->qual = MIN(p->qual, p->b_qual[p->seq_offset+1]);
         else
             p->qual = 0;
     } else {
@@ -196,9 +196,9 @@ static int get_next_base(pileup_t *p, hts_pos_t pos, int nth, int *is_insert) {
             p->base = '*';
             p->base4 = 16;
             if (p->seq_offset+1 < b->core.l_qseq)
-                p->qual = (p->qual + p->b_qual[p->seq_offset+1])/2;
+                p->qual = MIN(p->qual, p->b_qual[p->seq_offset+1]);
             else
-                p->qual = (p->qual + p->b_qual[p->seq_offset])/2;
+                p->qual = MIN(p->qual, p->b_qual[p->seq_offset]);
             break;
 
         case BAM_CPAD:
@@ -206,9 +206,9 @@ static int get_next_base(pileup_t *p, hts_pos_t pos, int nth, int *is_insert) {
             p->base = '*';
             p->base4 = 16;
             if (p->seq_offset+1 < b->core.l_qseq)
-                p->qual = (p->qual + p->b_qual[p->seq_offset+1])/2;
+                p->qual = MIN(p->qual, p->b_qual[p->seq_offset+1]);
             else
-                p->qual = (p->qual + p->b_qual[p->seq_offset])/2;
+                p->qual = MIN(p->qual, p->b_qual[p->seq_offset]);
             break;
 
         case BAM_CREF_SKIP:

--- a/doc/samtools-consensus.1
+++ b/doc/samtools-consensus.1
@@ -292,7 +292,7 @@ of whether the output is reported as ambiguous (it will be "N" if
 deemed to be heterozygous without \fB--ambig\fR mode enabled).
 
 .TP
-.BR -h ", " --homopoly-fix
+.BR -p ", " --homopoly-fix
 Some technologies that call runs of the same base type together always
 put the lowest quality calls at one end.  This can cause problems when
 reverse complementing and comparing alignments with indels.  This

--- a/doc/samtools-consensus.1
+++ b/doc/samtools-consensus.1
@@ -291,6 +291,14 @@ probability of the base being homozygous vs heterozygous, irrespective
 of whether the output is reported as ambiguous (it will be "N" if
 deemed to be heterozygous without \fB--ambig\fR mode enabled).
 
+.TP
+.BR -h ", " --homopoly-fix
+Some technologies that call runs of the same base type together always
+put the lowest quality calls at one end.  This can cause problems when
+reverse complementing and comparing alignments with indels.  This
+option averages the qualities at both ends to avoid orientation
+biases.  Recommended for old 454 or PacBio HiFi data sets.
+
 .SH EXAMPLES
 .IP -
 Create a modified FASTA reference that has a 1:1 coordinate correspondence with the original reference used in alignment.


### PR DESCRIPTION
With a homopoymer, eg in ATTTTC, one base in the run is likely given a low confidence value.  This is always the same end.  After reverse complementing during alignment, we get a mix of low qualities at the first and last base.  However the alignment algorithms typically do left-justification of gaps, so any slight strand bias will be exacerbated as high vs low confidence calls for that indel.

This method averages the first and last qualities together to get an amortised new quality.  It then averages the end two inner qualities together, and so on.

This has been seen to reduce indel consensus call errors considerably in some PB HiFi data sets.