### PR TITLE
Update CRAM versions

### DIFF
--- a/doc/samtools.1
+++ b/doc/samtools.1
@@ -967,7 +967,7 @@ references (such as a fragmented assembly).
 .TP
 .BI version= major.minor
 CRAM output only.  Specifies the CRAM version number.  Acceptable
-values are "2.1" and "3.0".
+values are "2.1", "3.0", and "3.1".
 .TP
 .BI seqs_per_slice= INT
 CRAM output only; defaults to 10000.


### PR DESCRIPTION
CRAM version 3.1 is missing from the list of valid CRAM version numbers in the man page.