### PR TITLE
Improve htslib#PRnum support for Cirrus-CI and GitHub Actions

### DIFF
--- a/.ci_helpers/clone
+++ b/.ci_helpers/clone
@@ -1,14 +1,21 @@
 #!/bin/sh
-# Usage: .ci_helpers/clone REPOSITORY [DIR] [BRANCH]
+# Usage: .ci_helpers/clone OWNER REPOSITORY [DIR] [BRANCH] [HTSLIB_PR]
 #
 # Creates a shallow clone, checking out the specified branch.  If BRANCH is
 # omitted or if there is no branch with that name, checks out origin/HEAD
 # from the samtools/htslib repository.
+#
+# If BRANCH cannot be found in htslib and HTSLIB_PR is defined (a number)
+# then we checkout that PR number instead.  This is used by Cirrus-CI when
+# making joint PRs on samtools/htslib or bcftools/htslib
 
-repository=$1
-localdir=$2
-branch=$3
-htslib_PR=$4
+echo CLONE: ${@+"$@"}
+
+owner=$1
+repository="https://github.com/$owner/$2"
+localdir=$3
+branch=$4
+htslib_PR=$5
 
 ref=''
 [ -n "$branch" ] && ref=$(git ls-remote --heads "$repository" "$branch" 2>/dev/null)
@@ -17,7 +24,8 @@ ref=''
 set -x
 git clone --recurse-submodules --shallow-submodules --depth=50 ${ref:+--branch="$branch"} "$repository" "$localdir"
 
-if [ "x$htslib_PR" != "x" ]
+# NB: "samtools" as the owner/organisation, not the repo name
+if [ "x$owner" = "xsamtools" -a -z "$ref" -a "x$htslib_PR" != "x" ]
 then
     cd "$localdir"
     git fetch origin "pull/$htslib_PR/head"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,8 +21,16 @@ timeout_in: 10m
 # clone with our own commands too.
 clone_template: &HTSLIB_CLONE
   htslib_clone_script: |
-    printenv CIRRUS_CHANGE_TITLE
-    .ci_helpers/clone "https://github.com/${CIRRUS_REPO_OWNER}/htslib" "${HTSDIR}" "${CIRRUS_BRANCH}" `printenv CIRRUS_CHANGE_TITLE | sed -n 's/.*htslib#\([0-9]*\).*/\1/p'`
+    # Tricky, but when run as a PR Cirrus-CI obscures the branch name and
+    # replaces it by pull/<num>.  This means we can't automatically get PRs
+    # to test whether the user has a similarly named branch to compiler and
+    # test against.
+    #
+    # Instead if we add htslib#NUM into the first line of the commit then
+    # we will use that PR from htslib instead.  This is only needed when
+    # making a PR, so for development prior to the PR being made the
+    # CIRRUS_BRANCH will be used in preference.
+    .ci_helpers/clone ${CIRRUS_REPO_OWNER} htslib "${HTSDIR}" "${CIRRUS_BRANCH}" `printenv CIRRUS_CHANGE_TITLE | sed -n 's/.*htslib#\([0-9]*\).*/\1/p'`
 
 htslib_compile_template: &HTSLIB_COMPILE
   << : *HTSLIB_CLONE

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Set up MSYS2 MinGW-W64
       uses: msys2/setup-msys2@v2
       with:
@@ -25,14 +27,10 @@ jobs:
     - name: Clone htslib
       shell: msys2 {0}
       run: |
-        # Todo 4th arg to track commit message of htslib#PRNUM to
-        # check out a specific htslib PR instead.
-        # Other useful vars:
-        # GITHUB_BASE_REF:  e.g. "develop"
-        # GITHUB_HEAD_REF:  e.g. "my-PR-feature" (aka GITHUB_REF_NAME?)
         export PATH="$PATH:/mingw64/bin:/c/Program Files/Git/bin"
         export MSYSTEM=MINGW64
-        .ci_helpers/clone "https://github.com/${GITHUB_REPOSITORY_OWNER}/htslib" htslib "${GITHUB_REF_NAME}"
+        htslib_pr=`git log -2 --format='%s' | sed -n 's/.*htslib#\([0-9]*\).*/\1/p'`
+        .ci_helpers/clone ${GITHUB_REPOSITORY_OWNER} htslib htslib ${GITHUB_HEAD_REF:-$GITHUB_REF_NAME} $htslib_pr
         pushd .
         cd htslib
         autoreconf -i


### PR DESCRIPTION
Cirrus-CI stopped knowing the author's branch name at some point and instead reported the branch name in the repository we're making a PR against (pull/num).  So instead we added the ability to specify htslib#NUM to the first line of a samtools PR to enable joint samtools/htslib PRs to work.  This wasn't particularly robust and had problems when not working as a PR (ie in the authors own repositories).

It was also completely absent from GitHub Actions.  Note there's no way of knowing the PR number for GitHub actions short of doing a git log, and it only has one commit in the log which is a merge commit. I changed it to use pull/NUM/head instead of pull/NUM/merge, but possibly it would be better done with "fetch-depth: 2" instead.  It's no big deal though as we check the mergability elsewhere.