### PR TITLE
fixmate no longer removes PAIRED flag.

### DIFF
--- a/bam_mate.c
+++ b/bam_mate.c
@@ -91,7 +91,7 @@ static void bam_template_cigar(bam1_t *b1, bam1_t *b2, kstring_t *str)
  * single Reads:
  * -if pos == 0 (1 based), tid == -1, or UNMAPPED then set UNMAPPED, pos = 0,
  *  tid = -1
- * -clear bad flags (PAIRED, MREVERSE, PROPER_PAIR)
+ * -clear bad flags (MREVERSE, PROPER_PAIR)
  * -set mpos = 0 (1 based), mtid = -1 and isize = 0
  * -write to output
  * Paired Reads:
@@ -1063,10 +1063,10 @@ static int bam_mating_core(samFile *in, samFile *out, int remove_reads,
             if (remove_reads) {
                 if (pre->core.flag&BAM_FUNMAP)
                     cur->core.flag &=
-                        ~(BAM_FPAIRED|BAM_FMREVERSE|BAM_FPROPER_PAIR);
+                        ~(BAM_FMREVERSE|BAM_FPROPER_PAIR);
                 if (cur->core.flag&BAM_FUNMAP)
                     pre->core.flag &=
-                        ~(BAM_FPAIRED|BAM_FMREVERSE|BAM_FPROPER_PAIR);
+                        ~(BAM_FMREVERSE|BAM_FPROPER_PAIR);
             }
         }
 
@@ -1075,7 +1075,7 @@ static int bam_mating_core(samFile *in, samFile *out, int remove_reads,
             pre->core.mtid = -1;
             pre->core.mpos = -1;
             pre->core.isize = 0;
-            pre->core.flag &= ~(BAM_FPAIRED|BAM_FMREVERSE|BAM_FPROPER_PAIR);
+            pre->core.flag &= ~(BAM_FMREVERSE|BAM_FPROPER_PAIR);
         }
 
         // Now process secondary and supplementary alignments

--- a/doc/samtools-fixmate.1
+++ b/doc/samtools-fixmate.1
@@ -57,7 +57,9 @@ name-sorted or name-collated alignment.
 .SH OPTIONS
 .TP 11
 .B -r
-Remove secondary and unmapped reads.
+Remove secondary and unmapped reads.  If one of a pair is removed, the PAIRED
+flag will not be unset on the remaining read.  This is a change from the older
+behaviour in samtools versions up to 1.20.
 .TP
 .B -p
 Disable FR proper pair check.


### PR DESCRIPTION
No longer removes paired flag from reads that have no mate (either removed or missing).  

Fixes #2052 using the idea that the PAIRED flag is a sequencing technology indicator not a feature of alignment.  This is a change in the behaviour of fixmate.