### PR TITLE
Work around CFLAGS overriding --enable-werror.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,8 +30,10 @@ htslib_compile_template: &HTSLIB_COMPILE
     cd $HTSDIR
     autoreconf -i
     if test "x$WERROR" != "xno"; then CONFIG_OPTS="--enable-werror"; fi
-    eval ./configure $CONFIG_OPTS --prefix=`pwd`/../inst CFLAGS=\"$CFLAGS\" || (cat config.log; /bin/false)
-    make -j3 -e install
+    eval ./configure $CONFIG_OPTS --prefix=`pwd`/../inst \
+        CFLAGS=\"$CFLAGS\" CPPFLAGS=\"$CPPFLAGS\" LDFLAGS=\"$LDFLAGS\" \
+        || (cat config.log; /bin/false)
+    make -j3 install
 
 #--------------------------------------------------
 # Template: samtools compile and test
@@ -44,17 +46,17 @@ compile_template: &COMPILE
     if test "x$WERROR" != "xno"; then CONFIG_OPTS="--enable-werror"; fi
     eval ./configure $CONFIG_OPTS --with-htslib=`pwd`/inst  \
         LDFLAGS=\"$LDFLAGS -Wl,-rpath,`pwd`/inst/lib\" \
-        CFLAGS=\"$CFLAGS\"|| \
+        CFLAGS=\"$CFLAGS\" CPPFLAGS=\"$CPPFLAGS\" || \
         (cat config.log; /bin/false)
     make -j3
 
 test_template: &TEST
   test_script: |
     if test "x$DO_MAINTAINER_CHECKS" = "xyes" ; then
-        make -e maintainer-check
+        make maintainer-check
     fi
-    make -e
-    make -e test BGZIP=inst/bin/bgzip
+    make
+    make test BGZIP=inst/bin/bgzip
 
 
 #--------------------------------------------------
@@ -73,8 +75,10 @@ gcc_task:
     CIRRUS_CLONE_DEPTH: 1
     HTSDIR: ./hidden-htslib
     DO_MAINTAINER_CHECKS: yes
-    WERROR: no
-    CFLAGS: -g -O3 -std=c99 -D_XOPEN_SOURCE=600 -pedantic -fsanitize=address,undefined
+    # gcc ubsan is incompatible with some -Wformat options, but they're checked
+    # in other tests.  See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=87884
+    CFLAGS: -g -O3 -std=c99 -D_XOPEN_SOURCE=600 -pedantic -fsanitize=address,undefined -Wno-format-truncation -Wno-format-overflow
+    CPPFLAGS: -DHTS_ALLOW_UNALIGNED=0
     LDFLAGS: -fsanitize=address,undefined
 
   << : *COMPILE
@@ -128,7 +132,7 @@ rocky_task:
     LC_ALL: C
     CIRRUS_CLONE_DEPTH: 1
     HTSDIR: ./hidden-htslib
-    CFLAGS: -O2 -Wextra -Wno-sign-compare -Wno-missing-field-initializers -Wno-unused-parameter -Wno-error=old-style-declaration -Wno-empty-body
+    CFLAGS: -O2 -Wextra -Wformat -Wformat=2 -Wno-sign-compare -Wno-missing-field-initializers -Wno-unused-parameter
 
   # NB: we could consider building a docker image with these
   # preinstalled and specifying that instead, to speed up testing.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,7 +29,8 @@ htslib_compile_template: &HTSLIB_COMPILE
   htslib_compile_script: |
     cd $HTSDIR
     autoreconf -i
-    ./configure --prefix=`pwd`/../inst || (cat config.log; /bin/false)
+    if test "x$WERROR" != "xno"; then CONFIG_OPTS="--enable-werror"; fi
+    eval ./configure $CONFIG_OPTS --prefix=`pwd`/../inst CFLAGS=\"$CFLAGS\" || (cat config.log; /bin/false)
     make -j3 -e install
 
 #--------------------------------------------------
@@ -40,8 +41,10 @@ compile_template: &COMPILE
 
   compile_script: |
     autoreconf -i
-    ./configure --enable-werror --with-htslib=`pwd`/inst  \
-        LDFLAGS="$LDFLAGS -Wl,-rpath,`pwd`/inst/lib" || \
+    if test "x$WERROR" != "xno"; then CONFIG_OPTS="--enable-werror"; fi
+    eval ./configure $CONFIG_OPTS --with-htslib=`pwd`/inst  \
+        LDFLAGS=\"$LDFLAGS -Wl,-rpath,`pwd`/inst/lib\" \
+        CFLAGS=\"$CFLAGS\"|| \
         (cat config.log; /bin/false)
     make -j3
 
