### PR TITLE
faidx/fqidx indexes along with output creation

### DIFF
--- a/doc/samtools-faidx.1
+++ b/doc/samtools-faidx.1
@@ -131,6 +131,10 @@ Print help message and exit.
 .BI --output-fmt-option\  OPT=VAL
 Set the output format options, level=0..9 for compression level 0 to 9.
 .TP
+.BI --write-index
+Create index for the output sequence data along with the output, in same path as
+<output name>.fai, <outputname>.gzi. This option is valid only for file output.
+.TP
 .BI "-@, --threads " N
 Set the number of extra threads for operations on compressed files.
 

--- a/doc/samtools-faidx.1
+++ b/doc/samtools-faidx.1
@@ -73,10 +73,8 @@ any extracted subsequence will be in FASTA format.
 
 .TP 8
 .BI "-o, --output " FILE
-Write FASTA to file rather than to stdout. With .gz, .bgz, .bgzf file extensions
-the output will be
-.B BGZF
-compressed.
+.RI "Write FASTA to file rather than to stdout. If " FILE " ends with .gz,"
+.RB ".bgz or .bgzf then it will be " BGZF " compressed."
 .TP
 .BI "-n, --length " INT
 Length for FASTA sequence line wrapping.  If zero, this means do not

--- a/doc/samtools-fqidx.1
+++ b/doc/samtools-fqidx.1
@@ -1,9 +1,9 @@
 '\" t
 .TH samtools-fqidx 1 "12 September 2024" "samtools-1.21" "Bioinformatics tools"
 .SH NAME
-samtools fqidx \- Indexes or queries regions from a fastq file
+samtools fqidx \- indexes or queries regions from a fastq file
 .\"
-.\" Copyright (C) 2008-2011, 2013-2018, 2020 Genome Research Ltd.
+.\" Copyright (C) 2008-2011, 2013-2018, 2020, 2024 Genome Research Ltd.
 .\" Portions copyright (C) 2010, 2011 Broad Institute.
 .\"
 .\" Author: Heng Li <lh3@sanger.ac.uk>
@@ -56,9 +56,9 @@ will index the file and create
 on the disk. If regions are specified, the subsequences will be
 retrieved and printed to stdout in the FASTQ format.
 
-The input file can be compressed in the
+The input and output can be files compressed in the
 .B BGZF
-format.
+format. When output is compressed, the default compression level is 4.
 
 The sequences in the input file should all have different names.
 If they do not, indexing will emit a warning about duplicate sequences and
@@ -74,7 +74,10 @@ searches using the index will be very slow and use a lot of memory.
 .SH OPTIONS
 .TP 8
 .BI "-o, --output " FILE
-Write FASTQ to file rather than to stdout.
+Write FASTQ to file rather than to stdout. With .gz, .bgz, .bgzf file extensions
+the output will be
+.B BGZF
+compressed.
 .TP
 .BI "-n, --length " INT
 Length for FASTQ sequence line wrapping.  If zero, this means do not
@@ -122,6 +125,16 @@ Read/Write to specified compressed file index (used with .gz files).
 .TP
 .B -h, --help
 Print help message and exit.
+.TP
+.BI --output-fmt-option\  OPT=VAL
+Set the output format options, level=0..9 for compression level 0 to 9.
+.TP
+.BI --write-index
+Create index for the output sequence data along with the output, in same path as
+<output name>.fai, <outputname>.gzi. This option is valid only for file output.
+.TP
+.BI "-@, --threads " N
+Set the number of extra threads for operations on compressed files.
 
 .SH AUTHOR
 .PP

--- a/doc/samtools-fqidx.1
+++ b/doc/samtools-fqidx.1
@@ -74,10 +74,8 @@ searches using the index will be very slow and use a lot of memory.
 .SH OPTIONS
 .TP 8
 .BI "-o, --output " FILE
-Write FASTQ to file rather than to stdout. With .gz, .bgz, .bgzf file extensions
-the output will be
-.B BGZF
-compressed.
+.RI "Write FASTQ to file rather than to stdout. If " FILE " ends with .gz,"
+.RB ".bgz or .bgzf then it will be " BGZF " compressed."
 .TP
 .BI "-n, --length " INT
 Length for FASTQ sequence line wrapping.  If zero, this means do not

--- a/test/test.pl
+++ b/test/test.pl
@@ -623,6 +623,22 @@ sub test_faidx
     cmd("$$opts{diff} $$opts{tmp}/faidx.fa.fai $$opts{tmp}/fa_test.fai");
     cmd("$$opts{diff} $$opts{tmp}/faidx.fa.gz.gzi $$opts{tmp}/fa_test.gzi");
 
