### PR TITLE
Make name sort put primary reads before secondary reads.

### DIFF
--- a/bam_sort.c
+++ b/bam_sort.c
@@ -240,8 +240,12 @@ static inline int heap_lt(const heap1_t a, const heap1_t b)
         case QueryName:
             t = strnum_cmp(bam_get_qname(a.entry.bam_record), bam_get_qname(b.entry.bam_record));
             if (t != 0) return t > 0;
-            fa = a.entry.bam_record->core.flag & 0xc0;
-            fb = b.entry.bam_record->core.flag & 0xc0;
+            fa = a.entry.bam_record->core.flag;
+            fb = b.entry.bam_record->core.flag;
+            // Sort order is READ1, READ2, (PRIMARY), SUPPLEMENTARY, SECONDARY
+            // Get the bits in this order so sort is a natural a-b
+            fa = ((fa&0xc0)<<8)|((fa&0x100)<<3)|((fa&0x800)>>3);
+            fb = ((fb&0xc0)<<8)|((fb&0x100)<<3)|((fb&0x800)>>3);
             if (fa != fb) return fa > fb;
             break;
         case TagQueryName:
@@ -262,7 +266,7 @@ static inline int heap_lt(const heap1_t a, const heap1_t b)
             break;
     }
 
-    // This compares by position in the input file(s)
+    // This compares by position (i/idx'th read) in the input file(s)
     if (a.i != b.i) return a.i > b.i;
     return a.idx > b.idx;
 }
