### PR TITLE
Speed up mpileup by reducing passes through arrays and qual

### DIFF
--- a/bam_plbuf.h
+++ b/bam_plbuf.h
@@ -50,11 +50,6 @@ void bam_plbuf_destroy(bam_plbuf_t *buf);
 
 int bam_plbuf_push(const bam1_t *b, bam_plbuf_t *buf);
 
-/* Exported from bam_plcmd.c */
-int pileup_seq(FILE *fp, const bam_pileup1_t *p, hts_pos_t pos,
-               hts_pos_t ref_len, const char *ref, kstring_t *ks,
-               int rev_del, int no_ins, int no_ins_mods,
-               int no_del, int no_ends);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The code has multiple passes through plp[i] getting ther qualities and comparing against conf->min_baseQ.  This is done for printing the depth, which sequence bases to display, as well as obviously the quality values.  All 3 of these are now computed in a single step, putting the values into kstrings.

We still have additional excess loops if we ask for the optional columns, but that's not the default output and can be dealt with at a later stage.

Also remove some of the excess seq_nt16_table and seq_nt_str back and forth, plus specialise for strand so we don't also have to call toupper and tolower plus detection of the "=" code.

The combined speed up is 20-25% on the BAM files I tested (long and short read).