### PR TITLE
Removed line that caused a warning in gcc-13.

### DIFF
--- a/bam_tview_curses.c
+++ b/bam_tview_curses.c
@@ -330,7 +330,6 @@ static void tv_win_goto(curses_tview_t *tv, int *tid, hts_pos_t *pos) {
 
 static void tv_win_help(curses_tview_t *tv) {
     int r = 1;
-    tview_t* base=(tview_t*)base;
     WINDOW *win = tv->whelp;
     wborder(win, '|', '|', '-', '-', '+', '+', '+', '+');
     mvwprintw(win, r++, 2, "        -=-    Help    -=- ");


### PR DESCRIPTION
In gcc 13.1.0 `tview_t* base=(tview_t*)base;` counts as using an uninitialised variable.