### PR TITLE
Fix a buffer read-overflow on sequences with seq "*".

### DIFF
--- a/bam_tview.c
+++ b/bam_tview.c
@@ -242,8 +242,10 @@ int tv_pl_func(uint32_t tid, hts_pos_t pos, int n, const bam_pileup1_t *pl, void
                         if (tv->show_name) {
                             char *name = bam_get_qname(p->b);
                             c = (p->qpos + 1 >= p->b->core.l_qname)? ' ' : name[p->qpos];
-                        } else {
-                            c = seq_nt16_str[bam_seqi(bam_get_seq(p->b), p->qpos)];
+                       } else {
+                            c = p->qpos < p->b->core.l_qseq
+                                ? seq_nt16_str[bam_seqi(bam_get_seq(p->b), p->qpos)]
+                                : 'N';
                             if (tv->is_dot && toupper(c) == toupper(rb)) c = bam_is_rev(p->b)? ',' : '.';
                         }
                     }
@@ -285,7 +287,9 @@ int tv_pl_func(uint32_t tid, hts_pos_t pos, int n, const bam_pileup1_t *pl, void
                     if (x > 4) x = 4;
                     attr |= tv->my_colorpair(tv,x);
                 } else if (tv->color_for == TV_COLOR_NUCL) {
-                    x = seq_nt16_int[bam_seqi(bam_get_seq(p->b), p->qpos)] + 5;
+                    x = p->qpos < p->b->core.l_qseq
+                        ? seq_nt16_int[bam_seqi(bam_get_seq(p->b), p->qpos)] + 5
+                        : 4;
                     attr |= tv->my_colorpair(tv,x);
                 } else if(tv->color_for == TV_COLOR_COL) {
                     x = 0;


### PR DESCRIPTION
When a record has no seq entry, but still has a CIGAR string, tview attempts to still display the sequence.  Trying to hide it is challenging as it needs changes in the lpileup code too, and potentially there is still merit in showing the alignment minus bases if that is indeed what we recorded.

However the sequence and qualities show are fetched from beyond the end of the seq and qual pointers, so it's a read buffer overrun into arbitrary memory.  They've now been replaced with N and qual 0.

Note htslib has a similar related bug.

It's amazing we've never spotted this before!