### PR TITLE
Make consensus --min-depth work for Bayesian mode too

### DIFF
--- a/bam_consensus.c
+++ b/bam_consensus.c
@@ -2083,7 +2083,10 @@ static int basic_pileup(void *cd, samFile *fp, sam_hdr_t *h, pileup_t *p,
         calculate_consensus_gap5m(pos, opts->use_mqual ? CONS_MQUAL : 0,
                                   depth, p, opts, &cons, opts->default_qual,
                                   &cons_prob_recall, &cons_prob_precise);
-        if (cons.het_logodd > 0 && opts->ambig) {
+        if (cons.depth < opts->min_depth) {
+            cb = 'N';
+            cq = 0;
+        } else if (cons.het_logodd > 0 && opts->ambig) {
             cb = "AMRWa" // 5x5 matrix with ACGT* per row / col
                  "MCSYc"
                  "RSGKg"
@@ -2228,14 +2231,17 @@ static int basic_fasta(void *cd, samFile *fp, sam_hdr_t *h, pileup_t *p,
         calculate_consensus_gap5m(pos, opts->use_mqual ? CONS_MQUAL : 0,
                                   depth, p, opts, &cons, opts->default_qual,
                                   &cons_prob_recall, &cons_prob_precise);
-        if (cons.het_logodd > 0 && opts->ambig) {
+        if (cons.depth < opts->min_depth) {
+            cb = 'N';
+            cq = 0;
+        } else if (cons.het_logodd > 0 && opts->ambig) {
             cb = "AMRWa" // 5x5 matrix with ACGT* per row / col
                  "MCSYc"
                  "RSGKg"
                  "WYKTt"
                  "acgt*"[cons.het_call];
             cq = cons.het_logodd;
-        } else{
+        } else {
             cb = "ACGT*"[cons.call];
             cq = cons.phred;
         }
@@ -2319,10 +2325,10 @@ static void usage_exit(FILE *fp, int exit_status) {
     fprintf(fp, "  --show-ins yes/no     Whether to show insertions [yes]\n");
     fprintf(fp, "  --mark-ins            Add '+' before every inserted base/qual [off]\n");
     fprintf(fp, "  -A, --ambig           Enable IUPAC ambiguity codes [off]\n");
+    fprintf(fp, "  -d, --min-depth INT   Minimum depth of INT [1]\n");
     fprintf(fp, "\nFor simple consensus mode:\n");
     fprintf(fp, "  -q, --(no-)use-qual   Use quality values in calculation [off]\n");
     fprintf(fp, "  -c, --call-fract INT  At least INT portion of bases must agree [0.75]\n");
-    fprintf(fp, "  -d, --min-depth INT   Minimum depth of INT [2]\n");
     fprintf(fp, "  -H, --het-fract INT   Minimum fraction of 2nd-most to most common base [0.15]\n");
     fprintf(fp, "\nFor default \"Bayesian\" consensus mode:\n");
     fprintf(fp, "  -C, --cutoff C        Consensus cutoff quality C [10]\n");

--- a/doc/samtools-consensus.1
+++ b/doc/samtools-consensus.1
@@ -212,6 +212,13 @@ derivation of the consensus to reference coordinate mapping.
 Enables IUPAC ambiguity codes in the consensus output.  Without this
 the output will be limited to A, C, G, T, N and *.
 
+.TP
+.BI "-d " D ", --min-depth " D
+The minimum depth required to make a call.  Defaults to 1.  Failing
+this depth check will produce consensus "N", or absent if it is an
+insertion.  Note this check is performed after filtering by flags
+and mapping/base quality.
+
 .TP 0
 The following options apply only to the simple consensus mode:
 
@@ -227,13 +234,6 @@ parameters too.  Quality values are always used for the "Gap5"
 consensus method and this option has no affect.
 Note currently  quality values only affect SNPs and not inserted
 sequences, which still get scores with a fixed +1 per base type occurrence.
-
-.TP
-.BI "-d " D ", --min-depth " D
-The minimum depth required to make a call.  Defaults to 1.  Failing
-this depth check will produce consensus "N", or absent if it is an
-insertion.  Note this check is performed after filtering by flags
-and mapping/base quality.
 
 .TP
 .BI "-H " H ", --het-fract " H


### PR DESCRIPTION
Also fixed the usage statement which claimed the default min-depth was
2.  It was 1 (as reported correctly in the man page).

Fixes #1982.