@@ -70,7 +73,8 @@ gcc_task:
     CIRRUS_CLONE_DEPTH: 1
     HTSDIR: ./hidden-htslib
     DO_MAINTAINER_CHECKS: yes
-    CFLAGS:  -std=c99 -D_XOPEN_SOURCE=600 -pedantic -fsanitize=address,undefined
+    WERROR: no
+    CFLAGS: -g -O3 -std=c99 -D_XOPEN_SOURCE=600 -pedantic -fsanitize=address,undefined
     LDFLAGS: -fsanitize=address,undefined
 
   << : *COMPILE
@@ -124,7 +128,7 @@ rocky_task:
     LC_ALL: C
     CIRRUS_CLONE_DEPTH: 1
     HTSDIR: ./hidden-htslib
-    CFLAGS: -Wextra -Wno-sign-compare -Wno-missing-field-initializers -Wno-unused-parameter -Wno-error=old-style-declaration
+    CFLAGS: -O2 -Wextra -Wno-sign-compare -Wno-missing-field-initializers -Wno-unused-parameter -Wno-error=old-style-declaration -Wno-empty-body
 
   # NB: we could consider building a docker image with these
   # preinstalled and specifying that instead, to speed up testing.
@@ -150,6 +154,7 @@ macosx_task:
     LC_ALL: C
     CIRRUS_CLONE_DEPTH: 1
     HTSDIR: ./hidden-htslib
+    CFLAGS: -g -Wall -O2
 
   package_install_script:
     - HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake libtool xz

--- a/bam2depth.c
+++ b/bam2depth.c
@@ -162,7 +162,7 @@ hts_pos_t qlen_used(bam1_t *b) {
 // unroll it.  By adding HTS_OPT3 we can force a better level of optimization.
 // On an Illumina BAM with gcc11 -O2, with HTS_OPT3 is 9% quicker for the
 // entire process (ie decompress, iterator, aggregate & report)
-static void inline HTS_OPT3 incr_hist(int *hist, int oplen) {
+static inline void HTS_OPT3 incr_hist(int *hist, int oplen) {
     const int N = 16;
     int k;
     for (k = 0; k < (oplen & ~(N-1)); k+=N) {
@@ -173,7 +173,7 @@ static void inline HTS_OPT3 incr_hist(int *hist, int oplen) {
         hist[k]++;
 }
 
-static void inline HTS_OPT3
+static inline void HTS_OPT3
 incr_hist_qual(int *hist, uint8_t *qual, int min_qual, int oplen) {
     if (!min_qual) {
         incr_hist(hist, oplen);

--- a/bam_import.c
+++ b/bam_import.c
@@ -160,7 +160,7 @@ static int import_fastq(int argc, char **argv, opts_t *opts) {
     if (argc == 1)
         opts->fn[FQ_SINGLE] = argv[0];
     else
-        for (i = 0; i < 4; i++)
+        for (i = 0; i < 2; i++)
             if (argc > i)
                 opts->fn[FQ_R1+i] = argv[i];
 

--- a/test/split/test_expand_format_string.c
+++ b/test/split/test_expand_format_string.c
@@ -107,9 +107,9 @@ int main(int argc, char**argv)
 {
     // test state
     TestState state = { NULL, KS_INITIALIZE, 0, 0, 0, 0};
-    const static htsFormat sam_fmt  = { sequence_data, sam  };
-    const static htsFormat bam_fmt  = { sequence_data, bam  };
-    const static htsFormat cram_fmt = { sequence_data, cram };
+    static const htsFormat sam_fmt  = { sequence_data, sam  };
+    static const htsFormat bam_fmt  = { sequence_data, bam  };
+    static const htsFormat cram_fmt = { sequence_data, cram };
 
     int getopt_char;
     while ((getopt_char = getopt(argc, argv, "v")) != -1) {


### PR DESCRIPTION
If we have CFLAGS set then ./configure --enable-werror has no impact, as it just sets this in CFLAGS rather than another variable.

In theory we should do ./configure --enable-werror CFLAGS=xyz. However that means parameterising the <<:*COMPILE template.  It's easiest to do this via an environment given the matrix, but we have to be careful to avoid it undoing itself again.  We also need to take care to not do --enable-werror when using ubsan.

This is a long-standing issue of removal of -Werror that's been present right since the first day we used cirrus-CI.