### PR TITLE
bedcov header to have optional headers as well

### DIFF
--- a/bedcov.c
+++ b/bedcov.c
@@ -51,13 +51,16 @@ typedef struct {
     int64_t rcnt;
 } aux_t;
 
+#define HDR_CHROM "#chrom\t"
+
 static int read_bam(void *data, bam1_t *b)
 {
     aux_t *aux = (aux_t*)data; // data in fact is a pointer to an auxiliary structure
     int ret;
     while (1)
     {
-        ret = aux->iter? sam_itr_next(aux->fp, aux->iter, b) : sam_read1(aux->fp, aux->header, b);
+        ret = aux->iter? sam_itr_next(aux->fp, aux->iter, b) :
+            sam_read1(aux->fp, aux->header, b);
         if ( ret<0 ) break;
         if ( b->core.flag & aux->flags ) continue;
         if ( (int)b->core.qual < aux->min_mapQ ) continue;
@@ -70,6 +73,50 @@ static int incr_rcnt(void *data, const bam1_t *b, bam_pileup_cd *cd) {
     aux_t *aux = (aux_t *)data;
     aux->rcnt++;
     return 0;
+}
+
+/// output_header - dump the header in output
+/** @param fp     - pointer to output file
+*   @param hdr    - header from bed file, when it has one
+*   @param fields - field count to fill with \t when it doesn't have a header
+*   @param filecount - no. of input files
+*   @param argv   - input files, for header naming
+*   @param depth  - depth threshold configuration
+*   @param rcount - show read count configuration
+* returns nothing
+*/
+static void output_header(FILE *fp, char *hdr, int fields, int filecount,
+    char *argv[], int depth, int rcount)
+{
+    int i = 0;
+    if (hdr) {  //header available from bed file
+        fprintf(fp, "%s", hdr);
+    } else {
+        /* no header in bed, add one. add headers as defined in format.
+        use empty header with tab separation for fields above those defined in
+        format */
+        char *bedcols[] = { "chrom", "chromStart", "chromEnd", "name", "score",
+            "strand", "thickStart", "thickEnd", "itemRgb", "blockCount",
+            "blockSizes", "blockStarts"};
+        for (i = 0; i < fields; ++i) {
+            fprintf(fp, "%s%s", (i ? "\t" : "#"),
+                (i < sizeof(bedcols)/sizeof(bedcols[i]) ? bedcols[i] : "."));
+        }
+    }
+    for (i = 0; i < filecount; ++i) {   //coverage header
+        fprintf(fp, "\t%s_cov", argv[i + optind + 1]);
+    }
+    if (depth >= 0) {                   //depth header
+        for (i = 0; i < filecount; ++i) {
+            fprintf(fp, "\t%s_depth", argv[i + optind + 1]);
+        }
+    }
+    if (rcount) {                       //read count header
+        for (i = 0; i < filecount; ++i) {
+            fprintf(fp, "\t%s_count", argv[i + optind + 1]);
+        }
+    }
+    fprintf(fp, "\n");
 }
 
 int main_bedcov(int argc, char *argv[])
@@ -85,7 +132,8 @@ int main_bedcov(int argc, char *argv[])
     const bam_pileup1_t **plp;
     int usage = 0, has_index_file = 0;
     uint32_t flags = (BAM_FUNMAP | BAM_FSECONDARY | BAM_FQCFAIL | BAM_FDUP);
-    int tflags = 0, min_depth = -1, max_depth = DEFAULT_DEPTH, print_header=0;
+    int tflags = 0, min_depth = -1, max_depth = DEFAULT_DEPTH, print_header=0,
+        hdr = 0;
 
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
     static const struct option lopts[] = {
@@ -154,6 +202,9 @@ int main_bedcov(int argc, char *argv[])
         n = argc - optind - 1;
     }
 
+    if (!print_header) { // no header output needed, avoid check for header line
+        hdr = 1;
+    }
     memset(&str, 0, sizeof(kstring_t));
     aux = calloc(n, sizeof(aux_t*));
     idx = calloc(n, sizeof(hts_idx_t*));
@@ -196,22 +247,6 @@ int main_bedcov(int argc, char *argv[])
         return 2;
     }
 
-    if (print_header) {
-        printf("#chrom\tstart\tend");
-        for (i = 0; i < n; ++i) {
-            printf("\t%s_cov", argv[i+optind+1]);
-        }
-        if (min_depth >= 0) {
-            for (i = 0; i < n; ++i)
-                printf("\t%s_depth", argv[i+optind+1]);
-        }
-        if (do_rcount) {
-            for (i = 0; i < n; ++i)
-                printf("\t%s_count", argv[i+optind+1]);
-        }
-        putchar('\n');
-    }
-
     ks = ks_init(fp);
     n_plp = calloc(n, sizeof(int));
     plp = calloc(n, sizeof(bam_pileup1_t*));
@@ -221,12 +256,36 @@ int main_bedcov(int argc, char *argv[])
         int64_t beg = 0, end = 0;
         bam_mplp_t mplp;
 
-        if (str.l == 0 || *str.s == '#') continue; /* empty or comment line */
+        if (str.l == 0) {
+            continue; /* empty */
+        }
+        if (*str.s == '#') { // header or comment
+            if (!hdr && !strncmp(str.s, HDR_CHROM, sizeof(HDR_CHROM) - 1)) {
+                //header line and header output set
+                output_header(stdout, str.s, -1, n, argv, min_depth, do_rcount);
+                hdr = 1;
+            }
+            continue; // comment line or header
+        }
         /* Track and browser lines.  Also look for a trailing *space* in
            case someone has badly-chosen a chromosome name (it would
            be followed by a tab in that case). */
         if (strncmp(str.s, "track ", 6) == 0) continue;
         if (strncmp(str.s, "browser ", 8) == 0) continue;
+        if (!hdr) {
+            //no header line, header output set, find no of fields from bed line
+            //no header line yet and need header, find no of fields in bed line
+            int fields = 0;
+            char *tmp = str.s;
+            while (*tmp) {
+                if (*tmp++ == '\t') {
+                    fields++;
+                }
+            }
+            output_header(stdout, NULL, fields + 1, n, argv, min_depth, do_rcount);
+            hdr = 1;
+            //continue the processing of bed data line
+        }
         for (p = q = str.s; *p && !isspace(*p); ++p);
         if (*p == 0) goto bed_error;
         char c = *p;

--- a/doc/samtools-bedcov.1
+++ b/doc/samtools-bedcov.1
@@ -3,7 +3,7 @@
 .SH NAME
 samtools bedcov \- reports coverage over regions in a supplied BED file
 .\"
-.\" Copyright (C) 2008-2011, 2013-2018, 2020, 2022 Genome Research Ltd.
+.\" Copyright (C) 2008-2011, 2013-2018, 2020, 2022, 2024 Genome Research Ltd.
 .\" Portions copyright (C) 2010, 2011 Broad Institute.
 .\"
 .\" Author: Heng Li <lh3@sanger.ac.uk>
@@ -94,7 +94,7 @@ Specifies the maximum depth used for the mpileup algorithm.
 If \fB-d\fR is used and is larger then this value will be used instead.
 Defaults to 2 billion, but smaller values may be used when we do not
 require an exact count in excessively deep regions and are interested
-in maximising speed of results.
+in maximizing speed of results.
 .TP
 .B -c
 Print an additional column with the read count for this region.  This
@@ -104,11 +104,17 @@ within in.  The whole read filtering options \fB-Q\fR, \fB-g\fR and
 will not.
 .TP
 .B "-X"
-If this option is set, it will allows user to specify customized index file location(s) if the data
-folder does not contain any index file. Example usage: samtools bedcov [options] -X <in.bed> </data_folder/in1.bam> [...] </index_folder/index1.bai> [...]
+If this option is set, it will allows user to specify customized index file
+location(s) if the data folder does not contain any index file. Example usage:
+samtools bedcov [options] -X <in.bed> </data_folder/in1.bam> [...]
+</index_folder/index1.bai> [...]
 .TP
 .B "-H"
-.RI "print a comment/header describing columns"
+.R When a header starting in "#chrom" is available in the input bed file, it is
+copied to the output. When it is not available, a header is created with field
+names matching the fields listed in the GA4GH BED specification.
+The \fB-c\fR and \fB-d\fR options can add further per-file columns named
+.IR in1.sam "_count and " in1.sam "_depth along with " in1.sam "_count."
 
 .SH AUTHOR
 .PP

--- a/test/test.pl
+++ b/test/test.pl
@@ -3683,11 +3683,55 @@ sub test_markdup
 sub test_bedcov
 {
     my ($opts,%args) = @_;
+    my $out;
 
     test_cmd($opts,out=>'bedcov/bedcov.expected',cmd=>"$$opts{bin}/samtools bedcov $$opts{path}/bedcov/bedcov.bed $$opts{path}/bedcov/bedcov.bam");
     test_cmd($opts,out=>'bedcov/bedcov_j.expected',cmd=>"$$opts{bin}/samtools bedcov -j $$opts{path}/bedcov/bedcov.bed $$opts{path}/bedcov/bedcov.bam");
     test_cmd($opts,out=>'bedcov/bedcov_gG.expected',cmd=>"$$opts{bin}/samtools bedcov -g512 -G2048 $$opts{path}/bedcov/bedcov_gG.bed $$opts{path}/bedcov/bedcov.bam");
     test_cmd($opts,out=>'bedcov/bedcov_c.expected',cmd=>"$$opts{bin}/samtools bedcov -c $$opts{path}/bedcov/bedcov_gG.bed $$opts{path}/bedcov/bedcov.bam");
+    #with header
+    cmd("echo \"#chrom\tchromStart\tchromEnd\t$$opts{path}/bedcov/bedcov.bam_cov\" > $$opts{tmp}/bedcovH1.expected");
+    cmd ("cat $$opts{path}/bedcov/bedcov.expected >> $$opts{tmp}/bedcovH1.expected");
+    cmd("$$opts{bin}/samtools bedcov -H $$opts{path}/bedcov/bedcov.bed $$opts{path}/bedcov/bedcov.bam > $$opts{tmp}/out.H1");
+    $out = cmd("diff $$opts{tmp}/bedcovH1.expected $$opts{tmp}/out.H1");
+    if ( $out ne "" ) {
+        failed($opts,msg=>"coverage with header",reason=>"output does $out not match to expected\n");
+    } else {
+        passed($opts,msg=>"coverage with header success\n");
+    }
+    #with custom header
+    cmd("echo \"#chrom\tchromStart\tchromEnd\tT1\nchr1\t12209228\t12209246\t10\" > $$opts{tmp}/bedcovH2.bed");
+    cmd("echo \"#chrom\tchromStart\tchromEnd\tT1\t$$opts{path}/bedcov/bedcov.bam_cov\nchr1\t12209228\t12209246\t10\t24\" > $$opts{tmp}/bedcovH2.expected");
+    cmd("$$opts{bin}/samtools bedcov -H $$opts{tmp}/bedcovH2.bed $$opts{path}/bedcov/bedcov.bam > $$opts{tmp}/out.H2");
+    $out = cmd("diff $$opts{tmp}/bedcovH2.expected $$opts{tmp}/out.H2");
+    if ( $out ne "" ) {
+        failed($opts,msg=>"coverage with custom header",reason=>"output does not match to expected\n");
+    } else {
+        passed($opts,msg=>"coverage with custom header success\n");
+    }
+    #with empty source header
+    cmd("echo \"#chrom\tchromStart\tchromEnd\t\nchr1\t12209228\t12209246\t10\" > $$opts{tmp}/bedcovH3.bed");
+    cmd("echo \"#chrom\tchromStart\tchromEnd\t\t$$opts{path}/bedcov/bedcov.bam_cov\nchr1\t12209228\t12209246\t10\t24\" > $$opts{tmp}/bedcovH3.expected");
+    cmd("$$opts{bin}/samtools bedcov -H $$opts{tmp}/bedcovH3.bed $$opts{path}/bedcov/bedcov.bam > $$opts{tmp}/out.H3");
+    $out = cmd("diff $$opts{tmp}/bedcovH3.expected $$opts{tmp}/out.H3");
+    if ( $out ne "" ) {
+        failed($opts,msg=>"coverage with src empty header",reason=>"output does not match to expected\n");
+    } else {
+        passed($opts,msg=>"coverage with src empty header success\n");
+    }
+    #empty added header
+    #chrom\tchromStart\tchromEnd\tname\tscore\tstrand\tthickStart\t\
+    #    thickEnd\titemRgb\tblockCount\tblockSizes\tblockStarts
+    cmd("echo \"chr1\t12209228\t12209246\t4\t5\t6\t7\t8\t9\t10\t11\t12\t13\t14\" > $$opts{tmp}/bedcovH4.bed");
+    cmd("echo \"#chrom\tchromStart\tchromEnd\tname\tscore\tstrand\tthickStart\tthickEnd\titemRgb\tblockCount\tblockSizes\tblockStarts\t.\t.\t$$opts{path}/bedcov/bedcov.bam_cov\" > $$opts{tmp}/bedcovH4.expected");
+    cmd("echo \"chr1\t12209228\t12209246\t4\t5\t6\t7\t8\t9\t10\t11\t12\t13\t14\t24\" >> $$opts{tmp}/bedcovH4.expected");
+    cmd("$$opts{bin}/samtools bedcov -H $$opts{tmp}/bedcovH4.bed $$opts{path}/bedcov/bedcov.bam > $$opts{tmp}/out.H4");
+    $out = cmd("diff $$opts{tmp}/bedcovH4.expected $$opts{tmp}/out.H4");
+    if ( $out ne "" ) {
+        failed($opts,msg=>"coverage with empty header",reason=>"output does not match to expected\n");
+    } else {
+        passed($opts,msg=>"coverage with empty header success\n");
+    }
 }
 
 sub test_split


### PR DESCRIPTION
Adds header for optional columns from bed file along with mandatory column headers.
If a header is present in bed file, it is used as such.
(A comment line starting with #chrom is considered as header in bed file.)

If header is not present in bed file, a header is made with text as mentioned in format (https://genome.ucsc.edu/FAQ/FAQformat#format1). There is difference from earlier version where "chrom tab start tab end" was used and now they are "chrom tab chromStart tab chromEnd".
If there are more fields than the format specified, empty header with tab separation is used.
Result column headers appended after this header.

fixes #2126 