### PR TITLE
Fix samtools merge crash on BAM files with malformed headers

### DIFF
--- a/bam_sort.c
+++ b/bam_sort.c
@@ -470,7 +470,14 @@ static int trans_tbl_add_sq(merged_header_t* merged_hdr, sam_hdr_t *translate,
     // Fill in the tid part of the translation table, adding new targets
     // to the merged header as we go.
 
-    for (i = 0; i < sam_hdr_nref(translate); ++i) {
+    tbl->n_targets = sam_hdr_nref(translate);
+    tbl->tid_trans = calloc(tbl->n_targets ? tbl->n_targets : 1, sizeof(int));
+    if (tbl->tid_trans == NULL) {
+        print_error_errno("merge", "failed to allocate @SQ translation table");
+        return -1;
+    }
+
+    for (i = 0; i < tbl->n_targets; ++i) {
         int trans_tid;
         sq_sn.l = 0;
         res = sam_hdr_find_tag_pos(translate, "SQ", i, "SN", &sq_sn);
@@ -797,11 +804,9 @@ static int trans_tbl_init(merged_header_t* merged_hdr, sam_hdr_t* translate,
     klist_t(hdrln) *rg_list = NULL;
     klist_t(hdrln) *pg_list = NULL;
 
-    tbl->n_targets = sam_hdr_nref(translate);
+    tbl->n_targets = 0;
+    tbl->tid_trans = NULL;
     tbl->rg_trans = tbl->pg_trans = NULL;
-    tbl->tid_trans = (int*)calloc(tbl->n_targets ? tbl->n_targets : 1,
-                                  sizeof(int));
-    if (tbl->tid_trans == NULL) goto memfail;
     tbl->rg_trans = kh_init(c2c);
     if (tbl->rg_trans == NULL) goto memfail;
     tbl->pg_trans = kh_init(c2c);


### PR DESCRIPTION
When the binary and text reference names disagree in a BAM header, it's possible for the number of references apparently present to increase when the header text is parsed.  This caused a crash when samtools merge built its reference translation table because the `trans_tbl_t::tid_trans` array was allocated in `trans_tbl_init()` with the smaller size, and then `trans_tbl_add_sq()` used the bigger one when trying to put data in it.

Fixed by moving the allocation to `trans_tbl_add_sq()`, so the space allocated will always match the number of items iterated over.

Thanks to @frostb1ten for the bug report.
Fixes #2127 (Heap Buffer Overflow in samtools merge within trans_tbl_add_sq function)