### PR TITLE
Fix undefined behaviour in samtools fastq with empty QUAL.

### DIFF
--- a/bam_fastq.c
+++ b/bam_fastq.c
@@ -848,8 +848,13 @@ int output_index(bam1_t *b1, bam1_t *b2, bam2fq_state_t *state,
         }
 
         char *bc_end = bc, *qt_end = qt;
-        while (len ? *bc_end && rem-- : isalpha(*bc_end))
-            bc_end++, qt_end += qt != NULL;
+        if (qt) {
+            while (len ? *bc_end && rem-- : isalpha(*bc_end))
+                bc_end++, qt_end++;
+        } else {
+            while (len ? *bc_end && rem-- : isalpha(*bc_end))
+                bc_end++;
+        }
 
         switch (fc) {
         case 'n':


### PR DESCRIPTION
Incrementing via "qt_end += qt != NULL" will be qt_end+=0 when we have a null qt/qt_end, but NULL+0 is technically undefined.

    bam_fastq.c:852:30: runtime error: applying zero offset to null pointer
    SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior bam_fastq.c:852:30 in

Easy to just replace with two loops and avoid such cleverness.  It's not a major portability issue, but it's nice to have no warnings from ubsan as it makes finding other problems easier.