### PR TITLE
Minor manual page updates

### DIFF
--- a/doc/samtools-cram-size.1
+++ b/doc/samtools-cram-size.1
@@ -85,7 +85,7 @@ g	gzip	Gzip
 G	gzip-max	Gzip -9
 b	bzip2	Bzip2
 b	bzip2-1 to bzip2-8	Explicit bzip2 compression levels
-B	bzip2-9			Bzip2 -9
+B	bzip2-9	Bzip2 -9
 l	lzma	LZMA
 r	r4x8-o0	rANS 4x8 Order-0
 R	r4x8-o1	rANS 4x8 Order-1
@@ -159,7 +159,7 @@ BLOCK       11    394734019     51023626  12.93% g       RN
 BLOCK       12   1504781763     99158495   6.59% R       QS
 BLOCK       13       330065        84195  25.51% _r.g    IN
 BLOCK       14     26625602      6803930  25.55% Rrg     SC
-...
+\&...
 .EE
 
 .IP -
@@ -178,7 +178,7 @@ BLOCK       13         9253         1988  21.49% gzip        IN
 BLOCK       14     23106404      5903351  25.55% r4x8-o1     SC
 BLOCK       14      1951616       513722  26.32% r4x8-o0     SC
 BLOCK       14      1567582       386857  24.68% gzip        SC
-...
+\&...
 .EE
 
 .IP -

--- a/doc/samtools.1
+++ b/doc/samtools.1
@@ -1354,7 +1354,8 @@ samtools.  Bob Handsaker from the Broad Institute implemented the BGZF
 library.  Petr Danecek and Heng Li wrote the VCF/BCF implementation.
 James Bonfield from the Sanger Institute developed the CRAM
 implementation.  Other large code contributions have been made by
-John Marshall, Rob Davies, Martin Pollard, Andrew Whitwham, Valeriu Ohan
+John Marshall, Rob Davies, Martin Pollard, Andrew Whitwham, Valeriu Ohan,
+Vasudeva Sarma
 (all while primarily at the Sanger Institute), with numerous other
 smaller but valuable contributions.  See the per-command manual pages
 for further authorship.


### PR DESCRIPTION
Fix bzip2-9 entry in samtools-cram-size.1 compression methods table

Also in samtools-cram-size.1, prepend `...` with a non-printable, zero-width glyph (`\&`) so it isn't misinterpreted as roff syntax.

Add Vasudeva to list of authors in samtools.1