### PR TITLE
Use the spec-defined PL values in man page example

### DIFF
--- a/doc/samtools-merge.1
+++ b/doc/samtools-merge.1
@@ -201,7 +201,7 @@ Attach the
 .B RG
 tag while merging sorted alignments:
 .EX 2
-perl -e 'print "@RG\\tID:ga\\tSM:hs\\tLB:ga\\tPL:Illumina\\n@RG\\tID:454\\tSM:hs\\tLB:454\\tPL:454\\n"' > rg.txt
+printf '@RG\\tID:ga\\tSM:hs\\tLB:ga\\tPL:ILLUMINA\\n@RG\\tID:454\\tSM:hs\\tLB:454\\tPL:LS454\\n' > rg.txt
 samtools merge -rh rg.txt merged.bam ga.bam 454.bam
 .EE
 The value in a


### PR DESCRIPTION
As noted by @zaeleus on Slack, an example in samtools ought to be using the correct specification-defined PL values.

Moreover the Perl command shown interpolates `@RG` as an undefined array and produces lines starting `<tab>ID:…`; instead simplify by using `printf(1)` (unfortunately… if only `echo` could portably express this with ease…) to avoid any such issues.