### PR TITLE
Make faidx/fqidx output line length default to the input line length.

### DIFF
--- a/doc/samtools-faidx.1
+++ b/doc/samtools-faidx.1
@@ -76,8 +76,8 @@ any extracted subsequence will be in FASTA format.
 Write FASTA to file rather than to stdout.
 .TP
 .BI "-n, --length " INT
-Length of FASTA sequence line.
-[60]
+Length for FASTA sequence line wrapping.  If zero, this means do not
+line wrap.  Defaults to the line length in the input file.
 .TP
 .B -c, --continue
 Continue working if a non-existent region is requested.

--- a/doc/samtools-fqidx.1
+++ b/doc/samtools-fqidx.1
@@ -77,7 +77,8 @@ searches using the index will be very slow and use a lot of memory.
 Write FASTQ to file rather than to stdout.
 .TP
 .BI "-n, --length " INT
-Length of FASTQ sequence line.
+Length for FASTQ sequence line wrapping.  If zero, this means do not
+line wrap.  Defaults to the line length in the input file.
 [60]
 .TP
 .B -c, --continue

--- a/doc/samtools-fqidx.1
+++ b/doc/samtools-fqidx.1
@@ -79,7 +79,6 @@ Write FASTQ to file rather than to stdout.
 .BI "-n, --length " INT
 Length for FASTQ sequence line wrapping.  If zero, this means do not
 line wrap.  Defaults to the line length in the input file.
-[60]
 .TP
 .B -c, --continue
 Continue working if a non-existent region is requested.


### PR DESCRIPTION
Also adjusted -n to accept 0 to mean unwrapped.

Finally, corrected an error in write_line regarding mistaking INT_MAX and HTS_POS_MAX for the bounds checking.

Fixes #1734

NB needs https://github.com/samtools/htslib/pull/1516 merging first.