### PR TITLE
sets sort order as unsorted when ordering is lost during merge

### DIFF
--- a/test/merge/test_trans_tbl_init.c
+++ b/test/merge/test_trans_tbl_init.c
@@ -342,7 +342,7 @@ int main(int argc, char**argv)
     }
     if (verbose) printf("RUN test 1\n");
     trans_tbl_init(merged_hdr, translate, &tbl_1, false, false, true, NULL);
-    finish_merged_header(merged_hdr);
+    finish_merged_header(merged_hdr, 0);
     out = merged_hdr->hdr;
     free_merged_header(merged_hdr);
     if (verbose) printf("END RUN test 1\n");
@@ -380,7 +380,7 @@ int main(int argc, char**argv)
     }
     if (verbose) printf("RUN test 2\n");
     trans_tbl_init(merged_hdr, translate, &tbl_2, false, false, true, NULL);
-    finish_merged_header(merged_hdr);
+    finish_merged_header(merged_hdr, 0);
     out = merged_hdr->hdr;
     free_merged_header(merged_hdr);
     if (verbose) printf("END RUN test 2\n");
@@ -417,7 +417,7 @@ int main(int argc, char**argv)
      }
     if (verbose) printf("RUN test 3\n");
     trans_tbl_init(merged_hdr, translate, &tbl_3, false, false, true, NULL);
-    finish_merged_header(merged_hdr);
+    finish_merged_header(merged_hdr, 0);
     out = merged_hdr->hdr;
     free_merged_header(merged_hdr);
     if (verbose) printf("END RUN test 3\n");
@@ -454,7 +454,7 @@ int main(int argc, char**argv)
     }
     if (verbose) printf("RUN test 4\n");
     trans_tbl_init(merged_hdr, translate, &tbl_4, false, false, true, NULL);
-    finish_merged_header(merged_hdr);
+    finish_merged_header(merged_hdr, 0);
     out = merged_hdr->hdr;
     free_merged_header(merged_hdr);
     if (verbose) printf("END RUN test 4\n");
@@ -492,7 +492,7 @@ int main(int argc, char**argv)
     }
     if (verbose) printf("RUN test 5\n");
     trans_tbl_init(merged_hdr, translate, &tbl_5, false, false, true, NULL);
-    finish_merged_header(merged_hdr);
+    finish_merged_header(merged_hdr, 0);
     out = merged_hdr->hdr;
     free_merged_header(merged_hdr);
     if (verbose) printf("END RUN test 5\n");
@@ -529,7 +529,7 @@ int main(int argc, char**argv)
     }
     if (verbose) printf("RUN test 6\n");
     trans_tbl_init(merged_hdr, translate, &tbl_6, false, false, true, "filename");
-    finish_merged_header(merged_hdr);
+    finish_merged_header(merged_hdr, 0);
     out = merged_hdr->hdr;
     free_merged_header(merged_hdr);
     if (verbose) printf("END RUN test 6\n");


### PR DESCRIPTION
Fixes #2159.
The sort order is set to unsorted when the order cannot be maintained after merge.
Also removes the GO and SS tags along with it.,