### PR TITLE
Speed up optical duplicate marking.

### DIFF
--- a/bam_markdup.c
+++ b/bam_markdup.c
@@ -1195,7 +1195,7 @@ static int check_duplicate_chain(md_param_t *param, khash_t(duplicates) *dup_has
         while (++end_name_match < list->length) {
             check_t *chk = &list->c[end_name_match];
 
-            if (memcmp(base_name + base->beg, bam_get_qname(chk->b) + chk->beg, base->len) != 0)
+            if ((base->len == chk->len) && memcmp(base_name + base->beg, bam_get_qname(chk->b) + chk->beg, base->len) != 0)
                 break;
         }
 


### PR DESCRIPTION
Checking optical duplicates in very deep data was very slow.

By adding more sort criteria we can reduce the total amount of work that needs to be done and so speed up the processing.  Sped of the processing of a 22GB file from two days to 70 minutes.

Fixes #1949.