### PR TITLE
Fixes to quality plots with fwd & rev reads

### DIFF
--- a/misc/plot-bamstats
+++ b/misc/plot-bamstats
@@ -812,7 +812,7 @@ sub plot_qualities
     $fh = $$args{fh};
     my $max = defined $lmax && $lmax > $fmax ? $lmax : $fmax;
     my $ytics = generate_ticks([ map { $_->[0] } @ffq ], $is_paired);
-    $pos_size = $is_paired ? " set origin 0.05,0.5\n set size 0.9,0.5" : '';
+    $pos_size = $is_paired ? " set origin 0.05,0.5\n set size 0.85,0.5" : '';
     print $fh qq[
             $$args{terminal}
             set output "$$args{img}"
@@ -850,7 +850,7 @@ sub plot_qualities
         my $ytics = generate_ticks([ map { $_->[0] } @lfq ], $is_paired);
         print $fh qq[
                 set origin 0.05,0.05
-                set size 0.9,0.5
+                set size 0.85,0.5
                 set ylabel "Cycle (rev reads)" offset character -1,0
                 set xlabel "Base Quality"
                 unset title

--- a/misc/plot-bamstats
+++ b/misc/plot-bamstats
@@ -818,8 +818,23 @@ sub plot_qualities
             set output "$$args{img}"
             unset key
             unset colorbox
+
+            # Perceptually uniform heatmap "plasma" by Nathaniel J. Smith & Stefan van der Walt
+            # used in Python's matplotlib:  https://github.com/BIDS/colormap/blob/master/colormaps.py
+            # Values from:  https://github.com/Gnuplotting/gnuplot-palettes/blob/master/plasma.pal
+            # Dark end squished to make low values more distinguishable.
             set palette model RGB
-            set palette defined (1 '#000066', 8 '#0000ff', 24 '#00ffff', 40 '#ffff00', 56 '#ff0000', 64 '#ffffff')
+            set palette defined ( \\
+                 0 '#0c0887' \\
+              ,  5 '#4b03a1' \\
+              , 10 '#7d03a8' \\
+              , 20 '#a82296' \\
+              , 30 '#cb4679' \\
+              , 40 '#e56b5d' \\
+              , 50 '#f89441' \\
+              , 60 '#fdc328' \\
+              , 70 '#f0f921' )
+
             set cbrange [0:$max]
             set yrange  [0:$ncycles]
             set xrange  [0:$nquals]

--- a/misc/plot-bamstats
+++ b/misc/plot-bamstats
@@ -737,7 +737,7 @@ sub plot_qualities
                 set size 0.4,0.8
                 unset ytics
                 set y2tics mirror
-                set yrange [0:$yrange]
+                set y2range [0:$yrange]
                 unset ylabel
                 set xlabel "Cycle (rev reads)"
                 set label "$$args{title}" at screen 0.5,0.95 center noenhanced
@@ -811,16 +811,15 @@ sub plot_qualities
     $args = get_defaults($opts,"$$opts{prefix}quals-hm.png", wh=>'600,500');
     $fh = $$args{fh};
     my $max = defined $lmax && $lmax > $fmax ? $lmax : $fmax;
-    my @ytics;
-    for my $cycle (@ffq) { if ( $$cycle[0]%10==0 ) { push @ytics,qq["$$cycle[0]" $$cycle[0]]; } }
-    my $ytics = join(',', @ytics);
-    $pos_size = $is_paired ? " set origin 0,0.46\n set size 0.95,0.6" : '';
+    my $ytics = generate_ticks([ map { $_->[0] } @ffq ], $is_paired);
+    $pos_size = $is_paired ? " set origin 0.05,0.5\n set size 0.9,0.5" : '';
     print $fh qq[
             $$args{terminal}
             set output "$$args{img}"
             unset key
             unset colorbox
-            set palette defined (0 0 0 0, 1 0 0 1, 3 0 1 0, 4 1 0 0, 6 1 1 1)
+            set palette model RGB
+            set palette defined (1 '#000066', 8 '#0000ff', 24 '#00ffff', 40 '#ffff00', 56 '#ff0000', 64 '#ffffff')
             set cbrange [0:$max]
             set yrange  [0:$ncycles]
             set xrange  [0:$nquals]
@@ -848,12 +847,10 @@ sub plot_qualities
     print $fh "\nend\n";
     if ( $is_paired )
     {
-        @ytics = ();
-        for my $cycle (@lfq) { if ( $$cycle[0]%10==0 ) { push @ytics,qq["$$cycle[0]" $$cycle[0]]; } }
-        $ytics = join(',', @ytics);
+        my $ytics = generate_ticks([ map { $_->[0] } @lfq ], $is_paired);
         print $fh qq[
-                set origin 0,0.03
-                set size 0.95,0.6
+                set origin 0.05,0.05
+                set size 0.9,0.5
                 set ylabel "Cycle (rev reads)" offset character -1,0
                 set xlabel "Base Quality"
                 unset title
@@ -876,6 +873,23 @@ sub plot_qualities
     plot($$args{gp});
 }
 
+sub generate_ticks {
+    my ($cycles, $skip_even) = @_;
+
+    my @marks;
+    foreach my $v (@$cycles) {
+        if ($v % 10 == 0) {
+            if ($skip_even) {
+                my $label = $v % 20 ? $v : '';
+                push @marks, qq{"$label" $v};
+            }
+            else {
+                push @marks, qq{"$v" $v};
+            }
+        }
+    }
+    return join(', ', @marks);
+}
 
 sub plot_acgt_cycles
 {

--- a/misc/plot-bamstats
+++ b/misc/plot-bamstats
@@ -26,6 +26,7 @@ use strict;
 use warnings;
 use Carp;
 use POSIX qw/floor ceil/;
+use URI::Escape qw(uri_escape);
 use List::Util qw(max);
 
 my $opts = parse_params();
@@ -1598,15 +1599,17 @@ sub create_html
         {
             # new row
             if ( $i>0 ) { print $fh "</tr>\n"; }
-            print $fh "<tr>";
+            print $fh "<tr>\n";
         }
         if ( -e "$$opts{prefix}$imgs[$i].png" )
         {
             my $desc = $imgs{$imgs[$i]};
-            print $fh qq[<td><a class="thumbnail" href="$prefix$imgs[$i].png"><img src="$prefix$imgs[$i].png" width="150px"><span>$desc<br><img src="$prefix$imgs[$i].png"></span></a>\n];
+            my $link = uri_escape("$prefix$imgs[$i].png");
+            print $fh qq[  <td><a class="thumbnail" href="$link"><img src="$link" width="150px"><span>$desc<br><img src="$link"></span></a>\n];
         }
-        else { print $fh "<td>\n"; }
+        else { print $fh "  <td />\n"; }
     }
+    print $fh "</tr></table>\n";
 
     my $reads_total      = get_value($opts,'SN','raw total sequences:');
     my $reads_filtered   = get_value($opts,'SN','filtered sequences:');
@@ -1634,7 +1637,6 @@ sub create_html
     $bases_mapped   = bignum($bases_mapped);
 
     print $fh qq[
-        </table>
 
         <table class="nums">
             <tr><th>Reads</tr>


### PR DESCRIPTION
Fixes warning:
```
"38911_1#35_F0xB00-quals2.gp" line 932: warning: y2 axis range undefined or overflow, resetting to [0:0]
```
which resulted in missing ticks on `quals2` plot.

Fixes `quals-hm` broken plot layout:

![38911_1#35_F0xB00-quals-hm](https://github.com/user-attachments/assets/4ad72737-9edd-497a-9a1f-af0afa18d015)

to:

![38911_1#35_F0xB00-quals-hm](https://github.com/user-attachments/assets/0ae5ab1b-cb07-40a2-b45d-711882fbde60)

and changes heatmap to a (hopefully) more interpretable one which avoids dark zones between blue and green and between  green and red.

Fixes broken table HTML in gallery file and broken links when file names contain characters which need to be URI escaped.