### PR TITLE
Use TMPDIR environment variable, when looking for a temporary folder.

### DIFF
--- a/bamshuf.c
+++ b/bamshuf.c
@@ -567,13 +567,18 @@ char * generate_prefix() {
     snprintf(prefix + ret, PREFIX_LEN - ret, "\\%x", pid);
     return prefix;
 #else
-#  define PREFIX_LEN 64
-    prefix = malloc(PREFIX_LEN);
+    char *tmp_env = getenv("TMPDIR");
+    if (!tmp_env)
+        tmp_env = "/tmp";
+
+    size_t prefix_len = strlen(tmp_env)+20;
+    prefix = malloc(prefix_len);
     if (!prefix) {
         perror("collate");
         return NULL;
     }
-    snprintf(prefix, PREFIX_LEN, "/tmp/collate%x", pid);
+    snprintf(prefix, prefix_len, "%s/collate%x", tmp_env, pid);
+
     return prefix;
 #endif
 }

--- a/bamshuf.c
+++ b/bamshuf.c
@@ -1,7 +1,7 @@
 /*  bamshuf.c -- collate subcommand.
 
     Copyright (C) 2012 Broad Institute.
-    Copyright (C) 2013, 2015-2019 Genome Research Ltd.
+    Copyright (C) 2013, 2015-2019,2023 Genome Research Ltd.
 
     Author: Heng Li <lh3@sanger.ac.uk>
 
@@ -527,15 +527,17 @@ static int bamshuf(const char *fn, int n_files, const char *pre, int clevel,
 
 static int usage(FILE *fp, int n_files, int reads_store) {
     fprintf(fp,
-            "Usage: samtools collate [-Ou] [-o <name>] [-n nFiles] [-l cLevel] <in.bam> [<prefix>]\n\n"
+            "Usage: samtools collate [options...] <in.bam> [<prefix>]\n\n"
             "Options:\n"
-            "      -O       output to stdout\n"
-            "      -o       output file name (use prefix if not set)\n"
-            "      -u       uncompressed BAM output\n"
-            "      -f       fast (only primary alignments)\n"
-            "      -r       working reads stored (with -f) [%d]\n" // reads_store
-            "      -l INT   compression level [%d]\n" // DEF_CLEVEL
-            "      -n INT   number of temporary files [%d]\n" // n_files
+            "      -O       Output to stdout\n"
+            "      -o       Output file name (use prefix if not set)\n"
+            "      -u       Uncompressed BAM output\n"
+            "      -f       Fast (only primary alignments)\n"
+            "      -r       Working reads stored (with -f) [%d]\n" // reads_store
+            "      -l INT   Compression level [%d]\n" // DEF_CLEVEL
+            "      -n INT   Number of temporary files [%d]\n" // n_files
+            "      -T PREFIX\n"
+            "               Write tempory files to PREFIX.nnnn.bam\n"
             "      --no-PG  do not add a PG line\n",
             reads_store, DEF_CLEVEL, n_files);
 
@@ -546,9 +548,21 @@ static int usage(FILE *fp, int n_files, int reads_store) {
     return 1;
 }
 
-char * generate_prefix() {
+char *generate_prefix(const char *out_fn) {
     char *prefix;
     unsigned int pid = getpid();
+
+    if (out_fn && !(*out_fn == '-' && out_fn[1] == '\0')) {
+        // <out_fn>.<collate><pid>.<nnnn>.<bam>
+        size_t plen = strlen(out_fn) + 50;
+        if (!(prefix = malloc(plen))) {
+            perror("collate");
+            return NULL;
+        }
+        snprintf(prefix, plen, "%s.collate%x", out_fn, pid);
+        return prefix;
+    }
+
 #ifdef _WIN32
 #  define PREFIX_LEN (MAX_PATH + 16)
     DWORD ret;
@@ -595,7 +609,7 @@ int main_bamshuf(int argc, char *argv[])
         { NULL, 0, NULL, 0 }
     };
 
-    while ((c = getopt_long(argc, argv, "n:l:uOo:@:fr:", lopts, NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "n:l:uOo:@:fr:T:", lopts, NULL)) >= 0) {
         switch (c) {
         case 'n': n_files = atoi(optarg); break;
         case 'l': clevel = atoi(optarg); break;
@@ -604,6 +618,7 @@ int main_bamshuf(int argc, char *argv[])
         case 'o': output_file = optarg; break;
         case 'f': fast_coll = 1; break;
         case 'r': reads_store = atoi(optarg); break;
+        case 'T': prefix = optarg; break;
         case 1: no_pg = 1; break;
         default:  if (parse_sam_global_opt(c, optarg, lopts, &ga) == 0) break;
                   /* else fall-through */
@@ -625,7 +640,7 @@ int main_bamshuf(int argc, char *argv[])
         return usage(stderr, n_files, reads_store);
     }
     if (!prefix) {
-        prefix = generate_prefix();
+        prefix = generate_prefix(output_file);
         pre_mem = 1;
     }
 

--- a/doc/samtools-collate.1
+++ b/doc/samtools-collate.1
@@ -58,14 +58,15 @@ but doesn't make any guarantees about the order of read names between groups.
 The output from this command should be suitable for any operation that
 requires all reads from the same template to be grouped together.
 
-If present, <prefix> is used to name the temporary files that collate
-uses when sorting the data.  If neither the \fB-O\fR nor \fB-o\fR options are used,
-<prefix> must be present and collate will use it to make an output file name
-by appending a suffix depending on the format written (.bam by default).
+Temporary files are written to <prefix>, specified either as the last
+argument or with the \fB-T\fR option.  If prefix is unspecified then
+one will be derived from the output filename (\fB\-o\fR option).
+If no output file was given then the \fBTMPDIR\fR environment variable will be
+used, and finally if that is unset then "/tmp" is used.
 
-If either the \fB-O\fR or \fB-o\fR option is used, <prefix> is optional.  If <prefix>
-is absent, collate will write the temporary files to a system-dependent
-location (/tmp on UNIX).
+Conversely, if prefix is specified but no output filename has been
+given then the output will be written to <prefix>.<fmt> where <fmt>
+is appropriate to the file format is use (e.g. "bam" or "cram").
 
 Using \fB-f\fR for fast mode will output \fBonly\fR primary alignments that have
 either the READ1 \fBor\fR READ2 flags set (but not both).
@@ -94,10 +95,17 @@ sizes on batches of reads.
 .SH OPTIONS
 .TP 8
 .B -O
-Output to stdout.  This option cannot be used with '-o'.
+Output to stdout.  This option cannot be used with \fB-o\fR.
 .TP
-.B -o FILE
-Write output to FILE.  This option cannot be used with '-O'.
+.BI "-o " FILE
+Write output to FILE.  This option cannot be used with \fB-O\fR.  If
+unspecified and \fB-O\fR is not set, the temporary file <prefix> is
+used, appended by the the appropriate file-format suffix.
+.TP
+.BI "-T " PREFIX
+Use \fIPREFIX\fR for temporary files.  This is the same as specifying
+\fIPREFIX\fR as the last argument on the command line.  This option
+is included for consistency with \fBsamtools sort\fR.
 .TP
 .B -u
 Write uncompressed BAM output


### PR DESCRIPTION
Fixes #1172, replaces #1178.

My changes to 1178 are minimal, to improve corner cases when on systems with larger PID values.