### PR TITLE
Avoid a potential double free on failure, in bed_read.

### DIFF
--- a/bedidx.c
+++ b/bedidx.c
@@ -343,10 +343,10 @@ void *bed_read(const char *fn)
         fp = NULL;
         goto fail;
     }
-    ks_destroy(ks);
-    free(str.s);
     if (bed_index(h) != 0)
         goto fail;
+    ks_destroy(ks);
+    free(str.s);
     //bed_unify(h);
     return h;
  fail:


### PR DESCRIPTION
If we run out of memory while calling bed_index then it rightly fails, but in doing so frees ks and str.vs twice.  Under normal conditions there were no memory errors.

This is a minor error handling glitch that arrived with #1962.