### PR TITLE
Make ampliconclip primer counts output deterministic

### DIFF
--- a/amplicon_stats.c
+++ b/amplicon_stats.c
@@ -1737,7 +1737,7 @@ int main_ampliconstats(int argc, char **argv) {
         return usage(&oargs, stderr, EXIT_FAILURE);
 
     khash_t(bed_list_hash) *bed_hash = kh_init(bed_list_hash);
-    if (load_bed_file_multi_ref(argv[optind], 1, 0, bed_hash)) {
+    if (load_bed_file_multi_ref(argv[optind], 1, 0, bed_hash, NULL, NULL)) {
         print_error_errno("ampliconstats",
                           "Could not read file \"%s\"", argv[optind]);
         return 1;

--- a/bam_ampliconclip.h
+++ b/bam_ampliconclip.h
@@ -49,7 +49,8 @@ KHASH_MAP_INIT_STR(bed_list_hash, bed_entry_list_t)
 
 
 int load_bed_file_multi_ref(char *infile, int get_strand,
-                        int sort_by_pos, khash_t(bed_list_hash) *bed_lists);
+                            int sort_by_pos, khash_t(bed_list_hash) *bed_lists,
+                            char ***ref_list, size_t *num_refs);
 
 void destroy_bed_hash(khash_t(bed_list_hash) *hash);
 


### PR DESCRIPTION
The primer-counts output was being written with references in the order stored in the hash table, which is pseudo-randomised by the hash function.  To get a more stable ordering, keep a list of references in the order they appear in the bed file, and then iterate through that.

`ampliconstats` uses the same bad file reading code, but already outputs in the order of references in the bam header, so the updated loader allows it to skip building the reference list from the bed file.  (`ampliconclip` could in theory work the same way, but as it doesn't insist that all bed references need to be in the bam header, and outputs zero counts for the missing ones, it's simpler to go with the bed file ordering so the output doesn't change more than it needs to.)