### PR TITLE
Permit 1 thread with samtools view.

### DIFF
--- a/sam_view.c
+++ b/sam_view.c
@@ -1233,7 +1233,7 @@ int main_samview(int argc, char *argv[])
         settings.unmap = 0;  // Not valid in counting mode
     }
 
-    if (ga.nthreads > 1) {
+    if (ga.nthreads > 0) {
         if (!(p.pool = hts_tpool_init(ga.nthreads))) {
             fprintf(stderr, "Error creating thread pool\n");
             ret = 1;


### PR DESCRIPTION
A grep for `nthreads( *)>` shows all other subcommands already permit -@1, but samtools view needed -@2 and above.

One thread is still beneficial as it permits asynchronous I/O. Testing the same file on two identical machines that haven't currently got that file in their local cache (the remote NFS server does have it cached, via samtools running on a 3rd machine) show approx 12% faster wall-clock speed.

Fixes #1743