### PR TITLE
Check fclose(stdout) at the end of main()

### DIFF
--- a/bamtk.c
+++ b/bamtk.c
@@ -303,5 +303,14 @@ int main(int argc, char *argv[])
         fprintf(stderr, "[main] unrecognized command '%s'\n", argv[1]);
         return 1;
     }
+
+    // For subcommands that may have produced substantial output on stdout,
+    // make a final check for delayed I/O errors. Ignore EBADF as other code
+    // may have already closed stdout.
+    if (fclose(stdout) != 0 && errno != EBADF) {
+        print_error_errno(argv[1], "closing standard output failed");
+        return 1;
+    }
+
     return ret;
 }


### PR DESCRIPTION
Companion pull request to samtools/htslib#1665. If that PR's approach is accepted, then `hts_open("-", "w")` / `hts_close()` no longer actually closes stdout. Close it explicitly at the end of `main()` so there is an opportunity to detect I/O errors in previously-uncommitted writes.

Ignore EBADF as other code may have already closed stdout, e.g., either particular subcommands or when (dynamically) linked against an older version of HTSlib.