### PR TITLE
Fix bug in split output format and improve man page

### DIFF
--- a/bam_split.c
+++ b/bam_split.c
@@ -1,6 +1,6 @@
 /*  bam_split.c -- split subcommand.
 
-    Copyright (C) 2013-2016,2018-2019 Genome Research Ltd.
+    Copyright (C) 2013-2016,2018-2019,2023 Genome Research Ltd.
 
     Author: Martin Pollard <mp15@sanger.ac.uk>
 
@@ -292,7 +292,7 @@ static state_t* init(parsed_opts_t* opts, const char *arg_list)
         }
     }
 
-    retval->merged_input_file = sam_open_format(opts->merged_input_name, "rb", &opts->ga.in);
+    retval->merged_input_file = sam_open_format(opts->merged_input_name, "r", &opts->ga.in);
     if (!retval->merged_input_file) {
         print_error_errno("split", "Could not open \"%s\"", opts->merged_input_name);
         cleanup_state(retval, false);
@@ -341,7 +341,10 @@ static state_t* init(parsed_opts_t* opts, const char *arg_list)
             }
         }
 
-        retval->unaccounted_file = sam_open_format(opts->unaccounted_name, "wb", &opts->ga.out);
+        char outmode[4] = "w";
+        sam_open_mode(outmode + 1, opts->unaccounted_name, NULL);
+        retval->unaccounted_file = sam_open_format(opts->unaccounted_name, outmode, &opts->ga.out);
+
         if (retval->unaccounted_file == NULL) {
             print_error_errno("split", "Could not open unaccounted output file \"%s\"", opts->unaccounted_name);
             cleanup_state(retval, false);
@@ -381,6 +384,7 @@ static state_t* init(parsed_opts_t* opts, const char *arg_list)
     size_t i;
     for (i = 0; i < retval->output_count; i++) {
         char* output_filename = NULL;
+        char outmode[4] = "w";
 
         output_filename = expand_format_string(opts->output_format_string,
                                                input_base_name,
@@ -394,7 +398,10 @@ static state_t* init(parsed_opts_t* opts, const char *arg_list)
         }
 
         retval->rg_output_file_name[i] = output_filename;
-        retval->rg_output_file[i] = sam_open_format(output_filename, "wb", &opts->ga.out);
+
+        sam_open_mode(outmode + 1, output_filename, NULL);
+        retval->rg_output_file[i] = sam_open_format(output_filename, outmode, &opts->ga.out);
+
         if (retval->rg_output_file[i] == NULL) {
             print_error_errno("split", "Could not open \"%s\"", output_filename);
             cleanup_state(retval, false);

--- a/doc/samtools-split.1
+++ b/doc/samtools-split.1
@@ -63,6 +63,10 @@ The \fB-u\fR option may be used to specify the output filename for any
 records with a missing or unrecognised RG tag.  This option will always write
 out a file even if there are no records.
 
+Output format defaults to BAM.  For SAM or CRAM then either set the format with
+\fB--output-fmt\fR or use \fB-f\fR to set the file extension e.g.
+\fB-f %*_%#.sam\fR. 
+
 .SH OPTIONS
 .TP 14
 .BI "-u " FILE1

--- a/doc/samtools-split.1
+++ b/doc/samtools-split.1
@@ -3,7 +3,7 @@
 .SH NAME
 samtools split \- splits a file by read group.
 .\"
-.\" Copyright (C) 2008-2011, 2013-2018 Genome Research Ltd.
+.\" Copyright (C) 2008-2011, 2013-2018,2023 Genome Research Ltd.
 .\" Portions copyright (C) 2010, 2011 Broad Institute.
 .\"
 .\" Author: Heng Li <lh3@sanger.ac.uk>
@@ -53,8 +53,15 @@ Splits a file by read group, producing one or more output files
 matching a common prefix (by default based on the input filename)
 each containing one read-group.
 
+Records without an RG tag or with an RG tag undefined in the header will cause
+the program to exit with an error unless the \fB-u\fR option is used.
+
+RG values defined in the header but with no records will produce an output file
+only containing a header.
+
 The \fB-u\fR option may be used to specify the output filename for any
-records without an RG tag.
+records with a missing or unrecognised RG tag.  This option will always write
+out a file even if there are no records.
 
 .SH OPTIONS
 .TP 14


### PR DESCRIPTION
All output in split was forced to be in BAM format.  This change will allow SAM and CRAM to be used as well as BAM.

Additions to the man page to explain split default behaviour.  Fixes #1817.