### PR TITLE
faidx with bgzf compressed output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for samtools, utilities for the Sequence Alignment/Map format.
 #
-#    Copyright (C) 2008-2022 Genome Research Ltd.
+#    Copyright (C) 2008-2022, 2024 Genome Research Ltd.
 #    Portions copyright (C) 2010-2012 Broad Institute.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -201,7 +201,7 @@ consensus_pileup.o: consensus_pileup.c config.h $(htslib_sam_h) $(consensus_pile
 cram_size.o: cram_size.c config.h $(htslib_bgzf_h) $(htslib_sam_h) $(htslib_cram_h) $(htslib_kstring_h) $(htslib_khash_h) $(samtools_h) $(sam_opts_h) $(htslib_hfile_h)
 cut_target.o: cut_target.c config.h $(htslib_hts_h) $(htslib_sam_h) $(htslib_faidx_h) $(samtools_h) $(sam_opts_h)
 dict.o: dict.c config.h $(htslib_khash_h) $(htslib_kseq_h) $(htslib_hts_h) $(samtools_h)
-faidx.o: faidx.c config.h $(htslib_faidx_h) $(htslib_hts_h) $(htslib_hfile_h) $(htslib_kstring_h) $(samtools_h)
+faidx.o: faidx.c config.h $(htslib_faidx_h) $(htslib_hts_h) $(htslib_hfile_h) $(htslib_kstring_h) $(htslib_bgzf_h) $(htslib_thread_pool_h) $(sam_opts_h) $(samtools_h)
 padding.o: padding.c config.h $(htslib_kstring_h) $(htslib_sam_h) $(htslib_faidx_h) $(sam_opts_h) $(samtools_h)
 phase.o: phase.c config.h $(htslib_hts_h) $(htslib_sam_h) $(htslib_kstring_h) $(sam_opts_h) $(samtools_h) $(htslib_hts_os_h) $(htslib_kseq_h) $(htslib_khash_h) $(htslib_ksort_h)
 reference.o: reference.c config.h $(htslib_sam_h) $(htslib_cram_h) $(samtools_h) $(sam_opts_h)

--- a/doc/samtools-faidx.1
+++ b/doc/samtools-faidx.1
@@ -3,7 +3,7 @@
 .SH NAME
 samtools faidx \- indexes or queries regions from a fasta file
 .\"
-.\" Copyright (C) 2008-2011, 2013-2018, 2020 Genome Research Ltd.
+.\" Copyright (C) 2008-2011, 2013-2018, 2020, 2024 Genome Research Ltd.
 .\" Portions copyright (C) 2010, 2011 Broad Institute.
 .\"
 .\" Author: Heng Li <lh3@sanger.ac.uk>
@@ -56,9 +56,9 @@ will index the file and create
 on the disk. If regions are specified, the subsequences will be
 retrieved and printed to stdout in the FASTA format.
 
-The input file can be compressed in the
+The input and output can be files compressed in the
 .B BGZF
-format.
+format. When output is compressed, the default compression level is 4.
 
 The sequences in the input file should all have different names.
 If they do not, indexing will emit a warning about duplicate sequences and
@@ -73,7 +73,10 @@ any extracted subsequence will be in FASTA format.
 
 .TP 8
 .BI "-o, --output " FILE
-Write FASTA to file rather than to stdout.
+Write FASTA to file rather than to stdout. With .gz, .bgz, .bgzf file extensions
+the output will be
+.B BGZF
+compressed.
 .TP
 .BI "-n, --length " INT
 Length for FASTA sequence line wrapping.  If zero, this means do not
@@ -124,6 +127,12 @@ Read/Write to specified compressed file index (used with .gz files).
 .TP
 .B -h, --help
 Print help message and exit.
+.TP
+.BI --output-fmt-option\  OPT=VAL
+Set the output format options, level=0..9 for compression level 0 to 9.
+.TP
+.BI "-@, --threads " N
+Set the number of extra threads for operations on compressed files.
 
 .SH AUTHOR
 .PP

