### PR TITLE
Apply `samtools fastq --input-fmt-option ...` settings

### DIFF
--- a/bam_fastq.c
+++ b/bam_fastq.c
@@ -423,7 +423,7 @@ static bool init_state(const bam2fq_opts_t* opts, bam2fq_state_t** state_out)
     state->hstdout = NULL;
     state->compression_level = opts->compression_level;
 
-    state->fp = sam_open(opts->fn_input, "r");
+    state->fp = sam_open_format(opts->fn_input, "r", &opts->ga.in);
     if (state->fp == NULL) {
         print_error_errno("bam2fq","Cannot read file \"%s\"", opts->fn_input);
         free(state);


### PR DESCRIPTION
The `samtools fastq` usage claims it supports `--input-fmt-option`, but any options specified are not actually applied to the input file. This one-line PR fixes that. Possibly worthy of a _NEWS_ entry.

(I have not audited other commands to see if any others have a similar problem.)