### PR TITLE
Fix a couple of problems spotted after merging #1777

### DIFF
--- a/.ci_helpers/clone
+++ b/.ci_helpers/clone
@@ -17,7 +17,7 @@ ref=''
 set -x
 git clone --recurse-submodules --shallow-submodules --depth=50 ${ref:+--branch="$branch"} "$repository" "$localdir"
 
-if [ "x$htslib_PR" != "" ]
+if [ "x$htslib_PR" != "x" ]
 then
     cd "$localdir"
     git fetch origin "pull/$htslib_PR/head"

--- a/doc/samtools-cram-size.1
+++ b/doc/samtools-cram-size.1
@@ -1,7 +1,7 @@
 '\" t
-.TH samtools-cram_size 1 "11 January 2023" "samtools-1.16.1" "Bioinformatics tools"
+.TH samtools-cram-size 1 "11 January 2023" "samtools-1.16.1" "Bioinformatics tools"
 .SH NAME
-samtools cram_size \- list a break down of data types in a CRAM file
+samtools cram-size \- list a break down of data types in a CRAM file
 .\"
 .\" Copyright (C) 2023 Genome Research Ltd.
 .\"
@@ -40,7 +40,7 @@ samtools cram_size \- list a break down of data types in a CRAM file
 .
 .SH SYNOPSIS
 .PP
-samtools cram_sizee
+samtools cram-size
 .RB [ -ve ]
 .RB [ -o
 .IR file ]
@@ -152,7 +152,7 @@ processing.
 .IP -
 The basic summary of block Content ID sizes for a CRAM file:
 .EX 2
-$ samtools cram_size in.cram
+$ samtools cram-size in.cram
 #   Content_ID  Uncomp.size    Comp.size   Ratio Method  Data_series
 BLOCK     CORE            0            0 100.00% .      
 BLOCK       11    394734019     51023626  12.93% g       RN
@@ -166,7 +166,7 @@ BLOCK       14     26625602      6803930  25.55% Rrg     SC
 Show the same file above with verbose mode.  Here we see the distinct
 compression methods which have been used per block Content ID.
 .EX 2
-$ samtools cram_size -v in.cram
+$ samtools cram-size -v in.cram
 #   Content_ID  Uncomp.size    Comp.size   Ratio Method      Data_series
 BLOCK     CORE            0            0 100.00% raw        
 BLOCK       11    394734019     51023626  12.93% gzip        RN
@@ -187,7 +187,7 @@ the standard CRAM Data Series and the three letter ones are the
 optional auxiliary tags with the tag name and type combined.
 
 .EX 2
-$ samtools cram_size -e in.cram
+$ samtools cram-size -e in.cram
 Container encodings
     RN      BYTE_ARRAY_STOP(stop=0,id=11)
     QS      EXTERNAL(id=12)

--- a/doc/samtools.1
+++ b/doc/samtools.1
@@ -61,7 +61,7 @@ samtools consensus -o out.fasta in.bam
 .PP
 samtools coverage aln.sorted.bam
 .PP
-samtools cram_size -v -o out.size in.cram
+samtools cram-size -v -o out.size in.cram
 .PP
 samtools depad input.bam
 .PP
@@ -330,9 +330,9 @@ but doesn't make any guarantees about the order of read names between groups.
 The output from this command should be suitable for any operation that
 requires all reads from the same template to be grouped together.
 
-.TP \"-------- cram_size
-.B cram_size
-samtools cram_size
+.TP \"-------- cram-size
+.B cram-size
+samtools cram-size
 .RI [ options ]
 .IR in.cram
 
@@ -1369,7 +1369,7 @@ for further authorship.
 .IR samtools-collate (1),
 .IR samtools-consensus (1),
 .IR samtools-coverage (1),
-.IR samtools-cram_size (1),
+.IR samtools-cram-size (1),
 .IR samtools-depad (1),
 .IR samtools-depth (1),
 .IR samtools-dict (1),


### PR DESCRIPTION
* cram-size manual page should say `cram-size`, not `cram_size`
* Fix CI clone of HTSlib when not referencing a specific HTSlib PR