### PR TITLE
Make the typical lack of --input-fmt option more explicit.

### DIFF
--- a/doc/samtools.1
+++ b/doc/samtools.1
@@ -861,8 +861,8 @@ Several long-options are shared between multiple samtools sub-commands:
 \fB--input-fmt\fR, \fB--input-fmt-option\fR, \fB--output-fmt\fR,
 \fB--output-fmt-option\fR, \fB--reference\fR, \fB--write-index\fR,
 and \fB--verbosity\fR.
-The input format is typically auto-detected so specifying the format
-is usually unnecessary and the option is included for completeness.
+The input format is auto-detected and specifying the format
+is unnecessary, so this option is rarely offered.
 Note that not all subcommands have all options.  Consult the subcommand
 help for more details.
 .PP


### PR DESCRIPTION
It is infact used in one command (ampliconstats).  I could move the description there, but it feels odd to have input format described there and not output format and I didn't want to replicate more than is necessary.  Hence this minimal change.

See comments in #823