### PR TITLE
Avoid tview buffer overflow for positions with ≥14 digits

### DIFF
--- a/bam_tview.c
+++ b/bam_tview.c
@@ -364,16 +364,11 @@ int base_draw_aln(tview_t *tv, int tid, hts_pos_t pos)
     tv->ccol = 0;
     // print ref and consensus
     if (tv->fai) {
-        char *str;
         if (tv->ref) free(tv->ref);
         assert(tv->curr_tid>=0);
 
         const char *ref_name = sam_hdr_tid2name(tv->header, tv->curr_tid);
-        str = (char*)calloc(strlen(ref_name) + 30, 1);
-        assert(str!=NULL);
-        sprintf(str, "%s:%"PRIhts_pos"-%"PRIhts_pos, ref_name, tv->left_pos + 1, tv->left_pos + tv->mcol);
-        tv->ref = fai_fetch64(tv->fai, str, &tv->l_ref);
-        free(str);
+        tv->ref = faidx_fetch_seq64(tv->fai, ref_name, tv->left_pos, tv->left_pos + tv->mcol - 1, &tv->l_ref);
         if ( !tv->ref )
         {
             fprintf(stderr,"Could not read the reference sequence. Is it seekable (plain text or compressed + .gzi indexed with bgzip)?\n");
@@ -398,7 +393,7 @@ int base_draw_aln(tview_t *tv, int tid, hts_pos_t pos)
         hts_pos_t pos = tv->last_pos + 1;
         int interval = pos < TEN_DIGITS ? 10 : 20;
         if (pos%interval == 0 && tv->mcol - tv->ccol >= 10) tv->my_mvprintw(tv,0, tv->ccol, "%-"PRIhts_pos, pos+1);
-        tv->my_mvaddch(tv,1, tv->ccol++, (tv->ref && pos < tv->l_ref)? tv->ref[pos - tv->left_pos] : 'N');
+        tv->my_mvaddch(tv,1, tv->ccol++, (tv->ref && pos - tv->left_pos < tv->l_ref)? tv->ref[pos - tv->left_pos] : 'N');
         ++tv->last_pos;
     }
     return 0;


### PR DESCRIPTION
As reported by @jmunoz94 in bioconda/bioconda-recipes#47137, the following crashes on some platforms, e.g., Linux:

```
$ samtools tview -dT   -p 17:99999999999999999999 test/mpileup/mpileup.1.bam test/mpileup/mpileup.ref.fa
malloc(): invalid next size (unsorted)
Aborted

$ samtools tview -dT -p chr1:99999999999999999999 wgEncodeUwRepliSeqBg02esG1bAlnRep1.bam GRCh38.fa
malloc(): corrupted top size
Aborted
```

(I happened to test this with [wgEncodeUwRepliSeqBg02esG1bAlnRep1.bam](http://hgdownload.cse.ucsc.edu/goldenPath/hg19/encodeDCC/wgEncodeUwRepliSeq/wgEncodeUwRepliSeqBg02esG1bAlnRep1.bam) lying around from previously looking into #1884. This particular BAM file demonstrates some additional problems as described below.)

Using AddressSanitizer this can be quickly tracked down to a buffer overflow within _bam_tview.c_ due to the very large position. This buffer's size was not revised when the 64-bit `hts_pos_t` was introduced in #1117. This PR rewrites it using `faidx_fetch_seq64()` instead to avoid needing to build region strings at all.

Testing this further with fewer 9s I noticed some additional problems:

```
$ samtools tview -d T -p chr1:999999 wgEncodeUwRepliSeqBg02esG1bAlnRep1.bam GRCh38-chr1.fa
  1000001   1000011   1000021   1000031   1000041   1000051   1000061           
GGGTGGAGCGCGCCGCCACGGACCACGGGCGNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
.....C.CA..CT.A..CA...AAG.ACCT.                                                 
.T.G.C.CA..CT.A..CA...AAG.ACCT.     
```

Notice that the reference line reverts to NNNNNN at positions past the reads. This turns out to be a buglet that has existed since 67392b892147cff4bfb8718a819bab86d577b4e3 in 2009! I've also fixed this in this commit: Fix `tv->ref` guard (compare the similar code in `tv_pl_func()`) so that areas with no reads show the reference rather than ...NNNNNN...

Additionally with this data file samtools goes into an infinite(?) loop when given two fewer 9s than in the original report:

```
$ samtools tview -d T -p chr1:999999999999999999 wgEncodeUwRepliSeqBg02esG1bAlnRep1.bam GRCh38-chr1.fa
[runs for a long time]
```

This can be traced to the `do … while` loop in `hts_itr_query()`, which loops perhaps forever through negative bin numbers. Possibly this code should check for a `beg` value massively beyond the maximum position covered by the index's bins and sidestep most of its processing. (I haven't addressed that in this PR and can raise it as an HTSlib issue if you wish.)

Finally these positions specified on the command line are well beyond 2<sup>63</sup> so are ingested as unrelated values within the range of `hts_pos_t` (or even negative) because `hts_parse_decimal()` does no overflow checking.

Looking back at PR #1171 there's surprisingly little discussion and no mention of overflow handling. It didn't occur to me that people would specify positions unrelated to any reality-based meaningful chromosome positions, so it didn't occur to me that people might specify numbers of such magnitude, beyond 2<sup>63</sup>. This could be left as is (garbage in, garbage out! Or alternatively: Doctor, it hurts when I do this…) on the basis that such input deserves what it gets, or overflow detection could be added to `hts_parse_decimal()` and reported in some way.