### PR TITLE
Sort name ascii2

### DIFF
--- a/bam_sort.c
+++ b/bam_sort.c
@@ -3743,7 +3743,7 @@ int bam_sort(int argc, char *argv[])
         goto sort_end;
     }
 
-    if (ga.write_index && (sam_order == QueryName || sam_order == TagQueryName || sam_order == TagCoordinate || sam_order == TemplateCoordinate)) {
+    if (ga.write_index && sam_order != Coordinate) {
         fprintf(stderr, "[W::bam_sort] Ignoring --write-index as it only works for position sorted files.\n");
         ga.write_index = 0;
     }

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -164,11 +164,15 @@ static template_coordinate_key_t* template_coordinate_key(bam1_t *b, template_co
 
 typedef enum {Coordinate, QueryName, TagCoordinate, TagQueryName, MinHash, TemplateCoordinate} SamOrder;
 static SamOrder g_sam_order = Coordinate;
+static int natural_sort = 1; // not ASCII, but alphanumeric: a12b > a7b
 static char g_sort_tag[2] = {0,0};
 
 #define is_digit(c) ((c)<='9' && (c)>='0')
 static int strnum_cmp(const char *_a, const char *_b)
 {
+    if (!natural_sort)
+        return strcmp(_a,_b);
+
     const unsigned char *a = (const unsigned char*)_a, *b = (const unsigned char*)_b;
     const unsigned char *pa = a, *pb = b;
     while (*pa && *pb) {
@@ -1535,7 +1539,8 @@ static void merge_usage(FILE *to)
 "   or: samtools merge [options] <out.bam> <in1.bam> ... <inN.bam>\n"
 "\n"
 "Options:\n"
-"  -n         Input files are sorted by read name\n"
+"  -n         Input files are sorted by read name (natural)\n"
+"  -N         Input files are sorted by read name (ASCII)\n"
 "  -t TAG     Input files are sorted by TAG value\n"
 "  -r         Attach RG tag (inferred from file names)\n"
 "  -u         Uncompressed BAM output\n"
@@ -1581,11 +1586,12 @@ int bam_merge(int argc, char *argv[])
         return 0;
     }
 
-    while ((c = getopt_long(argc, argv, "h:nru1R:o:f@:l:cps:b:O:t:XL:", lopts, NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "h:nNru1R:o:f@:l:cps:b:O:t:XL:", lopts, NULL)) >= 0) {
         switch (c) {
         case 'r': flag |= MERGE_RG; break;
         case 'f': flag |= MERGE_FORCE; break;
         case 'h': fn_headers = optarg; break;
+        case 'N': natural_sort = 0; // fall through
         case 'n': sam_order = QueryName; break;
         case 'o': fnout = optarg; break;
         case 't': sort_tag = optarg; break;
@@ -3287,6 +3293,9 @@ int bam_sort_core_ext(SamOrder sam_order, char* sort_tag, int minimiser_kmer,
             break;
         case QueryName:
             new_so = "queryname";
+            new_ss = natural_sort
+                ? "queryname:natural"
+                : "queryname:lexicographical";
             break;
         case MinHash:
             new_so = "coordinate";
@@ -3605,7 +3614,8 @@ static void sort_usage(FILE *fp)
 "  -I FILE    Order minimisers by their position in FILE FASTA\n"
 "  -w INT     Window size for minimiser indexing via -I ref.fa [100]\n"
 "  -H         Squash homopolymers when computing minimiser\n"
-"  -n         Sort by read name (not compatible with samtools index command)\n"
+"  -n         Sort by read name (natural): cannot be used with samtools index\n"
+"  -N         Sort by read name (ASCII): cannot be used with samtools index\n"
 "  -t TAG     Sort by value of TAG. Uses position as secondary index (or read name if -n is set)\n"
 "  -o FILE    Write final output to FILE rather than standard output\n"
 "  -T PREFIX  Write temporary files to PREFIX.nnnn.bam\n"
@@ -3658,9 +3668,10 @@ int bam_sort(int argc, char *argv[])
         { NULL, 0, NULL, 0 }
     };
 
-    while ((c = getopt_long(argc, argv, "l:m:no:O:T:@:t:MI:K:uRw:H", lopts, NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "l:m:nNo:O:T:@:t:MI:K:uRw:H", lopts, NULL)) >= 0) {
         switch (c) {
         case 'o': fnout = optarg; o_seen = 1; break;
+        case 'N': natural_sort = 0; // fall through
         case 'n': sam_order = QueryName; break;
         case 't': by_tag = true; sort_tag = optarg; break;
         case 'm': {

--- a/doc/samtools-merge.1
+++ b/doc/samtools-merge.1
@@ -83,8 +83,10 @@ of existing IDs in the output header will have a suffix appended to them to diff
 records from other files and the read records will be updated to reflect this.
 
 The ordering of the records in the input files must match the usage of the
-\fB-n\fP and \fB-t\fP command-line options.  If they do not, the output
-order will be undefined.  See
+\fB-n\fP, \fB-N\fP and \fB-t\fP command-line options.  If they do not,
+the output order will be undefined.  Note this also extends to
+disallowing mixing of "queryname" files with a combination of natural
+and lexicographical sort orders.  See
 .B sort
 for information about record ordering.
 
@@ -122,8 +124,20 @@ is actually in SAM format, though any alignment records it may contain
 are ignored.)
 .TP
 .B -n
-The input alignments are sorted by read names rather than by chromosomal
-coordinates
+The input alignments are sorted by read names using an alpha-numeric
+ordering, rather than by chromosomal coordinates.
+The alpha-numeric or \*(lqnatural\*(rq sort order detects runs of digits in the
+strings and sorts these numerically.  Hence "a7b" appears before "a12b".
+Note this is not suitable where hexadecimal values are in use.
+.TP
+.B -N
+The input alignments are sorted by read names using a lexicographical
+ordering, rather than by chromosomal coordinates.  Unlike \fB-n\fR no
+detection of numeric components is used, instead relying purely on the
+ASCII value of each character.  Hence "x12" comes before "x7" as "1"
+is before "7" in ASCII.  This is a more appropriate name sort order
+where all digits in names are already zero-padded and/or hexadecimal
+values are being used.
 .TP
 .BI -o \ FILE
 Write merged output to

--- a/doc/samtools-sort.1
+++ b/doc/samtools-sort.1
@@ -48,11 +48,12 @@ samtools sort
 
 .SH DESCRIPTION
 .PP
-Sort alignments by leftmost coordinates, by read name when \fB-n\fR
-is used, by tag contents with \fB-t\fR, or a minimiser-based collation
-order with \fB-M\fR.  An appropriate
-.B @HD-SO
-sort order header tag will be added or an existing one updated if necessary.
+Sort alignments by leftmost coordinates, by read name when \fB-n\fR or
+\fB-N\fR are used, by tag contents with \fB-t\fR, or a minimiser-based
+collation order with \fB-M\fR.  An appropriate \fB@HD SO\fR
+sort order header tag will be added or an existing one updated if
+necessary, along with the \fB@HD SS\fR sub-sort header tag where
+appropriate.
 
 The sorted output is written to standard output by default, or to the
 specified file
@@ -74,7 +75,8 @@ instead if you need name collated data without a full lexicographical sort.
 Note that if the sorted output file is to be indexed with
 .BR "samtools index" ,
 the default coordinate sort must be used.
-Thus the \fB-n\fR, \fB-t\fR and \fB-M\fR options are incompatible with
+Thus the \fB-n\fR, \fB-N\fR, \fB-t\fR and \fB-M\fR options are
+incompatible with
 .BR "samtools index" .
 
 When sorting by minimisier (\fB-M\fR), the sort order is defined by
@@ -115,11 +117,26 @@ minimum value of 1M for this setting.
 .B -n
 Sort by read names (i.e., the
 .B QNAME
-field) rather than by chromosomal coordinates.
+field) using an alpha-numeric ordering, rather than by chromosomal coordinates.
+The alpha-numeric or \*(lqnatural\*(rq sort order detects runs of digits in the
+strings and sorts these numerically.  Hence "a7b" appears before "a12b".
+Note this is not suitable where hexadecimal values are in use.
+Sets the header sub-sort (\fB@HD SS\fR) tag to \fBqueryname:natural\fR.
+.TP
+.B -N
+Sort by read names (i.e., the
+.B QNAME
+field) using the lexicographical ordering, rather than by chromosomal
+coordinates.  Unlike \fB-n\fR no detection of numeric components is
+used, instead relying purely on the ASCII value of each character.
+Hence "x12" comes before "x7" as "1" is before "7" in ASCII.  This is
+a more appropriate name sort order where all digits in names are
+already zero-padded and/or hexadecimal values are being used.
+Sets the header sub-sort (\fB@HD SS\fR) tag to \fBqueryname:lexicographical\fR.
 .TP
 .BI "-t " TAG
 Sort first by the value in the alignment tag TAG, then by position or name (if
-also using \fB-n\fP).
+also using \fB-n\fP or \fB-N\fR).
 .TP
 .B "-M "
 Sort unmapped reads (those in chromosome "*") by their sequence
@@ -212,7 +229,8 @@ and the sub-sort (SS) is
 The following rules are used for ordering records.
 
 If option \fB-t\fP is in use, records are first sorted by the value of
-the given alignment tag, and then by position or name (if using \fB-n\fP).
+the given alignment tag, and then by position or name (if using \fB-n\fP
+or \fB-N\fP).
 For example, \*(lq-t RG\*(rq will make read group the primary sort key.  The
 rules for ordering by tag are:
 
@@ -236,11 +254,17 @@ Character tags (type A) are compared by binary character value.
 No attempt is made to compare tags of other types \(em notably type B
 array values will not be compared.
 .PP
-When the \fB-n\fP option is present, records are sorted by name.  Names are
-compared so as to give a \*(lqnatural\*(rq ordering \(em i.e. sections
-consisting of digits are compared numerically while all other sections are
-compared based on their binary representation.  This means \*(lqa1\*(rq will
-come before \*(lqb1\*(rq and \*(lqa9\*(rq will come before \*(lqa10\*(rq.
+When the \fB-n\fP or \fB-N\fP option is present, records are sorted by
+name.  Historically samtools has used a \*(lqnatural\*(rq ordering
+\(em i.e. sections consisting of digits are compared numerically while
+all other sections are compared based on their binary representation.
+This means \*(lqa1\*(rq will come before \*(lqb1\*(rq and \*(lqa9\*(rq
+will come before \*(lqa10\*(rq.  However this alpha-numeric sort can
+be confused by runs of hexadecimal digits.  The newer \fB-N\fP
+option adds a simpler lexicographical based name collation which does not
+attempt any numeric comparisons and may be more appropriate for some
+data sets.  Note care must be taken when using \fBsamtools merge\fP to
+ensure all files are using the same collation order.
 Records with the same name will be ordered according to the values of
 the READ1 and READ2 flags (see
 .BR flags ).

--- a/test/sort/name.sort.expected.sam
+++ b/test/sort/name.sort.expected.sam
@@ -1,4 +1,4 @@
-@HD	VN:1.4	SO:queryname
+@HD	VN:1.4	SO:queryname	SS:queryname:natural
 @SQ	SN:insert	LN:599
 @SQ	SN:ref1	LN:45
 @SQ	SN:ref2	LN:40

--- a/test/sort/name2.sort.expected.sam
+++ b/test/sort/name2.sort.expected.sam
@@ -1,0 +1,24 @@
+@HD	VN:1.4	SO:queryname	SS:queryname:lexicographical
+@SQ	SN:insert	LN:599
+@SQ	SN:ref1	LN:45
+@SQ	SN:ref2	LN:40
+@SQ	SN:ref3	LN:4
+@PG	ID:llama
+@RG	ID:fish	PG:llama
+@RG	ID:cow	PU:13_&^&&*(:332	PG:donkey
+@RG	PU:*9u8jkjjkjd:	ID:colt
+@PG	ID:bull	PP:donkey
+@PG	ID:donkey
+@CO	Do you know?
+r005	83	ref1	37	30	9M	=	7	-39	CAGCGCCAT	*	RG:Z:colt	PG:Z:donkey
+r005	163	ref1	7	30	8M4I4M1D3M	=	37	39	TTAGATAAAGAGGATACTG	*	XX:B:S,12561,2,20,112	YY:i:100	RG:Z:colt	PG:Z:donkey
+r006	0	ref1	9	30	1S2I6M1P1I1P1I4M2I	*	0	0	AAAAGATAAGGGATAAA	*	XA:Z:abc	XB:i:-10	RG:Z:colt	PG:Z:donkey
+r006	16	ref1	29	30	6H5M	*	0	0	TAGGC	*	RG:Z:colt	PG:Z:donkey
+r007	0	ref1	9	30	5H6M	*	0	0	AGCTAA	*	RG:Z:colt	PG:Z:donkey
+r007	0	ref1	16	30	6M14N1I5M	*	0	0	ATAGCTCTCAGC	*	RG:Z:colt	PG:Z:donkey
+x10	0	ref2	10	30	25M	*	0	0	CAAATAATTAAGTCTACAGAGCAAC	?????????????????????????	RG:Z:cow	PG:Z:bull
+x11	0	ref2	12	30	24M	*	0	0	AATAATTAAGTCTACAGAGCAACT	????????????????????????	RG:Z:cow	PG:Z:bull
+x12	0	ref2	14	30	23M	*	0	0	TAATTAAGTCTACAGAGCAACTA	???????????????????????	RG:Z:cow	PG:Z:bull
+x7	0	ref2	1	30	20M	*	0	0	AGGTTTTATAAAACAAATAA	*	RG:Z:cow	PG:Z:bull
+x8	0	ref2	2	30	21M	*	0	0	GGTTTTATAAAACAAATAATT	?????????????????????	RG:Z:cow	PG:Z:bull
+x9	0	ref2	6	30	9M4I13M	*	0	0	TTATAAAACAAATAATTAAGTCTACA	??????????????????????????	RG:Z:cow	PG:Z:bull

--- a/test/test.pl
+++ b/test/test.pl
@@ -3213,6 +3213,7 @@ sub test_sort
 
     # Name sort
     test_cmd($opts, out=>"sort/name.sort.expected.sam", ignore_pg_header => 1, cmd=>"$$opts{bin}/samtools sort${threads} -n -m 10M $$opts{path}/dat/test_input_1_a.bam -O SAM -o -");
+    test_cmd($opts, out=>"sort/name2.sort.expected.sam", ignore_pg_header => 1, cmd=>"$$opts{bin}/samtools sort${threads} -N -m 10M $$opts{path}/dat/test_input_1_b.bam -O SAM -o -");
 
     # Tag sort (RG)
     test_cmd($opts, out=>"sort/tag.rg.sort.expected.sam", ignore_pg_header => 1, cmd=>"$$opts{bin}/samtools sort${threads} -t RG -m 10M $$opts{path}/dat/test_input_1_a.bam -O SAM -o -");


### PR DESCRIPTION
Add samtools sort -N / samtools merge -N option.

These handle an alternative form of read-name sort order that is purely ASCII instead of the "natural" alphanumeric sort.

Natural sort order will place "a12" after "a3", as it computes 12 > 3 rather than "1" < "3" (ASCII).  However it also means hexadecimal values such as "a12b" > "a3bc", and "a09b" > "a7bc".  Typically any read name generation system using leading fixed-width columns with leading zeros to pad is going to be safer using traditional ASCII sort orders.

Note while writing this my initial implementation was to add QueryNameASCII to the SamOrder typedef, but it turns out the sheer level of code duplication going on here means doing that yielding 81 changed lines, vs 15 for this.  I don't like using a global variable, but it's already using one due to the lacklustre ksort API which can't pass in a client state argument. (Being poorly modelled on qsort I assume.)  Hence a sibling global is a trivial change and less error prone.

Fixes #1500

Also corrected a poorly written (and incomplete) error checking on compatibility of `--write-index` with non-coordinate sort orders.
