### PR TITLE
Allow sorting using minimisers with fwd strand only

### DIFF
--- a/doc/samtools-sort.1
+++ b/doc/samtools-sort.1
@@ -55,6 +55,7 @@ samtools sort
 .RB [ -M ]
 .RB [ -K
 .IR kmerLen ]
+.RB [ -R ]
 .RB [ -n ]
 .RB [ -t
 .IR tag ]
@@ -140,6 +141,9 @@ option.  Note data compressed in this manner may need to be name
 collated prior to conversion back to fastq.
 .IP
 Mapped sequences are sorted by chromosome and position.
+.TP
+.B "-R "
+Do not use reverse strand (only compatible with -M).
 .TP
 .B -n
 Sort by read names (i.e., the


### PR DESCRIPTION
This feature enables avoiding downstream tools to have special logic for reverse unaligned records. It's in particular complicated when methylation tags or custom tags in native orientation are used. The compression is not as great as using both strands, but acceptable. We prefer ease of use and have this feature as part of the official `samtools sort`. On average, for PacBio Revio HiFi datasets with MM/ML, we reduce file size by 13.8% only using fwd strand and 14.0% using both strands.