### PR TITLE
Change default max depth for bedcov.

### DIFF
--- a/doc/samtools-bedcov.1
+++ b/doc/samtools-bedcov.1
@@ -87,6 +87,13 @@ Print an additional column, for each file, containing the number of bases having
 a depth above and including the given threshold. If the option is not used, the
 extra column is not displayed. The option value must be an integer >= 0.
 .TP
+.BI "--max-depth " INT
+Specifies the maximum depth used for the mpileup algorithm.
+If \fB-d\fR is used and is larger then this value will be used instead.
+Defaults to 2 billion, but smaller values may be used when we do not
+require an exact count in excessively deep regions and are interested
+in maximising speed of results.
+.TP
 .B -c
 Print an additional column with the read count for this region.  This
 will be +1 for every read covering the region, not just starting


### PR DESCRIPTION
The -d option is used for specifying the minimum depth we need to meet in order to count bases covered with at least that depth in a new column.  It also ups the bam_mplp_set_maxcnt mpileup limit from 64000 to the '-d' value if bigger.

Therefore extremely deep data requires the use of '-d' to count bases even when it's not interested in the additional column.

Changed the default to be INT_MAX (every read is counted) and added a new --max-depth option to control this so we can limit it for problematic files if desired.  (It is unfortunate that in mpileup `-d` is short for `--max-depth` and here it is a minimum depth instead.)

Also fixed usage statement formatting.

Fixes #1950