### PR TITLE
tview: add -i to hide inserts

### DIFF
--- a/bam_tview.c
+++ b/bam_tview.c
@@ -413,7 +413,8 @@ static void HTS_FORMAT(HTS_PRINTF_FMT, 1, 2) error(const char *format, ...)
 "   -X              include customized index file\n"
 "   -p chr:pos      go directly to this position\n"
 "   -s STR          display only reads from this sample or group\n"
-"   -w INT          display width (with -d T only)\n");
+"   -w INT          display width (with -d T only)\n"
+"   -i              hide inserts\n");
         sam_global_opt_help(stderr, "-.--.--.");
     }
     else
@@ -439,6 +440,7 @@ int bam_tview_main(int argc, char *argv[])
     int view_mode=display_ncurses, display_width = 0;
     tview_t* tv=NULL;
     char *samples=NULL, *position=NULL, *ref, *fn_idx=NULL;
+    int show_inserts = 1;
     int c, has_index_file = 0, ref_index = 0;
 
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
@@ -448,7 +450,7 @@ int bam_tview_main(int argc, char *argv[])
     };
 
     char *tmp;
-    while ((c = getopt_long(argc, argv, "s:p:d:Xw:", lopts, NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "s:p:d:Xw:i", lopts, NULL)) >= 0) {
         switch (c) {
             case 'w':
                 display_width = strtol(optarg,&tmp,10);
@@ -457,6 +459,7 @@ int bam_tview_main(int argc, char *argv[])
             case 's': samples=optarg; break;
             case 'p': position=optarg; break;
             case 'X': has_index_file=1; break; // -X flag for index filename
+            case 'i': show_inserts=0; break;
             case 'd':
             {
                 switch(optarg[0])
@@ -514,6 +517,7 @@ int bam_tview_main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
+    tv->ins = show_inserts;
     if ( position )
     {
         int tid;


### PR DESCRIPTION
Single base errors will be shown as inserts in `samtools tview`. If one works with reads of high error rates (like those of ONT), this will cause inserts to be shown all over.

This causes `samtools tview` very difficult interpreting - in some cases, unusable. While hiding inserts by pressing <kbd>i</kbd> have for long been an option in curses view, it hasn't been available for text or HTML view.

This PR adds option of using `-i` to hide inserts when outputting HTML and text with `samtools tview`, making it suitable for use with reads of high error rates. Using already implemented logic, just adding a CLI option for it.

Example with 500 ONT reads:
Before
```
   71                            81                             91                101               
A**C*G**G**C****GGC***C**G*****G*C*G**G****CA*G***C***C**A*****GC*GT*A**GCG*TC**C*ATGA***C**C***AC*A
.  . .  .  .    ...   .  .     . . .  .    .. .   .   .  .     .. .. .  ... ..  . ....   .  .   .. .
,**t*,a*,**,a***,,*******t*****,*,*,**,****,,*,***,***,**,*****,,*,,*,**,,,*,,**,*,,,,***,**,***,,*,
.**.*.**.A*.GATT...G**.A*.*****.*.*.C*.****..*.*******.**.*****.*****.**..**..**G*.G..***.TG.***.A*.
,*******,**,a***,,*******t*****,*,*,**,****,,*,***,***,**,*****,,*,,*,**,,,*,,**,*,,,,***,**,***,,*,
*****,**,**,****,,,***,**,*****,*,*,**,****,,*,***,***g**,*****,,*,,*,**,,,*,,**,*,,,,***,**,***,,*,
,**,*,**,**,****t,****,**,*****,*,*,**,****,,*,***,***,**,*****,,*,,*,**,,,*,,**,*,,,,***,**,***,,*,
.**.A.**C**.****...AAA*********.*.*.**.****..*.***.***.**.*****..*..C.**...*..**.*....***.**.***..*.
```
After
```
 71        81        91        101       111       121       131       141       151                
ACGGCGGCCGGCGGCAGCCAGCGTAGCGTCCATGACCACAGTCGCCTCGCTCTCCCTGGTGCCGCACCTGCTCATCAAGCCCTCCTTCCGCTGCCTCTCC
....................................................................................................
,t,,,,,**t,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,**,,,,,,,,,,,,,,,,,,,,,,,,,,,*,,***,,,,,,,,,,,,,,,,,,
.................*...***...*..G.G.....A.A....A.....*A.G....................*........................
,**,,,,**t,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,*****,,,,,,,,,,,,,,,,,,,,,,,,,,,,
**,,,,,,,,,,,,,,,,g,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
,,,,,t,*,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
```