### PR TITLE
Use MD/NM on CRAM for samtools consensus

### DIFF
--- a/bam_consensus.c
+++ b/bam_consensus.c
@@ -2695,11 +2695,6 @@ int main_consensus(int argc, char **argv) {
     if (ga.nthreads > 0)
         hts_set_threads(opts.fp, ga.nthreads);
 
-    if (hts_set_opt(opts.fp, CRAM_OPT_DECODE_MD, 0)) {
-        fprintf(stderr, "Failed to set CRAM_OPT_DECODE_MD value\n");
-        goto err;
-    }
-
     if (!(opts.h = sam_hdr_read(opts.fp))) {
         fprintf(stderr, "Failed to read header for \"%s\"\n", argv[optind]);
         goto err;


### PR DESCRIPTION
This is awkward as there's no right solution for BAM vs CRAM, but the previous method of not computing MD for CRAM was both illogical and also removing user control.

Now it basically relies on --input-fmt-option decode_md=1 (or =0) which is adjustable, defaulting to 1 (decode).

So BAM vs CRAM may differ now if the original BAM has no MD. Previously it differed if the original BAM had an MD.  The latter is much more common place, hence it was a bad choice.

TODO: Sadly CRAM doesn't have a mechanism to record whether the original data has MD/NM tags, so it always generates or always doesn't generate.  Consider adding a private htslib specific tag to hold this CRAM meta-data, or later extending the specification with additional CF (cram flag) bits.  We coould copy the CRAMv4 idea of a tag indicating the aux tag ordering, so if it contains MD and NM then we know to decode them, as well as which position in the tag string (along with RG too).  That's essentially how CRAMv4 works but via the TL dictionary.