### PR TITLE
Issue templates: Try to direct conda-related issues to Bioconda

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name:  Conda issues
+    url:   https://github.com/bioconda/bioconda-recipes
+    about: Please report issues specific to the samtools conda package to Bioconda.


### PR DESCRIPTION
Use an [issue template config file](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) to add a “Conda issues” link alongside samtools's issue templates on the “New issue” form. This may help users to report such issues in a more appropriate repository and stop spamming maintainers who are uninterested in conda.

You can see how this looks at https://github.com/jmarshall/samtools/issues/new/choose :—

<img width="1167" alt="New issue dialog on jmarshall's repository" src="https://user-images.githubusercontent.com/70921/230506458-63f55b88-75cd-46de-ba4c-5a4b21785740.png">
