### PR TITLE
Clarify consensus -@N speed expectations.

### DIFF
--- a/bam_consensus.c
+++ b/bam_consensus.c
@@ -2355,7 +2355,14 @@ static void usage_exit(FILE *fp, int exit_status) {
     fprintf(fp, "                        hiseq, hifi, r10.4_sup, r10.4_dup and ultima\n");
 
     fprintf(fp, "\nGlobal options:\n");
-    sam_global_opt_help(fp, "-.---@-.");
+    // Edited sam_global_opt_help(fp, "-.---@-.") help to expand -@ description.
+    fprintf(fp, "      --input-fmt-option OPT[=VAL]\n");
+    fprintf(fp, "               Specify a single input file format option in the form\n");
+    fprintf(fp, "               of OPTION or OPTION=VALUE\n");
+    fprintf(fp, "  -@, --threads INT\n");
+    fprintf(fp, "               Number of additional decompression threads to use [0]\n");
+    fprintf(fp, "      --verbosity INT\n");
+    fprintf(fp, "               Set level of verbosity\n");
     exit(exit_status);
 }
 

--- a/doc/samtools-consensus.1
+++ b/doc/samtools-consensus.1
@@ -261,6 +261,12 @@ fraction of bases agreeing with the most likely consensus call to emit
 that base type.  This defaults to 0.75.  Failing this check will
 output "N".
 
+.TP
+.BI "-@ " NTHREADS
+Specify the number of additional threads to use for decompressing the
+data.  Note currently the algorithm is dominated by the main consensus
+computation so asking for more than 1 additional thread will likely
+have minimal benefit.
 
 .TP 0
 The following options apply only to Bayesian consensus mode enabled


### PR DESCRIPTION
Like many commands, this is currently file format decoding only and the consensus command can be dominated by the main worker thread.  The most extreme case of calling a simple consensus on an archive-mode CRAM still only gained a 2 fold speed up, so more than 1 decode thread isn't necessary.

Fix #2134