### PR TITLE
Disable Appveyor build on all branches

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,6 +8,7 @@ branches:
     # Blacklist
     except:
       - gh-pages
+      - /.*/ # Appveyor builds are currently disabled.
 
 # Do not build on tags (GitHub and BitBucket)
 skip_tags: true

--- a/NEWS.md
+++ b/NEWS.md
@@ -108,6 +108,9 @@ Non user-visible changes and build improvements:
   Fix warnings from the new clang compiler.
   (PR #2043)
 
+* Windows based CI has been migrated from AppVeyor to GitHub Actions.
+  (PR #2072)
+
 * Turn on more warning options in Cirrus-CI builds, ensure everything builds
   with `-Werror`, and add undefined behaviour checks to the address sanitizer
   test.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 samtools
 ========
 
-[![Build Status](https://api.cirrus-ci.com/github/samtools/samtools.svg?branch=develop)](https://api.cirrus-ci.com/github/samtools/samtools)
-[![Build status](https://ci.appveyor.com/api/projects/status/enujqi06jlqw493t/branch/develop?svg=true)](https://ci.appveyor.com/project/samtools/samtools/branch/develop)
+[![Build Status](https://api.cirrus-ci.com/github/samtools/samtools.svg?branch=develop)](https://cirrus-ci.com/github/samtools/samtools)
+[![Build status](https://github.com/samtools/samtools/actions/workflows/windows-build.yml/badge.svg)](https://github.com/samtools/samtools/actions/workflows/windows-build.yml?query=branch%3Adevelop)
 [![Github All Releases](https://img.shields.io/github/downloads/samtools/samtools/total.svg)](https://github.com/samtools/samtools/releases/latest)
 
 This is the official development repository for samtools.


### PR DESCRIPTION
Now replaced by Github Actions.
Redirect the Windows build badge to GitHub Actions, and also fix the link for the cirrus-ci badge.