### PR TITLE
Compiler pedantry

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -70,6 +70,8 @@ gcc_task:
     CIRRUS_CLONE_DEPTH: 1
     HTSDIR: ./hidden-htslib
     DO_MAINTAINER_CHECKS: yes
+    CFLAGS:  -fsanitize=address
+    LDFLAGS: -fsanitize=address
 
   << : *COMPILE
   << : *TEST
@@ -94,8 +96,8 @@ ubuntu_task:
     - environment:
        CFLAGS: -std=gnu99 -O0
     - environment:
-       CFLAGS: -g -Wall -O3 -fsanitize=address
-       LDFLAGS: -fsanitize=address -Wl,-rpath,`pwd`/inst/lib
+       CFLAGS: -g -Wall -O3
+       LDFLAGS: -Wl,-rpath,`pwd`/inst/lib
 
   # NB: we could consider building a docker image with these
   # preinstalled and specifying that instead, to speed up testing.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -70,7 +70,7 @@ gcc_task:
     CIRRUS_CLONE_DEPTH: 1
     HTSDIR: ./hidden-htslib
     DO_MAINTAINER_CHECKS: yes
-    CFLAGS:  -fsanitize=address
+    CFLAGS:  -std=c99 -D_XOPEN_SOURCE=600 -pedantic -fsanitize=address
     LDFLAGS: -fsanitize=address
 
   << : *COMPILE

--- a/bam_ampliconclip.h
+++ b/bam_ampliconclip.h
@@ -40,7 +40,7 @@ typedef struct {
     int size;
 } bed_entry_list_t;
 
-KHASH_MAP_INIT_STR(bed_list_hash, bed_entry_list_t);
+KHASH_MAP_INIT_STR(bed_list_hash, bed_entry_list_t)
 
 #define BED_LIST_INIT {NULL, 0, 0, 0, {0}}
 

--- a/bam_md.c
+++ b/bam_md.c
@@ -328,7 +328,7 @@ static void refs_destroy(ref_cache *cache) {
     }
 }
 
