### PR TITLE
Add a warning for samtools fastq on coordinate sorted data.

### DIFF
--- a/bam_fastq.c
+++ b/bam_fastq.c
@@ -658,6 +658,15 @@ static bool init_state(const bam2fq_opts_t* opts, bam2fq_state_t** state_out)
         return false;
     }
 
+    kstring_t str = KS_INITIALIZE;
+    if (sam_hdr_find_tag_hd(state->h, "SO", &str) == 0 &&
+        strcmp(str.s, "coordinate") == 0) {
+        print_error(opts->filetype == FASTA ? "fasta" : "fastq",
+                    "Coordinate sorted file.  "
+                    "Read pairs may be out of order");
+    }
+    ks_free(&str);
+
     *state_out = state;
     return true;
 }


### PR DESCRIPTION
There can be legitimate cases of samtools fastq/fasta being run on such data, for example when it is single ended, and we do not wish to reorder the file. So making this a hard error may be problematic for existing pipelines.

However it is also a cause of confusion and mistakes to users, so a warning is necessary.

Fixes #2169