### PR TITLE
Documentation formatting etc fixes [minor]

### DIFF
--- a/doc/samtools-fasta.1
+++ b/doc/samtools-fasta.1
@@ -55,7 +55,7 @@ samtools fasta
 .PP
 Converts a BAM or CRAM into either FASTQ or FASTA format depending on the
 command invoked. The files will be automatically compressed if the
-file names have a .gz or .bgzf extension.
+file names have a .gz, .bgz, or .bgzf extension.
 
 Note this command is attempting to reverse the alignment process, so
 if the aligner took a single input FASTQ and produced multiple SAM

--- a/doc/samtools-reheader.1
+++ b/doc/samtools-reheader.1
@@ -45,9 +45,8 @@ samtools reheader \- replaces the header in the input file
 .PP
 samtools reheader
 .RB [ -iP ]
-[-c CMD | 
-.I in.header.sam
-] 
+.RB [ -c
+.IR CMD " | " in.header.sam ]
 .I in.bam
 
 .SH DESCRIPTION
@@ -75,24 +74,24 @@ Perform the header edit in-place, if possible.  This only works on CRAM
 files and only if there is sufficient room to store the new header.
 The amount of space available will differ for each CRAM file.
 .TP 8
-.B -c, --command CMD
+.BI "-c, --command " CMD
 Allow the header from 
 .I in.bam
 to be processed by external 
-.B CMD
+.I CMD
 and read back the result. When used in this manner, the external header file
 .I in.header.sam
 has to be omitted.
 
-.B CMD
+.I CMD
 must take the original header through stdin in SAM format and output the
 modified header to stdout.
-.B CMD
+.I CMD
 is passed to the system's command shell.
 Care should be taken to ensure the command is quoted correctly to avoid unwanted
 shell expansions (for example of $ variables).
 
-.B CMD
+.I CMD
 must return an exit status of zero.
 
 .SH EXAMPLES

--- a/doc/samtools.1
+++ b/doc/samtools.1
@@ -588,7 +588,7 @@ samtools fasta
 
 Converts a BAM or CRAM into either FASTQ or FASTA format depending on the
 command invoked. The files will be automatically compressed if the
-file names have a .gz or .bgzf extension.
+file names have a .gz, .bgz, or .bgzf extension.
 
 The input to this program must be collated by name.
 Use
@@ -1003,7 +1003,7 @@ compression method.  This is on by default for version 3.1 and above
 only when the small and archive profiles are in use.
 .TP
 .BI use_tok= 0|1
-CRAM \(>= 3.1 output only; enables and disables the namne tokeniser
+CRAM \(>= 3.1 output only; enables and disables the name tokeniser
 compression method.  This is on by default for version 3.1 and above.
 .TP
 .BI lossy_names= 0|1


### PR DESCRIPTION
Add `.bgz` to fasta/fastq's list of recognised compressed file extensions, as per `sam_open_z()`.
Format `CMD` as a metasyntactic variable.
Fix typo.