### PR TITLE
fix to use proper offset in faidx allocidx

### DIFF
--- a/faidx.c
+++ b/faidx.c
@@ -140,8 +140,8 @@ static inline idx_entry* allocidx(idx* in)
         if (!tmp) {
             return NULL;
         }
-        int count = newlen - in->n;
-        memset(tmp + in->n * sizeof(*tmp), 0, count * sizeof(*tmp));
+        size_t count = newlen - in->n;
+        memset(tmp + in->n, 0, count * sizeof(*tmp));
         in->indx = tmp;
         in->m = newlen;
     }


### PR DESCRIPTION
Fixes #2142

The memset in allocidx uses a pointer to struct but offset was used as if it was a pointer to a byte.
This should have updated incorrect addresses and caused this issue.

This change corrects the offset usage. Checked with bigger files where reallocation occurs and no corruptions observed.