### PR TITLE
Make calmd "work" on unaligned data or empty files.

### DIFF
--- a/bam_md.c
+++ b/bam_md.c
@@ -411,8 +411,11 @@ int bam_fillmd(int argc, char *argv[])
 
     header = sam_hdr_read(fp);
     if (header == NULL || sam_hdr_nref(header) == 0) {
-        fprintf(stderr, "[bam_fillmd] input SAM does not have header. Abort!\n");
-        goto fail;
+        // NB: if we have no SQ headers but have aligned data, then this will
+        // be caught during processing with e.g.
+        // "[E::sam_parse1] no SQ lines present in the header"
+        fprintf(stderr, "[bam_fillmd] warning: input SAM does not have "
+                "header, performing a no-op.\n");
     }
 
     fpout = sam_open_format("-", mode_w, &ga.out);


### PR DESCRIPTION
If a processing pipeline (eg pooling, barcode splitting, etc) has a chance to create a file with headers but no sequences, then it should not be an error.  It can instead simply repeat the header and exit cleanly.

Similarly a SAM file containing only unaligned data will have no alignments to rebuild the MD tag for, which also should not be an error.

We do however still produce a warning, as it's an unlikely scenario and it may be symptomatic of something having gone wrong earlier in processing.

Fixes #1839