--- a/test/test.pl
+++ b/test/test.pl
@@ -37,8 +37,8 @@ my $opts = parse_params();
 test_reference($opts);
 test_reference($opts, threads=>2);
 test_bgzip($opts);
-test_faidx($opts);
-test_fqidx($opts);
+test_faidx($opts, threads=>2);
+test_fqidx($opts, threads=>2);
 test_dict($opts);
 test_index($opts);
 test_index($opts, threads=>2);
@@ -577,6 +577,7 @@ sub faidx_wrap
 sub test_faidx
 {
     my ($opts,%args) = @_;
+    my $threads = exists($args{threads}) ? " -@ $args{threads}" : "";
 
     # Create test data: The fake sequence consists of sequence offsets coded
     # into A,C,G,T and separated with Ns. The offsets are 1-based.
@@ -606,7 +607,16 @@ sub test_faidx
 
     # Write to file
     cmd("$$opts{bin}/samtools faidx --length 5 $$opts{tmp}/faidx.fa 1:1-104 > $$opts{tmp}/output_faidx_base.fa");
+    cmd("$$opts{bin}/samtools faidx --length 5 $$opts{tmp}/faidx.fa 1 > $$opts{tmp}/output_faidx_base.1.fa");
     cmd("$$opts{bin}/samtools faidx --length 5 --output $$opts{tmp}/output_faidx.fa $$opts{tmp}/faidx.fa 1:1-104 && $$opts{diff} $$opts{tmp}/output_faidx.fa $$opts{tmp}/output_faidx_base.fa");
+    # Write to bgzip file
+    cmd("$$opts{bin}/samtools faidx --length 5 --output $$opts{tmp}/output_faidx.fa.1.gz $$opts{tmp}/faidx.fa 1:1-104 && $$opts{bgzip} -df $$opts{tmp}/output_faidx.fa.1.gz && $$opts{diff} $$opts{tmp}/output_faidx.fa.1 $$opts{tmp}/output_faidx_base.fa");
+    cmd("$$opts{bin}/samtools faidx --length 5 --output $$opts{tmp}/output_faidx.fa.2.bgz $$opts{tmp}/faidx.fa 1:1-104 && $$opts{bgzip} -df $$opts{tmp}/output_faidx.fa.2.bgz && $$opts{diff} $$opts{tmp}/output_faidx.fa.2 $$opts{tmp}/output_faidx_base.fa");
+    cmd("$$opts{bin}/samtools faidx --length 5 --output $$opts{tmp}/output_faidx.fa.3.bgzf $$opts{tmp}/faidx.fa 1:1-104 && $$opts{bgzip} -df $$opts{tmp}/output_faidx.fa.3.bgzf && $$opts{diff} $$opts{tmp}/output_faidx.fa.3 $$opts{tmp}/output_faidx_base.fa");
+    # Write to bgzip file with compression level
+    cmd("$$opts{bin}/samtools faidx --length 5 --output $$opts{tmp}/output_faidx.fa.4.gz $$opts{tmp}/faidx.fa 1 --output-fmt-opt=\"level=4\" && $$opts{bgzip} -df $$opts{tmp}/output_faidx.fa.4.gz && $$opts{diff} $$opts{tmp}/output_faidx.fa.4 $$opts{tmp}/output_faidx_base.1.fa");
+    # Write to bgzip file with thread
+    cmd("$$opts{bin}/samtools faidx ${threads} --length 5 --output $$opts{tmp}/output_faidx.fa.5.gz $$opts{tmp}/faidx.fa 1 && $$opts{bgzip} -df $$opts{tmp}/output_faidx.fa.5.gz && $$opts{diff} $$opts{tmp}/output_faidx.fa.5 $$opts{tmp}/output_faidx_base.1.fa");
 
     # Write indices to a file
     cmd("$$opts{bin}/samtools faidx --fai-idx $$opts{tmp}/fa_test.fai --gzi-idx $$opts{tmp}/fa_test.gzi $$opts{tmp}/faidx.fa.gz");
@@ -703,6 +713,7 @@ sub fqidx_qual_to_num
 sub test_fqidx
 {
     my ($opts,%args) = @_;
+    my $threads = exists($args{threads}) ? " -@ $args{threads}" : "";
 
     # Create test data: The fake sequence consists of sequence offsets coded
     # into A,C,G,T and separated with Ns. The offsets are 1-based.
@@ -748,6 +759,15 @@ sub test_fqidx
     # Write to file
     cmd("$$opts{bin}/samtools fqidx --length 5 $$opts{tmp}/fqidx.fq 1:1-104 > $$opts{tmp}/output_fqidx_base.fq");
     cmd("$$opts{bin}/samtools fqidx --length 5 --output $$opts{tmp}/output_fqidx.fq $$opts{tmp}/fqidx.fq 1:1-104 && $$opts{diff} $$opts{tmp}/output_fqidx.fq $$opts{tmp}/output_fqidx_base.fq");
+    cmd("$$opts{bin}/samtools fqidx --length 5 $$opts{tmp}/fqidx.fq 1 > $$opts{tmp}/output_fqidx_base.1.fq");
+    # Write to bgzip file
+    cmd("$$opts{bin}/samtools fqidx --length 5 --output $$opts{tmp}/output_fqidx.fq.1.gz $$opts{tmp}/fqidx.fq 1:1-104 && $$opts{bgzip} -df $$opts{tmp}/output_fqidx.fq.1.gz && $$opts{diff} $$opts{tmp}/output_fqidx.fq.1 $$opts{tmp}/output_fqidx_base.fq");
+    cmd("$$opts{bin}/samtools fqidx --length 5 --output $$opts{tmp}/output_fqidx.fq.2.bgz $$opts{tmp}/fqidx.fq 1:1-104 && $$opts{bgzip} -df $$opts{tmp}/output_fqidx.fq.2.bgz && $$opts{diff} $$opts{tmp}/output_fqidx.fq.2 $$opts{tmp}/output_fqidx_base.fq");
+    cmd("$$opts{bin}/samtools fqidx --length 5 --output $$opts{tmp}/output_fqidx.fq.3.bgzf $$opts{tmp}/fqidx.fq 1:1-104 && $$opts{bgzip} -df $$opts{tmp}/output_fqidx.fq.3.bgzf && $$opts{diff} $$opts{tmp}/output_fqidx.fq.3 $$opts{tmp}/output_fqidx_base.fq");
+    # Write to bgzip file with compression level
+    cmd("$$opts{bin}/samtools fqidx --length 5 --output $$opts{tmp}/output_fqidx.fq.4.gz $$opts{tmp}/fqidx.fq 1 --output-fmt-opt=\"level=4\" && $$opts{bgzip} -df $$opts{tmp}/output_fqidx.fq.4.gz && $$opts{diff} $$opts{tmp}/output_fqidx.fq.4 $$opts{tmp}/output_fqidx_base.1.fq");
+    # Write to bgzip file with thread
+    cmd("$$opts{bin}/samtools fqidx ${threads} --length 5 --output $$opts{tmp}/output_fqidx.fq.5.gz $$opts{tmp}/fqidx.fq 1 && $$opts{bgzip} -df $$opts{tmp}/output_fqidx.fq.5.gz && $$opts{diff} $$opts{tmp}/output_fqidx.fq.5 $$opts{tmp}/output_fqidx_base.1.fq");
 
     # Write indices to a file
     cmd("$$opts{bin}/samtools fqidx --fai-idx $$opts{tmp}/fq_test.fai --gzi-idx $$opts{tmp}/fq_test.gzi $$opts{tmp}/fqidx.fq.gz");


### PR DESCRIPTION
fixes #2055
fasta/fastq output of faidx/fqidx will be bgzf compressed if the output file has an extension of .gz/.bgz/.bgzf.
stdout will not be compressed.
also added extended option output-fmt-option to set compression levels and threads for bgzf compression.