### PR TITLE
Extend import --order TAG to --order TAG:length

### DIFF
--- a/doc/samtools-import.1
+++ b/doc/samtools-import.1
@@ -142,6 +142,12 @@ or collated in some manner and we wish this to be reversible.  In this
 case the tag may be used with \fBsamtools sort -t TAG\fR to regenerate
 the original input order.
 
+Note integer tags can only hold up to 2^32 record numbers
+(approximately 4 billion).  Data sets with more records can switch to
+using a fixed-width string tag instead, with leading 0s to ensure sort
+works.  To do this specify TAG:LENGTH.  E.g. \fB--order rn:12\fR will
+be able to sort up to 1 trillion records.
+
 .TP 8
 .BI -r\  RG_line ,\ --rg-line\  RG_line
 A complete \fB@RG\fR header line may be specified, with or without the


### PR DESCRIPTION
If we specify a tag length, it implicitly changes the tag format from integer to string and uses a 0-padded number (in string form) as the tag.  This works around issues of more than 4 billion records, where BAM and CRAM cannot encode the tag data.

We could use an alternative encoding, such as base64, but it looks like in CRAM 3.1 it's around 5% smaller tag (rans4x16pr -o65), which as a percentage of the entire file is tiny.  If we use bzip2 that gap reduces to ~3%.

Fixes #1847