### PR TITLE
Minor docs: Clarify that view -d argument does not include tag type

### DIFF
--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -318,6 +318,14 @@ and associated value
 .IR STR2 ,
 which can be a string or an integer [null].
 The value can be omitted, in which case only the tag is considered.
+
+Note that this option does not specify a tag type.
+For example, use
+.B -d XX:42
+to select alignments with an
+.B XX:i:42
+field, not
+.BR "-d XX:i:42" .
 .TP
 .BI "-D " STR:FILE ", --tag-file " STR:FILE
 Only output alignments with tag


### PR DESCRIPTION
See [this twitter thread](https://twitter.com/JWDebler/status/1663413833334165505) for context.

The coincidence of colons in the syntax could mislead users into using e.g. `-d XX:i:42` to try to match `XX:i:42` aux fields. The correct option is `-d XX:42`; that incorrect one would match `XX:Z:i:42` (which is a string with the value `"i:42"`).

It would be possible to check `optind+3` for `^[iZAf]:` or similar in the argument parsing (just before the `add_tag_value_single()` invocation) and print a warning, but that seems like more trouble than it's worth.