### PR TITLE
Fix bed_index regression

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 Release a.b
 -----------
 
+Bug Fixes:
+
+* Fixed a regression in 1.19.1 that broke BED filtering for inputs where
+  the region start positions for the same reference were not sorted in
+  ascending order.
+  (PR #1975, fixes #1974.  Reported by Anže Starič)
+
 Release 1.19.1 (22nd January 2024)
 ----------------------------------
 

--- a/bedidx.c
+++ b/bedidx.c
@@ -144,7 +144,7 @@ static int bed_index(reghash_t *h)
                 p->idx = NULL;
             }
             ks_introsort(hts_pair_pos_t, p->n, p->a);
-            if (!bed_index_core(p)) {
+            if (bed_index_core(p) != 0) {
                 return -1;
             }
         }
@@ -345,7 +345,7 @@ void *bed_read(const char *fn)
     }
     ks_destroy(ks);
     free(str.s);
-    if (!bed_index(h))
+    if (bed_index(h) != 0)
         goto fail;
     //bed_unify(h);
     return h;
@@ -549,7 +549,7 @@ void *bed_hash_regions(void *reg_hash, char **regs, int first, int last, int *op
     }
 
     if (!(*op)) {
-        if (!bed_index(t))
+        if (bed_index(t) != 0)
             goto fail;
         bed_unify(t);
         if (bed_filter(h, t) == NULL)
@@ -559,7 +559,7 @@ void *bed_hash_regions(void *reg_hash, char **regs, int first, int last, int *op
     }
 
     if (h) {
-        if (!bed_index(h))
+        if (bed_index(h) != 0)
             goto fail;
         bed_unify(h);
     }

--- a/test/dat/view.001.03.bed
+++ b/test/dat/view.001.03.bed
@@ -1,0 +1,28 @@
+# The MIT License
+# 
+# Copyright (c) 2014 Genome Research Ltd.
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+browser position ref1:1-56
+browser hide all
+track name="my track" description="A track line" visibility=2 colorByStrand="255,0,0 0,0,255"
+ref1	44	45
+ref1	10	24	somewhere	500	+	10	24	127,127,0	2	2,2	10,22
+ref2	46	47
+ref2	11	12

--- a/test/test.pl
+++ b/test/test.pl
@@ -2233,6 +2233,7 @@ sub test_view
     my $bed2 = "$$opts{path}/dat/view.001.02.bed";
     my $bed3 = "$$opts{path}/dat/view.002.01.bed";
     my $bed4 = "$$opts{path}/dat/view.002.02.bed";
+    my $bed5 = "$$opts{path}/dat/view.001.03.bed"; # unsorted
     my $bed1reg = [['ref1', 11, 24], ['ref1', 45, 45], ['ref2', 17, 17]];
 
     my @region_tests = (
@@ -2276,6 +2277,9 @@ sub test_view
                       ['Z', 35, 35], ['Z', 40, 50]]}, ['-L', $bed4], []],
         ['bed1', 1, { region => $bed1reg }, ['-L', $bed1], []],
         ['bed2', 1, { region => [['ref1', 6, 20]] }, ['-L', $bed2], []],
+        ['bed5', 1, { region => [['ref1', 11, 24], ['ref1', 45, 45],
+                                 ['ref2', 12, 12], ['ref2', 47, 47]]},
+         ['-L', $bed5], []],
 
         # BED file plus region specification.
 


### PR DESCRIPTION
The checks for failure of `bed_index()` and `bed_index_core()` were all inverted, causing `bed_index()` to stop after only processing entries for one reference.  This resulted in `bed_filter()` becoming less efficient on all but the one reference that was indexed; and searches to fail on unsorted BED files.

Fixed by writing the failure tests correctly, and adding a test on unsorted BED inputs.

Fixes #1974