### PR TITLE
Adjust -fsanitize=address,undefined test optimisation level and fix warnings

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -80,6 +80,7 @@ gcc_task:
     CFLAGS: -g -Og -std=c99 -D_XOPEN_SOURCE=600 -pedantic -fsanitize=address,undefined -Wno-format-truncation -Wno-format-overflow
     CPPFLAGS: -DHTS_ALLOW_UNALIGNED=0
     LDFLAGS: -fsanitize=address,undefined
+    UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
 
   << : *COMPILE
   << : *TEST

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -77,7 +77,7 @@ gcc_task:
     DO_MAINTAINER_CHECKS: yes
     # gcc ubsan is incompatible with some -Wformat options, but they're checked
     # in other tests.  See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=87884
-    CFLAGS: -g -O3 -std=c99 -D_XOPEN_SOURCE=600 -pedantic -fsanitize=address,undefined -Wno-format-truncation -Wno-format-overflow
+    CFLAGS: -g -Og -std=c99 -D_XOPEN_SOURCE=600 -pedantic -fsanitize=address,undefined -Wno-format-truncation -Wno-format-overflow
     CPPFLAGS: -DHTS_ALLOW_UNALIGNED=0
     LDFLAGS: -fsanitize=address,undefined
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -109,12 +109,12 @@ Non user-visible changes and build improvements:
   (PR #2043)
 
 * Windows based CI has been migrated from AppVeyor to GitHub Actions.
-  (PR #2072)
+  (PR #2072, PR #2108)
 
 * Turn on more warning options in Cirrus-CI builds, ensure everything builds
   with `-Werror`, and add undefined behaviour checks to the address sanitizer
   test.
-  (PR #2101, PR #2103)
+  (PR #2101, PR #2103, PR #2109)
 
 * Tidy up Makefile dependencies and untracked test files.
   (PR #2106.  Thanks to John Marshall)

--- a/bam_cat.c
+++ b/bam_cat.c
@@ -558,12 +558,8 @@ int cram_cat(samFile * const firstfile, int nfn, char * const *fn,
                 cram_transcode_rg(in_c, out_c, c, 1, &zero, &new_rg);
             } else {
                 int32_t num_slices;
-                int refid;
-                hts_pos_t start, span, end;
 
                 if (reg) {
-                    cram_container_get_coords(c, &refid, &start, &span);
-                    end = start+span;
                     if (before_hdr > cend) {
                         cram_free_container(c);
                         break;
@@ -572,6 +568,12 @@ int cram_cat(samFile * const firstfile, int nfn, char * const *fn,
 
                 // For chr:start-end regions, do we need to filter or skip?
                 if (iter && reg) {
+                    int refid;
+                    hts_pos_t start, span, end;
+
+                    cram_container_get_coords(c, &refid, &start, &span);
+                    end = start+span;
+
                     // Make refid -1 ("*") come after other chromosomes
                     if (refid == -1)
                         refid = INT_MAX;

--- a/bam_import.c
+++ b/bam_import.c
@@ -310,7 +310,7 @@ static int import_fastq(int argc, char **argv, opts_t *opts) {
 
 
     // Interleave / combine from n files (ids[0..n-1]).
-    int res;
+    int res = 0;
     int eof = 0;
     do {
         idx_seq.l = idx_qual.l = 0;

--- a/sam_view.c
+++ b/sam_view.c
@@ -1716,7 +1716,7 @@ int main_head(int argc, char *argv[])
     if (nrecords > 0) {
         b = bam_init1();
         uint64_t n;
-        int r;
+        int r = 0;
         for (n = 0; n < nrecords && (r = sam_read1(fp, hdr, b)) >= 0; n++) {
             if (sam_format1(hdr, b, &str) < 0) {
                 print_error_errno("head", "couldn't format record");


### PR DESCRIPTION
Enabling sanitizers leads to long compilation times at high optimisation levels.  Testing shows that with the sanitizers, changing from `-O3` to `-Og` makes almost no difference to the `make test` time, but gives a significantly faster build.

On a local machine, the total times for `make -j 3 && make test` were:

| Setting | Time      |
| ------: | --------: |
|     -O3 | 6m13.677s |
|     -O2 | 5m11.763s |
|     -Os | 4m11.703s |
|     -Og | 3m24.097s |

In all cases `make test` took around 2m10s +/- 2s.

Using this lower optimisation level triggers a couple of "may be used uninitialized" warnings, where the compiler isn't able to work out that they are actually always set before use.  These are silenced by making it more obvious that they are set.