### PR TITLE
View: add --save-counts option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ phase.o: phase.c config.h $(htslib_hts_h) $(htslib_sam_h) $(htslib_kstring_h) $(
 reference.o: reference.c config.h $(htslib_sam_h) $(htslib_cram_h) $(samtools_h) $(sam_opts_h)
 sam_opts.o: sam_opts.c config.h $(sam_opts_h)
 sam_utils.o: sam_utils.c config.h $(sam_utils_h)
-sam_view.o: sam_view.c config.h $(htslib_sam_h) $(htslib_faidx_h) $(htslib_khash_h) $(htslib_kstring_h) $(htslib_thread_pool_h) $(htslib_hts_expr_h) $(samtools_h) $(sam_opts_h) $(bam_h) $(bedidx_h) $(sam_utils_h)
+sam_view.o: sam_view.c config.h $(htslib_sam_h) $(htslib_faidx_h) $(htslib_khash_h) $(htslib_kstring_h) $(htslib_hfile_h) $(htslib_thread_pool_h) $(htslib_hts_expr_h) $(samtools_h) $(sam_opts_h) $(bam_h) $(bedidx_h) $(sam_utils_h)
 sample.o: sample.c config.h $(sample_h) $(htslib_khash_h)
 stats_isize.o: stats_isize.c config.h $(stats_isize_h) $(htslib_khash_h)
 stats.o: stats.c config.h $(htslib_faidx_h) $(htslib_sam_h) $(htslib_hts_h) $(htslib_hts_defs_h) $(samtools_h) $(htslib_khash_h) $(htslib_kstring_h) $(stats_isize_h) $(sam_opts_h) $(bedidx_h)

--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -204,6 +204,19 @@ and
 are taken into account.
 .RB "The " -p " option is ignored in this mode."
 .TP
+.BI "--save-counts " FILE
+Save data on the number of records processed, accepted and rejected by any
+filter options to
+.IR FILE .
+The data is stored in JSON format.
+The counts only include records that are processed through the filtering
+options.
+Any records skipped while iterating over regions will not be included,
+so the number processed may be less than the total number of records in the
+file.
+If used with the \fB--fetch-pairs\fR option,
+counts will be given for records processed during the second pass over the data.
+.TP
 .BR -? ", " --help
 Output long help and exit immediately.
 .TP


### PR DESCRIPTION
Adds an option to store counts of records processed, accepted and rejected by filtering to a file.  The data is saved as JSON, but pretty-printed so it also can be processed fairly easily as a simple text file.

Fixes #2038 (Using view command to filter the records from a bam file, but also report the number of reads passed the filter or dropped.)