### PR TITLE
Check for flag string validity in options.

### DIFF
--- a/amplicon_stats.c
+++ b/amplicon_stats.c
@@ -1,6 +1,6 @@
 /*  stats.c -- This is the former bamcheck integrated into samtools/htslib.
 
-    Copyright (C) 2020-2021 Genome Research Ltd.
+    Copyright (C) 2020-2021, 2024 Genome Research Ltd.
 
     Author: James Bonfield <jkb@sanger.ac.uk>
 
@@ -1652,15 +1652,34 @@ int main_ampliconstats(int argc, char **argv) {
         {"single-ref", no_argument, NULL, 'S'},
         {NULL, 0, NULL, 0}
     };
-    int opt;
+    int opt, tmp_flag;
 
     while ( (opt=getopt_long(argc,argv,"?hf:F:@:p:m:d:sa:l:t:o:c:b:D:S",loptions,NULL))>0 ) {
         switch (opt) {
-        case 'f': args.flag_require = bam_str2flag(optarg); break;
+        case 'f':
+            tmp_flag = bam_str2flag(optarg);
+
+            if (tmp_flag < 0) {
+                print_error("ampliconstats", "Unknown flag '%s'\n", optarg);
+                return 1;
+            }
+
+            args.flag_require = tmp_flag;
+            break;
+
         case 'F':
+            tmp_flag = bam_str2flag(optarg);
+
             if (args.flag_filter & 0x10000)
                 args.flag_filter = 0; // strip default on first -F usage
-            args.flag_filter |= bam_str2flag(optarg); break;
+
+            if (tmp_flag < 0) {
+                print_error("ampliconstats", "Unknown flag '%s'\n", optarg);
+                return 1;
+            }
+
+            args.flag_filter |= tmp_flag;
+            break;
 
         case 'm': args.max_delta = atoi(optarg); break; // margin
         case 'D': args.depth_bin = atof(optarg); break; // depth bin fraction

--- a/bam2depth.c
+++ b/bam2depth.c
@@ -1,7 +1,7 @@
 /*  bam2depth.c -- depth subcommand.
 
     Copyright (C) 2011, 2012 Broad Institute.
-    Copyright (C) 2012-2016, 2018, 2019-2022 Genome Research Ltd.
+    Copyright (C) 2012-2016, 2018, 2019-2022, 2024 Genome Research Ltd.
 
     Author: Heng Li <lh3@sanger.ac.uk> (to 2020)
     Author: James Bonfield <jkb@sanger.ac.uk> (2021 rewrite)
@@ -745,7 +745,7 @@ static void usage_exit(FILE *fp, int exit_status)
 
 int main_depth(int argc, char *argv[])
 {
-    int nfiles, i;
+    int nfiles, i, tmp_flag;
     samFile **fp;
     sam_hdr_t **header;
     int c, has_index_file = 0;
@@ -806,16 +806,44 @@ int main_depth(int argc, char *argv[])
             break;
 
         case 'g':
-            opt.flag &= ~bam_str2flag(optarg);
+            tmp_flag = bam_str2flag(optarg);
+
+            if (tmp_flag < 0) {
+                print_error("depth", "Unknown flag '%s'", optarg);
+                return 1;
+            }
+
+            opt.flag &= ~tmp_flag;
             break;
         case 'G': // reject if any set
-            opt.flag |= bam_str2flag(optarg);
+            tmp_flag = bam_str2flag(optarg);
+
+            if (tmp_flag < 0) {
+                print_error("depth", "Unknown flag '%s'", optarg);
+                return 1;
+            }
+
+            opt.flag |= tmp_flag;
             break;
         case 1: // reject unless at least one set (0 means ignore option)
-            opt.incl_flag |= bam_str2flag(optarg);
+            tmp_flag = bam_str2flag(optarg);
+
+            if (tmp_flag < 0) {
+                print_error("depth", "Unknown flag '%s'", optarg);
+                return 1;
+            }
+
+            opt.incl_flag |= tmp_flag;
             break;
         case 2: // reject unless all set
-            opt.require_flag |= bam_str2flag(optarg);
+            tmp_flag = bam_str2flag(optarg);
+
+            if (tmp_flag < 0) {
+                print_error("depth", "Unknown flag '%s'", optarg);
+                return 1;
+            }
+
+            opt.require_flag |= tmp_flag;
             break;
 
         case 'l':

--- a/sam_view.c
+++ b/sam_view.c
@@ -898,6 +898,8 @@ int main_samview(int argc, char *argv[])
     opterr = 0;
 
     char *tmp;
+    int tmp_flag;
+
     while ((c = getopt_long(argc, argv,
                             "SbBcCt:h1Ho:O:q:f:F:G:ul:r:T:R:N:d:D:L:s:@:m:x:U:MXe:pPz:",
                             lopts, NULL)) >= 0) {
@@ -942,19 +944,47 @@ int main_samview(int argc, char *argv[])
         case 'U': settings.fn_un_out = strdup(optarg); break;
         case 'X': has_index_file = 1; break;
         case 'f':
-            settings.flag_on |= bam_str2flag(optarg);
+            tmp_flag = bam_str2flag(optarg);
+
+            if (tmp_flag < 0) {
+                print_error("view", "Unknown flag '%s'", optarg);
+                return 1;
+            }
+
+            settings.flag_on |= tmp_flag;
             settings.count_rf |= SAM_FLAG | SAM_RNEXT;
             break;
         case 'F':
-            settings.flag_off |= bam_str2flag(optarg);
+            tmp_flag = bam_str2flag(optarg);
+
+            if (tmp_flag < 0) {
+                print_error("view", "Unknown flag '%s'", optarg);
+                return 1;
+            }
+
+            settings.flag_off |= tmp_flag;
             settings.count_rf |= SAM_FLAG | SAM_RNEXT;
             break;
         case LONGOPT('g'):
-            settings.flag_anyon |= bam_str2flag(optarg);
+            tmp_flag = bam_str2flag(optarg);
+
+            if (tmp_flag < 0) {
+                print_error("view", "Unknown flag '%s'", optarg);
+                return 1;
+            }
+
+            settings.flag_anyon |= tmp_flag;
             settings.count_rf |= SAM_FLAG | SAM_RNEXT;
             break;
         case 'G':
-            settings.flag_alloff |= bam_str2flag(optarg);
+            tmp_flag = bam_str2flag(optarg);
+
+            if (tmp_flag < 0) {
+                print_error("view", "Unknown flag '%s'", optarg);
+                return 1;
+            }
+
+            settings.flag_alloff |= tmp_flag;
             settings.count_rf |= SAM_FLAG | SAM_RNEXT;
             break;
         case 'q':
@@ -1114,8 +1144,27 @@ int main_samview(int argc, char *argv[])
             }
             settings.count_rf = INT_MAX; // no way to know what we need
             break;
-        case LONGOPT('r'): settings.remove_flag |= bam_str2flag(optarg); break;
-        case LONGOPT('a'): settings.add_flag |= bam_str2flag(optarg); break;
+        case LONGOPT('r'):
+            tmp_flag = bam_str2flag(optarg);
+
+            if (tmp_flag < 0) {
+                print_error("view", "Unknown flag '%s'", optarg);
+                return 1;
+            }
+
+            settings.remove_flag |= tmp_flag;
+            break;
+
+        case LONGOPT('a'):
+            tmp_flag = bam_str2flag(optarg);
+
+            if (tmp_flag < 0) {
+                print_error("view", "Unknown flag '%s'", optarg);
+                return 1;
+            }
+
+            settings.add_flag |= tmp_flag;
+            break;
 
         case 'x':
             if (*optarg == '^') {

--- a/stats.c
+++ b/stats.c
@@ -1,6 +1,6 @@
 /*  stats.c -- This is the former bamcheck integrated into samtools/htslib.
 
-    Copyright (C) 2012-2022 Genome Research Ltd.
+    Copyright (C) 2012-2024 Genome Research Ltd.
 
     Author: Petr Danecek <pd3@sanger.ac.uk>
     Author: Sam Nicholls <sam@samnicholls.net>
@@ -2440,14 +2440,34 @@ int main_stats(int argc, char *argv[])
         {"cov-threshold", required_argument, NULL, 'g'},
         {NULL, 0, NULL, 0}
     };
-    int opt;
+    int opt, tmp_flag;
 
     while ( (opt=getopt_long(argc,argv,"?hdsXxpr:c:l:i:t:m:q:f:F:g:I:S:P:@:",loptions,NULL))>0 )
     {
         switch (opt)
         {
-            case 'f': info->flag_require = bam_str2flag(optarg); break;
-            case 'F': info->flag_filter |= bam_str2flag(optarg); break;
+            case 'f':
+                tmp_flag = bam_str2flag(optarg);
+
+                if (tmp_flag < 0) {
+                    print_error("stats", "Unknown flag '%s'", optarg);
+                    return 1;
+                }
+
+                info->flag_require = tmp_flag;
+                break;
+
+            case 'F':
+                tmp_flag = bam_str2flag(optarg);
+
+                if (tmp_flag < 0) {
+                    print_error("stats", "Unknown flag '%s'", optarg);
+                    return 1;
+                }
+
+                info->flag_filter |= tmp_flag;
+                break;
+
             case 'd': info->flag_filter |= BAM_FDUP; break;
             case 'X': has_index_file = 1; break;
             case 's': break;


### PR DESCRIPTION
Several tools were not checking for flag string validity in options.

Fixes #1977. 