### PR TITLE
Minor fix to wording of mpileup --rf.

### DIFF
--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -941,9 +941,12 @@ static void print_usage(FILE *fp, const mplp_conf_t *mplp)
     fprintf(fp,
 "  -r, --region REG        region in which pileup is generated\n"
 "  -R, --ignore-RG         ignore RG tags (one BAM = one sample)\n"
-"  --rf, --incl-flags STR|INT  required flags: include reads with any of the mask bits set [%s]\n", tmp_require);
+"  --rf, --incl-flags STR|INT\n"
+"                          required flags: only include reads with any of\n"
+"                          the mask bits set [%s]\n", tmp_require);
     fprintf(fp,
-"  --ff, --excl-flags STR|INT  filter flags: skip reads with any of the mask bits set\n"
+"  --ff, --excl-flags STR|INT\n"
+"                          filter flags: skip reads with any of the mask bits set\n"
 "                                            [%s]\n", tmp_filter);
     fprintf(fp,
 "  -x, --ignore-overlaps-removal, --disable-overlap-removal\n"

--- a/doc/samtools-mpileup.1
+++ b/doc/samtools-mpileup.1
@@ -271,11 +271,13 @@ two requests.
 Ignore RG tags. Treat all reads in one BAM as one sample.
 .TP
 .BI --rf,\ --incl-flags \ STR|INT
-Required flags: include reads with any of the mask bits set [null]
+Required flags: only include reads with any of the mask bits set [null].
+Note this does not override the \fB--excl-flags\fR option.
 .TP
 .BI --ff,\ --excl-flags \ STR|INT
 Filter flags: skip reads with any of the mask bits set
-[UNMAP,SECONDARY,QCFAIL,DUP]
+[UNMAP,SECONDARY,QCFAIL,DUP].
+Note this does not override the \fB--incl-flags\fR option.
 .TP
 .B -x,\ --ignore-overlaps-removal, --disable-overlap-removal
 Overlap detection and removal is enabled by default.  This option


### PR DESCRIPTION
The change of "include reads" to "only include reads" is stronger language, emphasising that this is a filter-out rather than filter-in rule.  The use of "only" already appears in view, depth, fastq and consensus subcommands.

I note however that "coverage" currently says

    ... required flags: skip reads with mask bits unset []

This was my initial thought on phrasing this, as it's explicitly what the code does. However I chose to go with the majority for a smaller change instead. (Arguably we should also rephrase coverage.)

Also fixed line-wrapping to appear better on a standard 80 column terminal and to get the usage statement with consistent indentation.

Added text to the man page to make explicit that --rf and --ff work independently and don't override each other.

Fixes #1791