### PR TITLE
Add samtools fastq -d TAG[:VAL] check

### DIFF
--- a/doc/samtools-fasta.1
+++ b/doc/samtools-fasta.1
@@ -216,6 +216,14 @@ present in the FLAG field.
 can be specified in hex by beginning with `0x' (i.e. /^0x[0-9A-F]+/)
 or in octal by beginning with `0' (i.e. /^0[0-7]+/) [0].
 .TP 8
+.BI "-d " TAG [: VAL ]
+Only output alignments containing an auxiliary tag matching both
+\fITAG\fR and \fIVAL\fR.  If \fIVAL\fR is omitted then any value is
+accepted.  The tag types supported are i, f, Z, A and H.  "B" arrays
+are not supported.  This is comparable to the method used in
+\fBsamtools view -d\fR, but for single values only (i.e. there is no
+sibling \fB-D\fR option).
+.TP 8
 .B -i
 add Illumina Casava 1.8 format entry to header (eg 1:N:0:ATCACG)
 .TP 8

--- a/test/bam2fq/16.fq.expected
+++ b/test/bam2fq/16.fq.expected
@@ -1,0 +1,108 @@
+@ref1_grp1_p001/1	MD:Z:10	NM:i:0	RG:Z:grp1	BC:Z:ACGT	H0:i:1	aa:A:!	ab:A:~	fa:f:3.14159	za:Z:Hello world!	ha:H:DEADBEEF	ba:B:c,-128,0,127	bb:B:C,0,127,255	bc:B:s,-32768,0,32767	bd:B:S,0,32768,65535	be:B:i,-2147483648,0,2147483647	bf:B:I,0,2147483648,4294967295	bg:B:f,2.71828,6.626e-34,2.9979e+09
+CGAGCTCGGT
++
+!!!!!!!!!!
+@ref1_grp1_p001/2	MD:Z:10	NM:i:0	RG:Z:grp1
+GTCGACTCTA
++
+----------
+@ref1_grp1_p002/1	MD:Z:10	NM:i:0	RG:Z:grp1	BC:Z:AATTCCGG	H0:i:1	aa:A:a	ab:A:z	fa:f:4.3597e-18	za:Z:Another string	ha:H:2000AD
+CTCGGTACCC
++
+##########
+@ref1_grp1_p002/2	MD:Z:10	NM:i:0	RG:Z:grp1
+GCAGGTCGAC
++
+//////////
+@ref1_grp1_p003/1	MD:Z:10	NM:i:0	fa:f:1.66e-27	RG:Z:grp1
+GTACCCGGGG
++
+%%%%%%%%%%
+@ref1_grp1_p003/2	MD:Z:10	NM:i:0	RG:Z:grp1
+GCCTGCAGGT
++
+1111111111
+@ref1_grp1_p004/1	MD:Z:10	NM:i:0	fa:f:1.38e-23	za:Z:xRG:Z:grp2	RG:Z:grp1
+CCGGGGATCC
++
+''''''''''
+@ref1_grp1_p004/2	MD:Z:10	NM:i:0	RG:Z:grp1
+GCATGCCTGC
++
+3333333333
+@ref1_grp1_p005/1	MD:Z:10	NM:i:0	RG:Z:grp1	ia:i:40000
+GGATCCTCTA
++
+))))))))))
+@ref1_grp1_p005/2	MD:Z:10	NM:i:0	RG:Z:grp1
+GCTTGCATGC
++
+5555555555
+@ref1_grp1_p006/1	MD:Z:10	NM:i:0	RG:Z:grp1	ia:i:255
+CCTCTAGAGT
++
+++++++++++
+@ref1_grp1_p006/2	MD:Z:10	NM:i:0	RG:Z:grp1
+TCAAGCTTGC
++
+7777777777
+@ref1_grp2_p001/2	MD:Z:10	NM:i:0	RG:Z:grp2
+AGGTCGACTC
++
+..........
+@ref1_grp2_p002/1	MD:Z:10	NM:i:0	fa:f:6.022e+23	RG:Z:grp2
+CGGTACCCGG
++
+$$$$$$$$$$
+@ref1_grp2_p002/2	MD:Z:10	NM:i:0	RG:Z:grp2
+CTGCAGGTCG
++
+0000000000
+@ref1_grp2_p003/1	MD:Z:10	NM:i:0	RG:Z:grp2	ia:i:4294967295
+ACCCGGGGAT
++
+&&&&&&&&&&
+@ref1_grp2_p003/2	MD:Z:10	NM:i:0	RG:Z:grp2
+ATGCCTGCAG
++
+2222222222
+@ref1_grp2_p004/1	MD:Z:10	NM:i:0	RG:Z:grp2	ia:i:-2147483648
+GGGGATCCTC
++
+((((((((((
+@ref1_grp2_p004/2	MD:Z:10	NM:i:0	RG:Z:grp2
+TTGCATGCCT
++
+4444444444
+@ref1_grp2_p005/1	MD:Z:10	NM:i:0	RG:Z:grp2	ia:i:-1000
+ATCCTCTAGA
++
+**********
+@ref1_grp2_p005/2	MD:Z:10	NM:i:0	RG:Z:grp2
+AAGCTTGCAT
++
+6666666666
+@ref1_grp2_p006/1	MD:Z:10	NM:i:0	RG:Z:grp2	ia:i:-1
+TCTAGAGTCG
++
+,,,,,,,,,,
+@ref1_grp2_p006/2	MD:Z:10	NM:i:0	RG:Z:grp2
+ACTCAAGCTT
++
+8888888888
+@ref12_grp1_p001/1	MD:Z:10	NM:i:0	RG:Z:grp1
+TGCAGGCATG
++
+AAAAAAAAAA
+@ref12_grp1_p001/2	MD:Z:10	NM:i:0	RG:Z:grp1
+CACTATAGAA
++
+BBBBBBBBBB
+@ref12_grp2_p001/1	MD:Z:10	NM:i:0	RG:Z:grp2
+CAAGCTTGAG
++
+AAAAAAAAAA
+@ref12_grp2_p001/2	MD:Z:10	NM:i:0	RG:Z:grp2
+ATTTAGGTGA
++
+BBBBBBBBBB

--- a/test/bam2fq/17.fq.expected
+++ b/test/bam2fq/17.fq.expected
@@ -1,0 +1,124 @@
+@ref1_grp1_p001/1	MD:Z:10	NM:i:0	RG:Z:grp1	BC:Z:ACGT	H0:i:1	aa:A:!	ab:A:~	fa:f:3.14159	za:Z:Hello world!	ha:H:DEADBEEF	ba:B:c,-128,0,127	bb:B:C,0,127,255	bc:B:s,-32768,0,32767	bd:B:S,0,32768,65535	be:B:i,-2147483648,0,2147483647	bf:B:I,0,2147483648,4294967295	bg:B:f,2.71828,6.626e-34,2.9979e+09
+CGAGCTCGGT
++
+!!!!!!!!!!
+@ref1_grp1_p001/2	MD:Z:10	NM:i:0	RG:Z:grp1
+GTCGACTCTA
++
+----------
+@ref1_grp1_p002/1	MD:Z:10	NM:i:0	RG:Z:grp1	BC:Z:AATTCCGG	H0:i:1	aa:A:a	ab:A:z	fa:f:4.3597e-18	za:Z:Another string	ha:H:2000AD
+CTCGGTACCC
++
+##########
+@ref1_grp1_p002/2	MD:Z:10	NM:i:0	RG:Z:grp1
+GCAGGTCGAC
++
+//////////
+@ref1_grp1_p003/1	MD:Z:10	NM:i:0	fa:f:1.66e-27	RG:Z:grp1
+GTACCCGGGG
++
+%%%%%%%%%%
+@ref1_grp1_p003/2	MD:Z:10	NM:i:0	RG:Z:grp1
+GCCTGCAGGT
++
+1111111111
+@ref1_grp1_p004/1	MD:Z:10	NM:i:0	fa:f:1.38e-23	za:Z:xRG:Z:grp2	RG:Z:grp1
+CCGGGGATCC
++
+''''''''''
+@ref1_grp1_p004/2	MD:Z:10	NM:i:0	RG:Z:grp1
+GCATGCCTGC
++
+3333333333
+@ref1_grp1_p005/1	MD:Z:10	NM:i:0	RG:Z:grp1	ia:i:40000
+GGATCCTCTA
++
+))))))))))
+@ref1_grp1_p005/2	MD:Z:10	NM:i:0	RG:Z:grp1
+GCTTGCATGC
++
+5555555555
+@ref1_grp1_p006/1	MD:Z:10	NM:i:0	RG:Z:grp1	ia:i:255
+CCTCTAGAGT
++
+++++++++++
+@ref1_grp1_p006/2	MD:Z:10	NM:i:0	RG:Z:grp1
+TCAAGCTTGC
++
+7777777777
+@ref1_grp2_p001/1	MD:Z:8	NM:i:0	RG:Z:grp2	BC:Z:TGCA	H0:i:1	aa:A:A	ab:A:Z	fa:f:6.67e-11	za:Z:!"$%^&*()	ha:H:CAFE
+AGCTCGGTAC
++
+""""""""""
+@ref1_grp2_p001/2	MD:Z:10	NM:i:0	RG:Z:grp2
+AGGTCGACTC
++
+..........
+@ref1_grp2_p002/1	MD:Z:10	NM:i:0	fa:f:6.022e+23	RG:Z:grp2
+CGGTACCCGG
++
+$$$$$$$$$$
+@ref1_grp2_p002/2	MD:Z:10	NM:i:0	RG:Z:grp2
+CTGCAGGTCG
++
+0000000000
+@ref1_grp2_p003/1	MD:Z:10	NM:i:0	RG:Z:grp2	ia:i:4294967295
+ACCCGGGGAT
++
+&&&&&&&&&&
+@ref1_grp2_p003/2	MD:Z:10	NM:i:0	RG:Z:grp2
+ATGCCTGCAG
++
+2222222222
+@ref1_grp2_p004/1	MD:Z:10	NM:i:0	RG:Z:grp2	ia:i:-2147483648
+GGGGATCCTC
++
+((((((((((
+@ref1_grp2_p004/2	MD:Z:10	NM:i:0	RG:Z:grp2
+TTGCATGCCT
++
+4444444444
+@ref1_grp2_p005/1	MD:Z:10	NM:i:0	RG:Z:grp2	ia:i:-1000
+ATCCTCTAGA
++
+**********
+@ref1_grp2_p005/2	MD:Z:10	NM:i:0	RG:Z:grp2
+AAGCTTGCAT
++
+6666666666
+@ref1_grp2_p006/1	MD:Z:10	NM:i:0	RG:Z:grp2	ia:i:-1
+TCTAGAGTCG
++
+,,,,,,,,,,
+@ref1_grp2_p006/2	MD:Z:10	NM:i:0	RG:Z:grp2
+ACTCAAGCTT
++
+8888888888
+@ref2_grp3_p001/1	MD:Z:15	NM:i:0	RG:Z:grp3
+GTGACACTATAGAAT
++
+~~~~~~~~~~~~~~~
+@ref2_grp3_p002/1	MD:Z:15	NM:i:0	RG:Z:grp3
+CTGTTTCCTGTGTGA
++
+{{{{{{{{{{{{{{{
+@ref2_grp3_p002/2	MD:Z:15	NM:i:0	RG:Z:grp3
+CGCCAAGCTATTTAG
++
+}}}}}}}}}}}}}}}
+@ref12_grp1_p001/1	MD:Z:10	NM:i:0	RG:Z:grp1
+TGCAGGCATG
++
+AAAAAAAAAA
+@ref12_grp1_p001/2	MD:Z:10	NM:i:0	RG:Z:grp1
+CACTATAGAA
++
+BBBBBBBBBB
+@ref12_grp2_p001/1	MD:Z:10	NM:i:0	RG:Z:grp2
+CAAGCTTGAG
++
+AAAAAAAAAA
+@ref12_grp2_p001/2	MD:Z:10	NM:i:0	RG:Z:grp2
+ATTTAGGTGA
++
+BBBBBBBBBB

--- a/test/bam2fq/18.fq.expected
+++ b/test/bam2fq/18.fq.expected
@@ -1,0 +1,24 @@
+@ref1_grp1_p005/1	MD:Z:10	NM:i:0	RG:Z:grp1	ia:i:40000
+GGATCCTCTA
++
+))))))))))
+@ref1_grp1_p006/1	MD:Z:10	NM:i:0	RG:Z:grp1	ia:i:255
+CCTCTAGAGT
++
+++++++++++
+@ref1_grp2_p003/1	MD:Z:10	NM:i:0	RG:Z:grp2	ia:i:4294967295
+ACCCGGGGAT
++
+&&&&&&&&&&
+@ref1_grp2_p004/1	MD:Z:10	NM:i:0	RG:Z:grp2	ia:i:-2147483648
+GGGGATCCTC
++
+((((((((((
+@ref1_grp2_p005/1	MD:Z:10	NM:i:0	RG:Z:grp2	ia:i:-1000
+ATCCTCTAGA
++
+**********
+@ref1_grp2_p006/1	MD:Z:10	NM:i:0	RG:Z:grp2	ia:i:-1
+TCTAGAGTCG
++
+,,,,,,,,,,

--- a/test/test.pl
+++ b/test/test.pl
@@ -3021,10 +3021,15 @@ sub test_bam2fq
     test_cmd($opts, out=>'dat/empty.expected', out_map=>{'0.fq' => 'bam2fq/14.0.fq.expected', 'i1.fq' => 'bam2fq/14.i1.fq.expected', 'i2.fq' => 'bam2fq/14.i2.fq.expected', '0.fq' => 'bam2fq/14.0.fq.expected'}, cmd=>"$$opts{bin}/samtools fastq @$threads --index-format 'i8n1i8' --i1 $$opts{path}/i1.fq --i2 $$opts{path}/i2.fq -0 $$opts{path}/0.fq $$opts{path}/dat/bam2fq.014.sam");
 
     # -T flag, all tags mode
-    test_cmd($opts, out=>'bam2fq/15.fq.expected', cmd=>"$$opts{bin}/samtools fastq @$threads -N -T '*' $$opts{path}/dat/bam2fq.001.sam");
     test_cmd($opts, out=>'bam2fq/15.fq.expected', cmd=>"$$opts{bin}/samtools fastq @$threads -N -T '' $$opts{path}/dat/bam2fq.001.sam");
     test_cmd($opts, out=>'bam2fq/15.fq.expected', cmd=>"$$opts{bin}/samtools fastq @$threads -N -t -T '*' $$opts{path}/dat/bam2fq.001.sam");
+
+    # -d TAG
+    test_cmd($opts, out=>'bam2fq/16.fq.expected', cmd=>"$$opts{bin}/samtools fastq @$threads -N -T '*' -d MD:10 $$opts{path}/dat/bam2fq.001.sam");
+    test_cmd($opts, out=>'bam2fq/17.fq.expected', cmd=>"$$opts{bin}/samtools fastq @$threads -N -T '*' -d NM:0 $$opts{path}/dat/bam2fq.001.sam");
+    test_cmd($opts, out=>'bam2fq/18.fq.expected', cmd=>"$$opts{bin}/samtools fastq @$threads -N -T '*' -d ia $$opts{path}/dat/bam2fq.001.sam");
 }
+
 
 sub test_depad
 {


### PR DESCRIPTION
This mirrors view -d.  Note we don't have view -D functionality (multiple values).  Tag types supported as i, f, Z, and H.  No "B" arrays.  View is the same bar missing 'f'.  Possibly due to the complexity of comparing floats.  Best efforts are made here, but I'm not sure it's robust.

Fixes #1854