### PR TITLE
fix for stat crash on invalid reference file

### DIFF
--- a/stats.c
+++ b/stats.c
@@ -2132,7 +2132,7 @@ static void HTS_NORETURN error(const char *format, ...)
 
 void cleanup_stats_info(stats_info_t* info){
     if (info->fai) fai_destroy(info->fai);
-    sam_close(info->sam);
+    if (info->sam) sam_close(info->sam);
     free(info);
 }
 


### PR DESCRIPTION
This change is to fix the crash mentioned in htslib issue 1723.
A null check is made before invoking samclose.
Along with this, a change is made in htslib to resolve the incorrect messaging and invalid access.