-int calmd_usage() {
+int calmd_usage(void) {
     fprintf(stderr,
 "Usage: samtools calmd [-eubrAESQ] <aln.bam> <ref.fasta>\n"
 "Options:\n"

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -328,7 +328,7 @@ static void trans_tbl_destroy(trans_tbl_t *tbl) {
  *  Create a merged_header_t struct.
  */
 
-static merged_header_t * init_merged_header() {
+static merged_header_t * init_merged_header(void) {
     merged_header_t *merged_hdr;
 
     merged_hdr = calloc(1, sizeof(*merged_hdr));

--- a/bam_tview_curses.c
+++ b/bam_tview_curses.c
@@ -151,8 +151,8 @@ static int tv_win_goto_get_completions(curses_tview_t *tv, char *str,
         new_str[i] = str[i];
     }
 
-    size_t l_str = strnlen(new_str, TV_MAX_GOTO+1);
-    bool is_different = l_str != strnlen(str, TV_MAX_GOTO+1);
+    size_t l_str = strlen(new_str);
+    bool is_different = l_str != strlen(str);
 
     for (i = 0; i < num_references; i++) {
         char *ref = references[i];
@@ -161,7 +161,7 @@ static int tv_win_goto_get_completions(curses_tview_t *tv, char *str,
         if (strncmp(ref, new_str, l_str) == 0) {
 
             // Special case handling if the reference is already selected
-            if (is_different && strnlen(ref, TV_MAX_GOTO+1) == l_str) {
+            if (is_different && strlen(ref) == l_str) {
                 num_matches = 1;
                 if (hts_resize(int, num_matches, matches_size, matches, 0) == -1)
                     return -1;

--- a/bamtk.c
+++ b/bamtk.c
@@ -75,7 +75,7 @@ int main_reference(int argc, char *argv[]);
 int main_reset(int argc, char *argv[]);
 int main_cram_size(int argc, char *argv[]);
 
-const char *samtools_version()
+const char *samtools_version(void)
 {
     return SAMTOOLS_VERSION;
 }

--- a/bedidx.c
+++ b/bedidx.c
@@ -539,12 +539,12 @@ void *bed_hash_regions(void *reg_hash, char **regs, int first, int last, int *op
 
         //if op==1 insert reg to the bed hash table
         if (*op && !(bed_insert(h, reg, beg, end))) {
-            fprintf(stderr, "Error when inserting region='%s' in the bed hash table at address=%p!\n", regs[i], h);
+            fprintf(stderr, "Error when inserting region='%s' in the bed hash table at address=%p!\n", regs[i], (void *)h);
         }
         //if op==0, first insert the regions in the temporary hash table,
         //then filter the bed hash table using it
         if (!(*op) && !(bed_insert(t, reg, beg, end))) {
-            fprintf(stderr, "Error when inserting region='%s' in the temporary hash table at address=%p!\n", regs[i], t);
+            fprintf(stderr, "Error when inserting region='%s' in the temporary hash table at address=%p!\n", regs[i], (void *)t);
         }
     }
 

--- a/coverage.c
+++ b/coverage.c
@@ -105,7 +105,7 @@ static const char *const BLOCK_CHARS2[2] = {".", ":"};
 // in bam_plcmd.c
 int read_file_list(const char *file_list, int *n, char **argv[]);
 
-static int usage() {
+static int usage(void) {
     fprintf(stdout, "Usage: samtools coverage [options] in1.bam [in2.bam [...]]\n\n"
             "Input options:\n"
             "  -b, --bam-list FILE     list of input BAM filenames, one per line\n"

--- a/lz4/lz4.c
+++ b/lz4/lz4.c
@@ -411,7 +411,7 @@ typedef enum { full = 0, partial = 1 } earlyEnd_directive;
 int LZ4_versionNumber (void) { return LZ4_VERSION_NUMBER; }
 const char* LZ4_versionString(void) { return LZ4_VERSION_STRING; }
 int LZ4_compressBound(int isize)  { return LZ4_COMPRESSBOUND(isize); }
-int LZ4_sizeofState() { return LZ4_STREAMSIZE; }
+int LZ4_sizeofState(void) { return LZ4_STREAMSIZE; }
 
 
 /*-******************************
@@ -1434,7 +1434,7 @@ int LZ4_uncompress_unknownOutputSize (const char* source, char* dest, int isize,
 
 /* Obsolete Streaming functions */
 
-int LZ4_sizeofStreamState() { return LZ4_STREAMSIZE; }
+int LZ4_sizeofStreamState(void) { return LZ4_STREAMSIZE; }
 
 static void LZ4_init(LZ4_stream_t* lz4ds, BYTE* base)
 {

--- a/stats.c
+++ b/stats.c
@@ -2252,7 +2252,7 @@ int init_stat_info_fname(stats_info_t* info, const char* bam_fname, const htsFor
     return 0;
 }
 
-stats_t* stats_init()
+stats_t* stats_init(void)
 {
     stats_t *stats = calloc(1,sizeof(stats_t));
     if (!stats)

--- a/test/vcf-miniview.c
+++ b/test/vcf-miniview.c
@@ -31,7 +31,7 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include <htslib/vcf.h>
 
-void usage()
+void usage(void)
 {
     fprintf(stderr,
 "Usage: vcf-miniview [view] [-f] [FILE]\n"


### PR DESCRIPTION
Fix the ubuntu Clang address sanitizer issue which appeared recently due to Cirrus-CI upgrading.

Also copy the htslib policy of our code passing `-stdc=c99 -pedantic`.  We haven't previously enforced this for Samtools, but it was deemed to be valuable so it's now here too.  (With XOPEN_SOURCE so we also allow posix things such as `strdup`)