@@ -1965,7 +1969,13 @@ static inline int bam1_cmp_core(const bam1_tag a, const bam1_tag b)
     if (g_sam_order == QueryName || g_sam_order == TagQueryName) {
         int t = strnum_cmp(bam_get_qname(a.bam_record), bam_get_qname(b.bam_record));
         if (t != 0) return t;
-        return (int) (a.bam_record->core.flag&0xc0) - (int) (b.bam_record->core.flag&0xc0);
+        int af = a.bam_record->core.flag;
+        int bf = b.bam_record->core.flag;
+        // Sort order is READ1, READ2, (PRIMARY), SUPPLEMENTARY, SECONDARY
+        // Get the bits in this order so sort is a natural a-b
+        af = ((af&0xc0)<<8)|((af&0x100)<<3)|((af&0x800)>>3);
+        bf = ((bf&0xc0)<<8)|((bf&0x100)<<3)|((bf&0x800)>>3);
+        return af - bf;
     } else {
         pa = a.bam_record->core.tid;
         pb = b.bam_record->core.tid;

--- a/doc/samtools-sort.1
+++ b/doc/samtools-sort.1
@@ -266,8 +266,10 @@ attempt any numeric comparisons and may be more appropriate for some
 data sets.  Note care must be taken when using \fBsamtools merge\fP to
 ensure all files are using the same collation order.
 Records with the same name will be ordered according to the values of
-the READ1 and READ2 flags (see
-.BR flags ).
+the READ1 and READ2 flags (see \fBsamtools flags\fR). When that flag
+is also equal, ties are resolved with primary alignments first, then
+SUPPLEMENTARY, SECONDARY, and finally SUPPLEMENTARY plus SECONDARY.
+Any remaining ties are reported in the same order as the input data.
 
 When the 
 .B --template-coordinate

--- a/test/dat/sort_name_input_1.sam
+++ b/test/dat/sort_name_input_1.sam
@@ -1,0 +1,20 @@
+@HD	VN:1.5	SO:coordinate
+@SQ	SN:1	LN:249250621	M5:1b22b98cdeb4a9304cb5d48026a85128	UR:/nfs/srpipe_references/references/Human/1000Genomes_hs37d5/all/fasta/hs37d5.fa
+b	68	1	999	60	151M	*	0	0	*	*	cr:Z:read1	cc:Z:correct order
+b	64	1	999	60	151M	*	0	0	*	*	cr:Z:read1	cc:Z:correct order
+b	2112	1	999	60	151M	*	0	0	*	*
+b	320	1	999	60	151M	*	0	0	*	*
+b	2368	1	999	60	151M	*	0	0	*	*
+b	128	1	999	60	151M	*	0	0	*	*	cr:Z:read2	cc:Z:correct order
+b	2176	1	999	60	151M	*	0	0	*	*
+b	384	1	999	60	151M	*	0	0	*	*
+b	2432	1	999	60	151M	*	0	0	*	*
+a	2432	1	999	60	151M	*	0	0	*	*	cc:Z:reversed order
+a	384	1	999	60	151M	*	0	0	*	*
+a	2176	1	999	60	151M	*	0	0	*	*
+a	128	1	999	60	151M	*	0	0	*	*
+a	2368	1	999	60	151M	*	0	0	*	*
+a	320	1	999	60	151M	*	0	0	*	*
+a	2112	1	999	60	151M	*	0	0	*	*
+a	64	1	999	60	151M	*	0	0	*	*
+a	68	1	999	60	151M	*	0	0	*	*

--- a/test/sort/name3.sort.expected.sam
+++ b/test/sort/name3.sort.expected.sam
@@ -1,0 +1,21 @@
+@HD	VN:1.5	SO:queryname	SS:queryname:natural
+@SQ	SN:1	LN:249250621	M5:1b22b98cdeb4a9304cb5d48026a85128	UR:/nfs/srpipe_references/references/Human/1000Genomes_hs37d5/all/fasta/hs37d5.fa
+@PG	ID:samtools	PN:samtools	VN:1.19.2-19-g11384b23-dirty	CL:samtools sort -Osam -n ../samtools/_sort.sam
+a	64	1	999	60	151M	*	0	0	*	*
+a	68	1	999	60	151M	*	0	0	*	*
+a	2112	1	999	60	151M	*	0	0	*	*
+a	320	1	999	60	151M	*	0	0	*	*
+a	2368	1	999	60	151M	*	0	0	*	*
+a	128	1	999	60	151M	*	0	0	*	*
+a	2176	1	999	60	151M	*	0	0	*	*
+a	384	1	999	60	151M	*	0	0	*	*
+a	2432	1	999	60	151M	*	0	0	*	*	cc:Z:reversed order
+b	68	1	999	60	151M	*	0	0	*	*	cr:Z:read1	cc:Z:correct order
+b	64	1	999	60	151M	*	0	0	*	*	cr:Z:read1	cc:Z:correct order
+b	2112	1	999	60	151M	*	0	0	*	*
+b	320	1	999	60	151M	*	0	0	*	*
+b	2368	1	999	60	151M	*	0	0	*	*
+b	128	1	999	60	151M	*	0	0	*	*	cr:Z:read2	cc:Z:correct order
+b	2176	1	999	60	151M	*	0	0	*	*
+b	384	1	999	60	151M	*	0	0	*	*
+b	2432	1	999	60	151M	*	0	0	*	*

--- a/test/test.pl
+++ b/test/test.pl
@@ -3223,6 +3223,7 @@ sub test_sort
     # Name sort
     test_cmd($opts, out=>"sort/name.sort.expected.sam", ignore_pg_header => 1, cmd=>"$$opts{bin}/samtools sort${threads} -n -m 10M $$opts{path}/dat/test_input_1_a.bam -O SAM -o -");
     test_cmd($opts, out=>"sort/name2.sort.expected.sam", ignore_pg_header => 1, cmd=>"$$opts{bin}/samtools sort${threads} -N -m 10M $$opts{path}/dat/test_input_1_b.bam -O SAM -o -");
+    test_cmd($opts, out=>"sort/name3.sort.expected.sam", ignore_pg_header => 1, cmd=>"$$opts{bin}/samtools sort${threads} -n -m 10M $$opts{path}/dat/sort_name_input_1.sam -O SAM -o -");
 
     # Tag sort (RG)
     test_cmd($opts, out=>"sort/tag.rg.sort.expected.sam", ignore_pg_header => 1, cmd=>"$$opts{bin}/samtools sort${threads} -t RG -m 10M $$opts{path}/dat/test_input_1_a.bam -O SAM -o -");


### PR DESCRIPTION
For completeness, we consider non-secondary supplementaries as before secondaries, and non-supplementary secondaries before secondary+supplementary.

This is because a (non-2ndary) supplementary read is a continuation of the primary read and should be grouped before alternate alignments for this read.

We still have all READ1 data before all READ2 data, so the primary alignment has not changed ordering.  This is simply a better way of resolving ties than keeping the original ordering.

Fixes #2010