### PR TITLE
Consistent, more comprehensive flag filtering for samtools fasta/fastq

### DIFF
--- a/doc/samtools-fasta.1
+++ b/doc/samtools-fasta.1
@@ -189,7 +189,7 @@ present in the FLAG field.
 can be specified in hex by beginning with `0x' (i.e. /^0x[0-9A-F]+/)
 or in octal by beginning with `0' (i.e. /^0[0-7]+/) [0].
 .TP 8
-.BI "-F " INT
+.BI "-F " INT ", ", --excl-flags " INT ", --exclude-flags " INT
 Do not output alignments with any bits set in
 .I INT
 present in the FLAG field.
@@ -199,6 +199,15 @@ or in octal by beginning with `0' (i.e. /^0[0-7]+/) [0x900].
 This defaults to 0x900 representing filtering of secondary and
 supplementary alignments.
 .TP 8
+.BI "--rf " INT " , --incl-flags " INT ", --include-flags " INT
+Only output alignments with any bits set in
+.I INT
+present in the FLAG field.
+.I INT
+can be specified in hex by beginning with `0x' (i.e. /^0x[0-9A-F]+/),
+in octal by beginning with `0' (i.e. /^0[0-7]+/), as a decimal number
+not beginning with '0' or as a comma-separated list of flag names [0].
+.TP
 .BI "-G " INT
 Only EXCLUDE reads with all of the bits set in
 .I INT


### PR DESCRIPTION
This PR is an extension of https://github.com/samtools/samtools/pull/1508,  for the `fasta`/`fastq` command - similar to https://github.com/samtools/samtools/pull/1718 for `depth`. This should allow exporting reads that match any/either of the bits present in the FLAG to a fastq file. I have followed the conversation in https://github.com/samtools/samtools/issues/1470 and https://github.com/samtools/samtools/pull/1442#issuecomment-871244137, and followed the recommendations for variable naming.

Summary of changes:
- Added the `--rf/incl[ude]-flags` option
- Allowed for `--rf/incl[ude]-flags` to be a longoption-only argument using the LONGOPT macro
- Added aliases for the existing `-F` option (`--excl[ude]-flags`)
- Refactored the assignment of the value for `-F` for conciseness and better readability
- Updated documentation for `fasta`/`fastq`