### PR TITLE
Add region and section/part filtering to CRAM samtools cat.

### DIFF
--- a/bam_cat.c
+++ b/bam_cat.c
@@ -1,6 +1,7 @@
 /*  bam_cat.c -- efficiently concatenates bam files.
 
-    Copyright (C) 2008-2009, 2011-2013, 2015-2017, 2019, 2021, 2023 Genome Research Ltd.
+    Copyright (C) 2008-2009, 2011-2013, 2015-2017, 2019, 2021,
+                  2023-2024 Genome Research Ltd.
     Modified SAMtools work copyright (C) 2010 Illumina, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -46,6 +47,7 @@ Illumina.
 #include "htslib/sam.h"
 #include "htslib/cram.h"
 #include "htslib/kstring.h"
+#include "htslib/hfile.h"
 #include "samtools.h"
 #include "sam_opts.h"
 
@@ -202,18 +204,202 @@ fail:
     return NULL;
 }
 
-int cram_cat(samFile * const firstfile, int nfn, char * const *fn, const sam_hdr_t *h, const char* outcram, sam_global_args *ga, char *arg_list, int no_pg)
+
+/* ----------------------------------------------------------------------
+ * CRAM cat
+ */
+
+// Reports the number of CRAM containers spanning a specified region if
+// specified, or the entire file if not.
+// This is the implements the "samtools cat -q [-r reg]" functionality.
+//
+// Returns 0 on success, <0 on error.
+static int cram_query_ncont(int nfn, char * const *fn, char *reg) {
+    int i;
+    hts_idx_t *idx = NULL;
+    sam_hdr_t *hdr = NULL;
+    hts_itr_t *iter = NULL;
+    samFile *in = NULL;
+
+    for (i = 0; i < nfn; i++) {
+        in = sam_open(fn[i], "r");
+        if (!in) {
+            print_error_errno("cat", "Couldn't open file %s", fn[i]);
+            return -1;
+        }
+        idx = sam_index_load(in, fn[i]);
+        if (!idx) {
+            print_error("cat", "No index found");
+            goto err;
+        }
+
+        off_t cstart = 0, cend = 0;
+        if (reg) {
+            sam_hdr_t *hdr = sam_hdr_read(in);
+            hts_itr_t *iter = sam_itr_querys(idx, hdr, reg);
+            if (!hdr) {
+                print_error("cat", "Unable to read header");
+                goto err;
+            }
+            if (!iter) {
+                print_error("cat", "Unable to parse region");
+                goto err;
+            }
+
+            if (cram_index_extents(in->fp.cram, iter->tid, iter->beg,
+                                   iter->end, &cstart, &cend) < 0) {
+                print_error("cat", "Failed to query index");
+                goto err;
+            }
+
+            hts_itr_destroy(iter);
+            sam_hdr_destroy(hdr);
+        }
+
+        int64_t first, last;
+        int64_t nc = cram_num_containers_between(in->fp.cram, cstart, cend,
+                                                 &first, &last);
+        printf("%s\t%"PRId64"\t%"PRId64"\t%"PRId64"\n",
+               fn[i], nc, first, last);
+        sam_close(in);
+        hts_idx_destroy(idx);
+    }
+
+    return 0;
+
+ err:
+    if (idx)
+        hts_idx_destroy(idx);
+    if (hdr)
+        sam_hdr_destroy(hdr);
+    if (iter)
+        hts_itr_destroy(iter);
+
+    sam_close(in);
+
+    return -1;
+}
+
+// Container range #:A-B or #:A.
+// Returns 0 on success, -1 on failure.
+static int cram_handle_cnum_region(cram_fd *fd, hts_idx_t *idx,
+                                   char *reg, off_t *cstart, off_t *cend) {
+    int cnum_start, cnum_end; // container versions
+    int n = sscanf(reg, "#:%d-%d", &cnum_start, &cnum_end);
+
+    if (n == 0) {
+        print_error("cat", "ERROR: Malformed region: %s", reg);
+        return -1;
+    } else if (n == 1) {
+        cnum_end = cnum_start;
+    }
+
+    int64_t nc = cram_num_containers(fd);
+    if (cnum_end >= nc) {
+        print_error("cat", "Too many containers.  "
+                    "The end range should be < %"PRId64, nc);
+        return -1;
+    }
+
+    // Container number to offset
+    *cstart = cram_container_num2offset(fd, cnum_start);
+    *cend   = cram_container_num2offset(fd, cnum_end);
+    if (*cstart < 0 || *cend < 0)
+        return -1;
+
+    // Seek manually
+    return cram_seek(fd, *cstart, SEEK_SET);
+}
+
+// Normal range chr:start-end.
+// Returns an hts iterator on success, NULL on failure.
+static hts_itr_t *cram_handle_region(cram_fd *fd, hts_idx_t *idx, sam_hdr_t *h,
+                                     char *reg, off_t *cstart, off_t *cend) {
+    hts_itr_t *iter;
+
+    if (!idx) {
+        fprintf(stderr, "[%s] ERROR: No index found.\n", __func__);
+        return NULL;
+    }
+
+    // This does an implicit seek and modifies the cram_fd.
+    if (!(iter = sam_itr_querys(idx, h, reg))) {
+        print_error("cat", "Unable to parse region %s", reg);
+        return NULL;
+    }
+    if (cram_index_extents(fd, iter->tid, iter->beg,
+                           iter->end, cstart, cend) < 0) {
+        print_error("cat", "Failed to query index");
+        return NULL;
+    }
+
+    return iter;
+}
+
+// Handle the -p A/B option to subdivide our region or file into portions.
+// Updates cstart/cend.
+// returns 0 on success (do something),
+//         1 on success (but nothing to do),
+//        -1 on failure.
+static int cram_subdivide_part(cram_fd *fd, hts_idx_t *idx, char *part,
+                               off_t *cstart, off_t *cend) {
+    int a, b;
+    // Part N of M
+    if (sscanf(part, "%d/%d", &a, &b) != 2) {
+        print_error("cat", "malformed region %s. Should be e.g. '1/10'", part);
+        return -1;
+    }
+
+    // Inclusive container numbers for range, 0 to NC-1
+    // Our part N/M is in container percentages as we can't have
+    // partial containers, so convert to that first.
+    int64_t cnum1, cnum2;
+    if (cstart) {
+        cnum1 = cram_container_offset2num(fd, *cstart);
+        cnum2 = cram_container_offset2num(fd, *cend);
+    } else {
+        cnum1 = 0;
+        cnum2 = cram_num_containers(fd)-1;
+    }
+
+    // Subdivide cnum1/cnum2 container numbers to new range cnum_start/end
+    int64_t nc = cnum2 - cnum1 + 1;
+    if (b > nc)
+        b = nc;
+
+    int cnum_start = (a-1)*(double)nc/b;
+    int cnum_end   = a*(double)nc/b - 1;
+    if (cnum_start < 0 || cnum_end >= nc)
+        return 1;
+
+    // Then convert back to file offsets so we can seek and do htell
+    // to detect EOR/EOF.
+    *cstart = cram_container_num2offset(fd, cnum_start + cnum1);
+    *cend   = cram_container_num2offset(fd, cnum_end   + cnum1);
+
+    return 0;
+}
+
+// The main cram_cat interface.
+// Returns 0 on success, < 0 on error.
+int cram_cat(samFile * const firstfile, int nfn, char * const *fn,
+             const sam_hdr_t *h, const char* outcram, sam_global_args *ga,
+             char *arg_list, int no_pg, char *reg, char *part, int fast_reg)
 {
     samFile *out = NULL;
     cram_fd *out_c;
     int i, vers_maj, vers_min, ret = -1;
     sam_hdr_t *new_h = NULL;
     samFile **files = NULL;
+    hts_idx_t *idx = NULL;
+    hts_itr_t *iter = NULL;
+    sam_hdr_t *old_h = NULL;
 
-    /* Check consistent versioning and compatible headers;
-    merges RG lines, opens all files and returns them that multiple non-seekable
-    stream inputs can be handled */
-    if (!(files = cat_check_merge_hdr(firstfile, nfn, fn, h, &vers_maj, &vers_min, &new_h)))
+    // Check consistent versioning and compatible headers;
+    // merges RG lines, opens all files and returns them that multiple
+    // non-seekable stream inputs can be handled
+    if (!(files = cat_check_merge_hdr(firstfile, nfn, fn, h, &vers_maj,
+                                      &vers_min, &new_h)))
         return -1;
 
     if (!new_h) {
@@ -224,14 +410,15 @@ int cram_cat(samFile * const firstfile, int nfn, char * const *fn, const sam_hdr
     /* Open the file with cram_vers */
     char vers[100];
     snprintf(vers, sizeof(vers), "%d.%d", vers_maj, vers_min);
-    out = sam_open_format(outcram, "wc", &ga->out);
+
+    // Can override level=1 with e.g. "--output-fmt-option level=9"
+    out = sam_open_format(outcram, "wc1", &ga->out);
     if (out == 0) {
         print_error_errno("cat", "fail to open output file '%s'", outcram);
         goto closefiles;
     }
     out_c = out->fp.cram;
     cram_set_option(out_c, CRAM_OPT_VERSION, vers);
-    //fprintf(stderr, "Creating cram vers %s\n", vers);
 
     if (!no_pg && sam_hdr_add_pg(new_h, "samtools",
                                  "VN", samtools_version(),
@@ -250,7 +437,6 @@ int cram_cat(samFile * const firstfile, int nfn, char * const *fn, const sam_hdr
         samFile *in;
         cram_fd *in_c;
         cram_container *c;
-        sam_hdr_t *old_h;
         int new_rg = -1;
 
         in = files[i];
@@ -283,6 +469,68 @@ int cram_cat(samFile * const firstfile, int nfn, char * const *fn, const sam_hdr
             new_rg = 0;
         }
 
+        // We have multiple region syntax.  Either the standard chr:start-end
+        // or a cat-specific #:num-num for explicit container numbers.
+        // Both of these seek to a specific file offset and also have the
+        // end offset known so we can use htell to detect when we're done.
+        // Those offsets are in cstart and cend.
+        //
+        // However for the e.g. -p 1/10 syntax we need to know the container
+        // numbers corresponding to the cstart/cend offsets as we can't
+        // start half way through a container when doing fractions.
+        // These are cnum1 and cnum2.  (We could short cut this for the
+        // #:num-num, but it's simpler to just treat all regions identically.)
+        off_t cstart = 0, cend = 0;
+        int filter_by_cnum = 0;
+
+        if (reg || part) {
+            idx = sam_index_load(in, fn[i]);
+            if (!idx) {
+                print_error("cat", "failed to load index");
+                goto closefiles;
+            }
+        }
+
+        if (reg) {
+            if (strncmp(reg, "#:", 2) == 0) {
+                // Region as container numbers
+                if (cram_handle_cnum_region(in_c, idx, reg, &cstart,&cend) < 0)
+                    goto closefiles;
+
+                filter_by_cnum = 1;
+            } else {
+                // Normal range chr:start-end
+                if (!(iter = cram_handle_region(in_c, idx, old_h, reg,
+                                                &cstart, &cend)))
+                    goto closefiles;
+            }
+        }
+
+        // We can also take a range above and subdivide it into parts.
+        // Eg -r chr1 -p 1/10 (... to -p 10/10).  Part only implies
+        // portions of the entire file.
+        if (part) {
+            int r = cram_subdivide_part(in_c, idx, part, &cstart, &cend);
+            if (r != 0) {
+                if (r > 0) // Not an error, just nothing to do
+                    ret = 0;
+                goto closefiles;
+            }
+        }
+
+        if (cstart) // reg or part
+            if (0 != cram_seek(in_c, cstart, SEEK_SET))
+                goto closefiles;
+
+
+        // Make refid -2 ("*") come after other chromosomes, for easy sort
+        int itid = iter
+            ? (iter->tid == HTS_IDX_NOCOOR ? INT_MAX : iter->tid)
+            : 0;
+        int last_ref_id = -99;
+
+        off_t before_hdr = htell(cram_fd_get_fp(in_c));
+
         // Copy contains and blocks within them
         while ((c = cram_read_container(in_c))) {
             if (cram_container_is_empty(in_c)) {
@@ -295,47 +543,139 @@ int cram_cat(samFile * const firstfile, int nfn, char * const *fn, const sam_hdr
                 continue;
             }
 
+            int filter = 0;
+
             // If we have just one RG key and new_rg != 0 then
             // we need to edit the compression header. IF WE CAN.
             if (new_rg) {
+                if (reg) {
+                    print_error("cat", "Cannot specify a region while "
+                                "transcoding RG lines");
+                    goto closefiles;
+                }
                 int zero = 0;
                 //fprintf(stderr, "Transcode RG %d to %d\n", 0, new_rg);
                 cram_transcode_rg(in_c, out_c, c, 1, &zero, &new_rg);
             } else {
                 int32_t num_slices;
-                cram_block *blk;
+                int refid;
+                hts_pos_t start, span, end;
 
-                // Not switching rg so do the usual read/write loop
-                if (cram_write_container(out_c, c) != 0)
-                    goto closefiles;
-
-                // Container compression header
-                if (!(blk = cram_read_block(in_c)))
-                    goto closefiles;
-                if (cram_write_block(out_c, blk) != 0) {
-                    cram_free_block(blk);
-                    goto closefiles;
+                if (reg) {
+                    cram_container_get_coords(c, &refid, &start, &span);
+                    end = start+span;
+                    if (before_hdr > cend) {
+                        cram_free_container(c);
+                        break;
+                    }
                 }
-                cram_free_block(blk);
 
-                // Container num_blocks can be invalid, due to a bug.
-                // Instead we iterate in slice context instead.
-                (void)cram_container_get_landmarks(c, &num_slices);
-                cram_copy_slice(in_c, out_c, num_slices);
+                // For chr:start-end regions, do we need to filter or skip?
+                if (iter && reg) {
+                    // Make refid -1 ("*") come after other chromosomes
+                    if (refid == -1)
+                        refid = INT_MAX;
+
+                    if (refid > itid || start > iter->end) {
+                        // Beyond the requested range
+                        break;
+                    } else if (refid == -2) {
+                        // Multi-ref containers.  We only support this if
+                        // the RI data series is in a container by itself.
+                        filter = 3;
+                    } else if (refid < itid || end < iter->beg) {
+                        // Skip, in case of mixed size containers.
+                        // Eg: Use "=", skip "-".
+                        // ==========|======|=
+                        //   ----  ==|==  ==|== ----
+                        //     ----- | ====   ----
+                        filter = 2;
+                    } else if (start < iter->beg || end > iter->end) {
+                        // Container overlaps region.
+                        // Fast mode just copies overlapping containers.
+                        // Slow mode does a precise filtering by reading and
+                        // filtering each record in turn so it's the same as
+                        // a samtools view command.
+                        filter = fast_reg ? 0 : 1;
+                    }
+                    // else we're in an "internal" container, so just copy
+                }
+
+                if (filter && last_ref_id == -1 && itid == INT_MAX)
+                    // Multi-ref containers consisting solely of ref "*" are
+                    // common, but if it's sorted then we know it's "*" from
+                    // here on so we don't need to filter despite multi-ref.
+                    filter = 0;
+
+                if (filter) {
+                    // Filter or skip
+                    cram_filter_container(in_c, out_c, c, &last_ref_id);
+                } else {
+                    // Copy. Consider adding a cram_copy_container API instead.
+
+                    // Container compression header
+                    cram_block *blk;
+                    if (!(blk = cram_read_block(in_c)))
+                        goto closefiles;
+
+                    // Not switching rg so do the usual read/write loop
+                    if (cram_write_container(out_c, c) != 0)
+                        goto closefiles;
+
+                    // Contatiner compression header
+                    if (cram_write_block(out_c, blk) != 0) {
+                        cram_free_block(blk);
+                        goto closefiles;
+                    }
+
+                    // Container num_blocks can be invalid, due to a bug.
+                    // Instead we iterate in slice context instead.
+                    (void)cram_container_get_landmarks(c, &num_slices);
+                    if (cram_copy_slice(in_c, out_c, num_slices) < 0) {
+                        cram_free_block(blk);
+                        goto closefiles;
+                    }
+                    cram_free_block(blk);
+                }
             }
             cram_free_container(c);
+
+            // Location of next container start
+            before_hdr = htell(cram_fd_get_fp(in_c));
+            if (filter_by_cnum && before_hdr > cend)
+                break;
         }
         sam_hdr_destroy(old_h);
+        old_h = NULL;
+
+        if (idx) {
+            hts_idx_destroy(idx);
+            idx = NULL;
+        }
+
+        if (iter) {
+            hts_itr_destroy(iter);
+            iter = NULL;
+        }
     }
     ret = 0;
 
 closefiles:
-    if (out) {
+    if (old_h)
+        sam_hdr_destroy(old_h);
+
+    if (idx)
+        hts_idx_destroy(idx);
+
+    if (iter)
+        hts_itr_destroy(iter);
+
+    if (out)
         sam_close(out);
-    }
-    if (new_h) {
+
+    if (new_h)
         sam_hdr_destroy(new_h);
-    }
+
     for (i = 1; i < nfn; ++i) {     //skip firstfile and close rest
         if (files[i]) {
             sam_close(files[i]);
@@ -345,7 +685,9 @@ closefiles:
     return ret;
 }
 
-
+/* ----------------------------------------------------------------------
+ * BAM cat
+ */
 #define BUF_SIZE 0x10000
 
 #define GZIPID1 31
@@ -484,12 +826,13 @@ int main_cat(int argc, char *argv[])
     char *outfn = 0;
     char **infns = NULL; // files to concatenate
     int infns_size = 0;
-    int c, ret = 0, no_pg = 0, usage = 0;
+    int c, ret = 0, no_pg = 0, usage = 0, query_ncont = 0, fast_mode = 0;
     samFile *in;
     sam_global_args ga;
+    char *reg = NULL, *part = NULL;
 
     static const struct option lopts[] = {
-        SAM_OPT_GLOBAL_OPTIONS('-', '-', '-', 0, '-', '@'),
+        SAM_OPT_GLOBAL_OPTIONS('-', '-', '-', 0, '-', '-'),
         {"no-PG", no_argument, NULL, 1},
         { NULL, 0, NULL, 0 }
     };
@@ -497,7 +840,7 @@ int main_cat(int argc, char *argv[])
     char *arg_list = NULL;
 
     sam_global_args_init(&ga);
-    while ((c = getopt_long(argc, argv, "h:o:b:@:", lopts, NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "h:o:b:r:p:qf", lopts, NULL)) >= 0) {
         switch (c) {
             case 'h': {
                 samFile *fph = sam_open(optarg, "r");
@@ -538,6 +881,19 @@ int main_cat(int argc, char *argv[])
             case 1:
                 no_pg = 1;
                 break;
+            case 'r':
+                reg = optarg;
+                break;
+            case 'p':
+                part = optarg;
+                break;
+            case 'f':
+                fast_mode = 1;
+                break;
+            case 'q':
+                query_ncont=1;
+                break;
+
             default:
                 if (parse_sam_global_opt(c, optarg, lopts, &ga) == 0) break;
                 /* else fall-through */
@@ -568,7 +924,14 @@ int main_cat(int argc, char *argv[])
         fprintf(stderr, "         -h FILE  copy the header from FILE [default is 1st input file]\n");
         fprintf(stderr, "         -o FILE  output BAM/CRAM\n");
         fprintf(stderr, "         --no-PG  do not add a PG line\n");
-        sam_global_opt_help(stderr, "---.-@-.");
+        fprintf(stderr, "\nCRAM only options for filtering:\n");
+        fprintf(stderr, "         -r REG   filter to region REG.\n");
+        fprintf(stderr, "                  REG can also be #:cstart-cend for specific container numbers\n");
+        fprintf(stderr, "         -p N/M   Specify part N of M (where N is 1 to M inclusive)\n");
+        fprintf(stderr, "         -f       Fast mode: don't filter containers to exactly match region\n");
+        fprintf(stderr, "         -q       Query the total number of indexed containers\n");
+        fprintf(stderr, "\nStandard options:\n");
+        sam_global_opt_help(stderr, "---.---.");
         ret = 1;
         goto end;
     }
@@ -587,8 +950,15 @@ int main_cat(int argc, char *argv[])
         break;
 
     case cram:
-        if (cram_cat(in, infns_size+nargv_fns, infns, h, outfn? outfn : "-", &ga, arg_list, no_pg) < 0)
+        if (query_ncont) {
+            if (cram_query_ncont(infns_size+nargv_fns, infns, reg) < 0)
+                ret = 1;
+        } else {
+            if (cram_cat(in, infns_size+nargv_fns, infns, h,
+                         outfn? outfn : "-", &ga, arg_list, no_pg, reg,
+                         part, fast_mode) < 0)
             ret = 1;
+        }
         break;
 
     default:

--- a/doc/samtools-cat.1
+++ b/doc/samtools-cat.1
@@ -75,6 +75,49 @@ from the first file to be concatenated.
 .BI "-o " FILE
 Write the concatenated output to \fIFILE\fR.  By default this is sent
 to stdout.
+.TP 8
+.B -q
+[CRAM only] Query the number of containers in the CRAM file.  The
+output is the filename, the number of containers, and the first and
+last container number as an inclusive range, with one file per line.
+
+Note this works in conjunction with the \fB-r \fIRANGE\fR option, in
+which case the 3rd and 4th columns become useful for identifying which
+containers span the requested range.
+.TP
+.BI "-r " RANGE
+[CRAM only] Filter the CRAM file to a specific \fIRANGE\fR.  This can
+be the usual chromosome:start-end syntax, or "*" for unmapped records
+at the end of alignments.
+
+If the range is of the form "#:start-end" then the start and end
+coordinates are interpreted as inclusive CRAM container numbers,
+starting at 0 and ending 1 less than the number of containers reported
+by \fB-q\fR.  For example \fB-r "#:0-9"\fR is the first 10 CRAM
+containers of data.
+
+All range types filter data in as fast a manner as possible, using
+operating system read/write loops where appropriate.
+
+.TP
+.BI "-p " A/B
+[CRAM only] Filter the CRAM file using a specific fraction.  The file
+is split into B approximately equal parts and returns element A where A
+is between 1 and B inclusive. If there are more parts specified than
+CRAM containers then some of the output will be empty CRAMs.
+
+This can also be combined with the range option above to operate of
+parts of that range.  For example \fB-r chr2 -p 1/10\fR returns the
+first 1/10th of data aligned against chromosome 2.
+
+.TP
+.B -f
+[CRAM only] Enable fast mode.  When filtering by chromosome range with
+\fB-r\fR we normally do careful recoding of any containers that
+overlap the start and end of the range so the record count precisely
+matches that returned by a \fBsamtools view\fR equivalent.  Fast mode
+does no filtering, so may return additional alignments in the same
+container but outside of the requested region.
 .TP
 .BI --no-PG
 Do not add a @PG line to the header of the output file.
@@ -82,9 +125,46 @@ Do not add a @PG line to the header of the output file.
 .BI "-@, --threads " INT
 Number of input/output compression threads to use in addition to main thread [0].
 
+.SH EXAMPLES
+.IP o 2
+Extract a specific chromosome from a CRAM file, outputting to a new
+CRAM.
+.EX 2
+samtools cat -o chr10.cram -r chr10 in.cram
+.EE
+
+.IP o 2
+Split a CRAM file up into separate files, each containing at most 123
+containers.
+.EX 2
+set -- $(samtools cat -q in.cram); nc=$2; s=0
+while [ $s -lt $nc ]
+do
+    e=`expr $s + 123`
+    if [ $e -ge $nc ]
+    then
+        e=$nc
+    fi
+    r="$s-`expr $e - 1`"; echo $r
+    fn=/tmp/_part-`printf "%08d" $s`.cram
+    samtools cat -o $fn in.cram -r "#:$r"
+    s=$e
+done
+.EE
+
+.IP o 2
+Split any unaligned data from a (potentially aligned) CRAM file into
+10 approximately equal sized pieces.
+.EX 2
+for i in `seq 1 10`
+do
+   samtools cat in.cram -r "*" -p $i/10 -o part-`printf "%02d" $i`.cram
+done
+
 .SH AUTHOR
 .PP
 Written by Heng Li from the Sanger Institute.
+Updated for CRAM by James Bonfield (also Sanger Institute).
 
 .SH SEE ALSO
 .IR samtools (1)


### PR DESCRIPTION
Region filtering permits samtools cat to produce new CRAMs that only cover a specified region.
This now acts as a potential replacement for io_lib's [cram_filter](https://github.com/jkbonfield/io_lib/blob/master/progs/cram_filter.c) tool.
Eg

    samtools cat -o chr1-bit.cram -r chr1:10m-20m in.cram

This is the same as as view command, but considerably faster.

    samtools view -o chr1-bit.cram in.cram chr1:10m-20m

On a similar test the view command took 22.7s while the cat took 0.4s and the files have the same records.  Unlike view we cannot change format or do other filtering, however this samtools cat functionality is designed for rapid read/write based region data extraction for purposes of distributed processing pipelines.

This can be made faster still with the new -f option which doesn't precisely filter containers that overlap the start and/or end of the region, and instead copy out the whole container.

Note breaking up by region in this manner may give some alignment records in more than one adjacent CRAM file as the record spans both regions.

As elsewhere, region "*" represents the unmapped data, however we can't subdivide this easily by position. Hence we can partition a region, or the entire file, using `-p A/B` for part A of B total parts.

For example the first tenth of unmapped data would be

    samtools cat -r "*" -p 1/10 -o unmapped_1.cram NA12878_S1.cram

Subdivisions in this manner will never share alignment records between parts, so the sum of the parts will equal the original input data.

Regions can also be container numbers, using a custom region syntax of "#:cnum-cnum" for inclusive container numbers, starting at zero.  As with part numbers, records will not then be in multple output files unless the same container numbers are shared between files.

We can use `samtools cat -q [-r region]` to query the number of containers spanning that region and the first/last respectively. For example, to query the containers for unmapped data.

    samtools cat -q -r "*" NA12878_S1.cram

A more complex usage which breaks a file up into a fixed size number of containers regardless of part numbers can be implemented using `-q`:

    set -- $(samtools cat -q novaseq.10m.cram)
    nc=$2
    s=0
    while [ $s -lt $nc ]
    do
        e=`expr $s + 123`
        if [ $e -ge $nc ]
        then
            e=$nc
        fi
        r="#:$s-`expr $e - 1`"
        echo Region $r
        samtools cat -o part-`printf "%08d" $s`.cram novaseq.10m.cram -r $r
        s=$e
    done

    # Check with:
    samtools cat part*cram -o full.cram
    samtools view -c full.cram
    samtools view -c novaseq.10m.cram