### PR TITLE
Remove -5 option from samtools consensus.

### DIFF
--- a/doc/samtools-consensus.1
+++ b/doc/samtools-consensus.1
@@ -264,13 +264,9 @@ output "N".
 
 .TP 0
 The following options apply only to Bayesian consensus mode enabled
-with the \fB-5\fR option.
+(default on).
 
 .TP 10
-.B -5
-Enable Bayesian consensus algorithm.
-
-.TP
 .BI "-C " C ", --cutoff " C
 Only used for the Gap5 consensus mode, which produces a Phred style
 score for the final consensus quality.  If this is below


### PR DESCRIPTION
This option referred to the original name of the "gap5" mode, but it's now just called "-m bayesian" and is the default anyway.  The -5 option produces an error now.