### PR TITLE
Fix samtools consensus buffer overrun with MD:Z handling.

### DIFF
--- a/bam_consensus.c
+++ b/bam_consensus.c
@@ -460,6 +460,8 @@ int nm_init(void *client_data, samFile *fp, sam_hdr_t *h, pileup_t *p) {
 
     const bam1_t *b = &p->b;
     int qlen = b->core.l_qseq, i;
+    if (qlen <= 0)
+        return 0;
     int *local_nm = calloc(qlen, sizeof(*local_nm));
     if (!local_nm)
         return -1;
@@ -593,7 +595,7 @@ int nm_init(void *client_data, samFile *fp, sam_hdr_t *h, pileup_t *p) {
         }
 
         // substitution
-        for (i = pos-halo*2 >= 0 ? pos-halo*2 : 0; i < pos-halo; i++)
+        for (i = pos-halo*2 >= 0 ?pos-halo*2 :0; i < pos-halo && i < qlen; i++)
             local_nm[i]+=5;
         for (; i < pos+halo && i < qlen; i++)
             local_nm[i]+=10;


### PR DESCRIPTION
An MD tag that refers to bases beyond the SEQ field could write beyond the end of the local_nm buffer.  We already had bounds checks in 2 out of 3 initialisation loops, but sadly missed the first one.  The code adds +5 to an array entry, rather than arbitrary user-specified data, but it's still a security risk to this one sub-command.

Also streamlined the process to simply skip data with qlen of zero (SEQ "*").

Fixes #1744