+    #with write-index
+    cmd("$$opts{bin}/samtools faidx $$opts{tmp}/faidx.fa 1 --write-index"); #ignores write-index
+    cmd("echo \"1\n2\n3\" > $$opts{tmp}/1.reg"); #create region file
+    cmd("$$opts{bin}/samtools faidx $$opts{tmp}/faidx.fa --write-index -r $$opts{tmp}/1.reg -o $$opts{tmp}/1.fa"); #writes and indexes
+    cmd("$$opts{diff} $$opts{tmp}/faidx.fa.fai $$opts{tmp}/1.fa.fai");
+    cmd("$$opts{bin}/samtools faidx $$opts{tmp}/faidx.fa -r $$opts{tmp}/1.reg -o $$opts{tmp}/out.fa.gz"); #create output for comparison
+    cmd("$$opts{bin}/samtools faidx $$opts{tmp}/out.fa.gz");
+    cmd("$$opts{bin}/samtools faidx $$opts{tmp}/faidx.fa --write-index -r $$opts{tmp}/1.reg -o $$opts{tmp}/1.fa.gz");  #write and index 1.fa.gz.fai and 1.fa.gz.gzi
+    cmd("$$opts{diff} $$opts{tmp}/out.fa.gz.fai $$opts{tmp}/1.fa.gz.fai");
+    cmd("$$opts{diff} $$opts{tmp}/out.fa.gz.gzi $$opts{tmp}/1.fa.gz.gzi");
+    cmd("$$opts{bin}/samtools faidx --fai-idx $$opts{tmp}/fa_test.fai --gzi-idx $$opts{tmp}/fa_test.gzi $$opts{tmp}/faidx.fa.gz -r $$opts{tmp}/1.reg -o $$opts{tmp}/1.fa");    #write and index 1.fa.fai
+    cmd("$$opts{diff} $$opts{tmp}/faidx.fa.fai $$opts{tmp}/1.fa.fai");
+    cmd("$$opts{bin}/samtools faidx --fai-idx $$opts{tmp}/fa_test.fai --gzi-idx $$opts{tmp}/fa_test.gzi $$opts{tmp}/faidx.fa.gz -r $$opts{tmp}/1.reg -o $$opts{tmp}/1.fa.gz"); #write and index 1.fa.gz.fai and 1.fa.gz.gzi
+    cmd("$$opts{diff} $$opts{tmp}/out.fa.gz.fai $$opts{tmp}/1.fa.gz.fai");
+    cmd("$$opts{diff} $$opts{tmp}/out.fa.gz.gzi $$opts{tmp}/1.fa.gz.gzi");
+
     # test continuing after an error
     cmd("$$opts{bin}/samtools faidx --output $$opts{tmp}/output_faidx.fa --continue $$opts{tmp}/faidx.fa 100 EEE FFF");
 
@@ -773,6 +789,22 @@ sub test_fqidx
     cmd("$$opts{bin}/samtools fqidx --fai-idx $$opts{tmp}/fq_test.fai --gzi-idx $$opts{tmp}/fq_test.gzi $$opts{tmp}/fqidx.fq.gz");
     cmd("$$opts{diff} $$opts{tmp}/fqidx.fq.fai $$opts{tmp}/fq_test.fai");
     cmd("$$opts{diff} $$opts{tmp}/fqidx.fq.gz.gzi $$opts{tmp}/fq_test.gzi");
+
+    #with write-index
+    cmd("$$opts{bin}/samtools fqidx $$opts{tmp}/fqidx.fq 1 --write-index"); #ignores write-index
+    cmd("echo \"1\n2\n3\" > $$opts{tmp}/1.reg"); #create region file
+    cmd("$$opts{bin}/samtools fqidx $$opts{tmp}/fqidx.fq --write-index -r $$opts{tmp}/1.reg -o $$opts{tmp}/1.fq"); #writes and indexes
+    cmd("$$opts{diff} $$opts{tmp}/fqidx.fq.fai $$opts{tmp}/1.fq.fai");
+    cmd("$$opts{bin}/samtools fqidx $$opts{tmp}/fqidx.fq -r $$opts{tmp}/1.reg -o $$opts{tmp}/out.fq.gz"); #create output for comparison
+    cmd("$$opts{bin}/samtools fqidx $$opts{tmp}/out.fq.gz");
+    cmd("$$opts{bin}/samtools fqidx $$opts{tmp}/fqidx.fq --write-index -r $$opts{tmp}/1.reg -o $$opts{tmp}/1.fq.gz");  #write and index 1.fq.gz.fai and 1.fq.gz.gzi
+    cmd("$$opts{diff} $$opts{tmp}/out.fq.gz.fai $$opts{tmp}/1.fq.gz.fai");
+    cmd("$$opts{diff} $$opts{tmp}/out.fq.gz.gzi $$opts{tmp}/1.fq.gz.gzi");
+    cmd("$$opts{bin}/samtools fqidx --fai-idx $$opts{tmp}/fq_test.fai --gzi-idx $$opts{tmp}/fq_test.gzi $$opts{tmp}/fqidx.fq.gz -r $$opts{tmp}/1.reg -o $$opts{tmp}/1.fq");    #write and index 1.fa.fai
+    cmd("$$opts{diff} $$opts{tmp}/fqidx.fq.fai $$opts{tmp}/1.fq.fai");
+    cmd("$$opts{bin}/samtools fqidx --fai-idx $$opts{tmp}/fq_test.fai --gzi-idx $$opts{tmp}/fq_test.gzi $$opts{tmp}/fqidx.fq.gz -r $$opts{tmp}/1.reg -o $$opts{tmp}/1.fq.gz"); #write and index 1.fa.gz.fai and 1.fa.gz.gzi
+    cmd("$$opts{diff} $$opts{tmp}/out.fq.gz.fai $$opts{tmp}/1.fq.gz.fai");
+    cmd("$$opts{diff} $$opts{tmp}/out.fq.gz.gzi $$opts{tmp}/1.fq.gz.gzi");
 
     # test continuing after an error
     cmd("$$opts{bin}/samtools fqidx --output $$opts{tmp}/output_fqidx.fq --continue $$opts{tmp}/fqidx.fq 100 EEE FFF");


### PR DESCRIPTION
faidx/fqidx index can be created along with sequence retrieval, with --write-index option
uncompressed output was created through FILE handle and updated to create using BGZF uncompressed writing
fqidx man page update for compressed output creation details.
Resolves #2118 