### PR TITLE
fix various typos caught by lintian parsers

### DIFF
--- a/bam_ampliconclip.c
+++ b/bam_ampliconclip.c
@@ -1014,7 +1014,7 @@ int amplicon_clip_main(int argc, char **argv) {
 
     if (param.tol < 0) {
         fprintf(stderr, "[ampliconclip] warning: invalid tolerance of %d,"
-                        " reseting tolerance to default of 5.\n", param.tol);
+                        " resetting tolerance to default of 5.\n", param.tol);
         param.tol = 5;
     }
 

--- a/bamshuf.c
+++ b/bamshuf.c
@@ -537,7 +537,7 @@ static int usage(FILE *fp, int n_files, int reads_store) {
             "      -l INT   Compression level [%d]\n" // DEF_CLEVEL
             "      -n INT   Number of temporary files [%d]\n" // n_files
             "      -T PREFIX\n"
-            "               Write tempory files to PREFIX.nnnn.bam\n"
+            "               Write temporary files to PREFIX.nnnn.bam\n"
             "      --no-PG  do not add a PG line\n",
             reads_store, DEF_CLEVEL, n_files);
 

--- a/doc/samtools-fasta.1
+++ b/doc/samtools-fasta.1
@@ -1,7 +1,7 @@
 '\" t
 .TH samtools-fasta 1 "21 February 2023" "samtools-1.17" "Bioinformatics tools"
 .SH NAME
-samtools fasta / fastq \- converts a SAM/BAM/CRAM file to FASTA or FASTQ
+samtools-fasta, samtools-fastq \- converts a SAM/BAM/CRAM file to FASTA or FASTQ
 .\"
 .\" Copyright (C) 2008-2011, 2013-2020 Genome Research Ltd.
 .\" Portions copyright (C) 2010, 2011 Broad Institute.

--- a/doc/samtools-merge.1
+++ b/doc/samtools-merge.1
@@ -94,7 +94,7 @@ number of simultaneously open files.  See \fBulimit -n\fR for more
 information.  Additionally many files being read from simultaneously
 may cause a certain amount of "disk thrashing".  To partially
 alleviate this the merge command will load 1MB of data at a time from
-each file, but this in turn adds to the overal merge program memory
+each file, but this in turn adds to the overall merge program memory
 usage.  Please take this into account when setting memory limits.
 
 In extreme cases, it may be necessary to reduce the problem to fewer

--- a/doc/samtools-reset.1
+++ b/doc/samtools-reset.1
@@ -97,7 +97,7 @@ all PG entries will be in output.
 
 .TP 8
 .BI --no-RG
-RG lines in input will be discarded with this option. By default, RG lines will be present in ouput.
+RG lines in input will be discarded with this option. By default, RG lines will be present in output.
 
 With this option, RG aux tags will also be discarded.
 

--- a/doc/samtools-samples.1
+++ b/doc/samtools-samples.1
@@ -122,7 +122,7 @@ S5	S5.bam	Y
 \&.	example.sam	N
 .EE
 .IP o 2
-print wether the files are indexed using custom bai files.
+print whether the files are indexed using custom bai files.
 .EX 2
 $ samtools samples -i -h -X S1.bam S2.bam S1.bam.bai S2.bam.bai
 #SM	PATH	INDEX


### PR DESCRIPTION
This patch addresses a couple of typos, plus a few malformations in manual pages, caught by lintian while packaging the latest samtools version of the day for Debian.

I was overdue to forward this upstream.
Thanks John Marshall for the reminder!