### PR TITLE
Fix SEGV in samtoools collate when no filename given.

### DIFF
--- a/bamshuf.c
+++ b/bamshuf.c
@@ -607,6 +607,12 @@ int main_bamshuf(int argc, char *argv[])
     }
     if (is_un) clevel = 0;
     if (argc >= optind + 2) prefix = argv[optind+1];
+    if (argc == optind) {
+        if (argc > 1 || !isatty(STDIN_FILENO))
+            fprintf(stderr, "collate: no input filename specified.\n");
+        return usage(argc > 1 || !isatty(STDIN_FILENO) ? stderr : stdout,
+                     n_files, reads_store);
+    }
     if (!(prefix || is_stdout || output_file))
         return usage(stderr, n_files, reads_store);
     if (is_stdout && output_file) {

--- a/bamshuf.c
+++ b/bamshuf.c
@@ -201,7 +201,7 @@ static int bamshuf(const char *fn, int n_files, const char *pre, int clevel,
 
     // Read input, distribute reads pseudo-randomly into n_files temporary
     // files.
-    fp = sam_open_format(fn, "r", &ga->in);
+    fp = sam_open_format(fn ? fn : "-", "r", &ga->in);
     if (fp == NULL) {
         print_error_errno("collate", "Cannot open input file \"%s\"", fn);
         return 1;


### PR DESCRIPTION
"/dev/stdin" or "-" both work, but just reading from stdin crashed.