### PR TITLE
Clarification for stats with different sorts

### DIFF
--- a/stats.c
+++ b/stats.c
@@ -1537,7 +1537,7 @@ void output_stats(FILE *to, stats_t *stats, int sparse)
     fprintf(to, "SN\traw total sequences:\t%ld\t# excluding supplementary and secondary reads\n", (long)(stats->nreads_filtered+stats->nreads_1st+stats->nreads_2nd+stats->nreads_other));  // not counting excluded seqs (and none of the below)
     fprintf(to, "SN\tfiltered sequences:\t%ld\n", (long)stats->nreads_filtered);
     fprintf(to, "SN\tsequences:\t%ld\n", (long)(stats->nreads_1st+stats->nreads_2nd+stats->nreads_other));
-    fprintf(to, "SN\tis sorted:\t%d\n", stats->is_sorted ? 1 : 0);
+    fprintf(to, "SN\tis sorted:\t%d\t# %s by coordinate\n", stats->is_sorted ? 1 : 0, stats->is_sorted ? "sorted" : "not sorted");
     fprintf(to, "SN\t1st fragments:\t%ld\n", (long)stats->nreads_1st);
     fprintf(to, "SN\tlast fragments:\t%ld\n", (long)stats->nreads_2nd);
     fprintf(to, "SN\treads mapped:\t%ld\n", (long)(stats->nreads_paired_and_mapped+stats->nreads_single_mapped));
@@ -1821,47 +1821,50 @@ void output_stats(FILE *to, stats_t *stats, int sparse)
             fprintf(to, "IC\t%d\t%ld\t%ld\t%ld\t%ld\n", ilen+1, (long)stats->ins_cycles_1st[ilen], (long)stats->ins_cycles_2nd[ilen], (long)stats->del_cycles_1st[ilen], (long)stats->del_cycles_2nd[ilen]);
     }
 
-    fprintf(to, "# Coverage distribution. Use `grep ^COV | cut -f 2-` to extract this part.\n");
-    if  ( stats->cov[0] )
-        fprintf(to, "COV\t[<%d]\t%d\t%ld\n",stats->info->cov_min,stats->info->cov_min-1, (long)stats->cov[0]);
-    for (icov=1; icov<stats->ncov-1; icov++)
-        if ( stats->cov[icov] )
-            fprintf(to, "COV\t[%d-%d]\t%d\t%ld\n",stats->info->cov_min + (icov-1)*stats->info->cov_step, stats->info->cov_min + icov*stats->info->cov_step-1,stats->info->cov_min + icov*stats->info->cov_step-1, (long)stats->cov[icov]);
-    if ( stats->cov[stats->ncov-1] )
-        fprintf(to, "COV\t[%d<]\t%d\t%ld\n",stats->info->cov_min + (stats->ncov-2)*stats->info->cov_step-1,stats->info->cov_min + (stats->ncov-2)*stats->info->cov_step-1, (long)stats->cov[stats->ncov-1]);
+    if (stats->is_sorted) {
+        fprintf(to, "# Coverage distribution. Use `grep ^COV | cut -f 2-` to extract this part.\n");
+        if  ( stats->cov[0] )
+            fprintf(to, "COV\t[<%d]\t%d\t%ld\n",stats->info->cov_min,stats->info->cov_min-1, (long)stats->cov[0]);
+        for (icov=1; icov<stats->ncov-1; icov++)
+            if ( stats->cov[icov] )
+                fprintf(to, "COV\t[%d-%d]\t%d\t%ld\n",stats->info->cov_min + (icov-1)*stats->info->cov_step, stats->info->cov_min + icov*stats->info->cov_step-1,stats->info->cov_min + icov*stats->info->cov_step-1, (long)stats->cov[icov]);
+        if ( stats->cov[stats->ncov-1] )
+            fprintf(to, "COV\t[%d<]\t%d\t%ld\n",stats->info->cov_min + (stats->ncov-2)*stats->info->cov_step-1,stats->info->cov_min + (stats->ncov-2)*stats->info->cov_step-1, (long)stats->cov[stats->ncov-1]);
 
-    // Calculate average GC content, then sort by GC and depth
-    fprintf(to, "# GC-depth. Use `grep ^GCD | cut -f 2-` to extract this part. The columns are: GC%%, unique sequence percentiles, 10th, 25th, 50th, 75th and 90th depth percentile\n");
-    uint32_t igcd;
-    for (igcd=0; igcd<stats->igcd; igcd++)
-    {
-        if ( stats->info->fai )
-            stats->gcd[igcd].gc = rint(100. * stats->gcd[igcd].gc);
-        else
-            if ( stats->gcd[igcd].depth )
-                stats->gcd[igcd].gc = rint(100. * stats->gcd[igcd].gc / stats->gcd[igcd].depth);
-    }
-    if ( stats->ngcd )
-        qsort(stats->gcd, stats->igcd+1, sizeof(gc_depth_t), gcd_cmp);
-    igcd = 0;
-    while ( igcd < stats->igcd )
-    {
-        // Calculate percentiles (10,25,50,75,90th) for the current GC content and print
-        uint32_t nbins=0, itmp=igcd;
-        float gc = stats->gcd[igcd].gc;
-        while ( itmp<stats->igcd && fabs(stats->gcd[itmp].gc-gc)<0.1 )
+
+        // Calculate average GC content, then sort by GC and depth
+        fprintf(to, "# GC-depth. Use `grep ^GCD | cut -f 2-` to extract this part. The columns are: GC%%, unique sequence percentiles, 10th, 25th, 50th, 75th and 90th depth percentile\n");
+        uint32_t igcd;
+        for (igcd=0; igcd<stats->igcd; igcd++)
         {
-            nbins++;
-            itmp++;
+            if ( stats->info->fai )
+                stats->gcd[igcd].gc = rint(100. * stats->gcd[igcd].gc);
+            else
+                if ( stats->gcd[igcd].depth )
+                    stats->gcd[igcd].gc = rint(100. * stats->gcd[igcd].gc / stats->gcd[igcd].depth);
         }
-        fprintf(to, "GCD\t%.1f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\n", gc, (igcd+nbins+1)*100./(stats->igcd+1),
-                gcd_percentile(&(stats->gcd[igcd]),nbins,10) *avg_read_length/stats->info->gcd_bin_size,
-                gcd_percentile(&(stats->gcd[igcd]),nbins,25) *avg_read_length/stats->info->gcd_bin_size,
-                gcd_percentile(&(stats->gcd[igcd]),nbins,50) *avg_read_length/stats->info->gcd_bin_size,
-                gcd_percentile(&(stats->gcd[igcd]),nbins,75) *avg_read_length/stats->info->gcd_bin_size,
-                gcd_percentile(&(stats->gcd[igcd]),nbins,90) *avg_read_length/stats->info->gcd_bin_size
-              );
-        igcd += nbins;
+        if ( stats->ngcd )
+            qsort(stats->gcd, stats->igcd+1, sizeof(gc_depth_t), gcd_cmp);
+        igcd = 0;
+        while ( igcd < stats->igcd )
+        {
+            // Calculate percentiles (10,25,50,75,90th) for the current GC content and print
+            uint32_t nbins=0, itmp=igcd;
+            float gc = stats->gcd[igcd].gc;
+            while ( itmp<stats->igcd && fabs(stats->gcd[itmp].gc-gc)<0.1 )
+            {
+                nbins++;
+                itmp++;
+            }
+            fprintf(to, "GCD\t%.1f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\n", gc, (igcd+nbins+1)*100./(stats->igcd+1),
+                    gcd_percentile(&(stats->gcd[igcd]),nbins,10) *avg_read_length/stats->info->gcd_bin_size,
+                    gcd_percentile(&(stats->gcd[igcd]),nbins,25) *avg_read_length/stats->info->gcd_bin_size,
+                    gcd_percentile(&(stats->gcd[igcd]),nbins,50) *avg_read_length/stats->info->gcd_bin_size,
+                    gcd_percentile(&(stats->gcd[igcd]),nbins,75) *avg_read_length/stats->info->gcd_bin_size,
+                    gcd_percentile(&(stats->gcd[igcd]),nbins,90) *avg_read_length/stats->info->gcd_bin_size
+                  );
+            igcd += nbins;
+        }
     }
 }
 

--- a/test/stat/1.stats.expected
+++ b/test/stat/1.stats.expected
@@ -5,7 +5,7 @@ CHK	1a1c1362	29c426ae	f4bab09e
 SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	1
 SN	reads mapped:	2

--- a/test/stat/1.stats.large.expected
+++ b/test/stat/1.stats.large.expected
@@ -5,7 +5,7 @@ CHK	1a1c1362	29c426ae	f4bab09e
 SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	1
 SN	reads mapped:	2

--- a/test/stat/10.stats.expected
+++ b/test/stat/10.stats.expected
@@ -5,7 +5,7 @@ CHK	343826c4	53884d5c	e975613c
 SN	raw total sequences:	4	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	4
-SN	is sorted:	0
+SN	is sorted:	0	# not sorted by coordinate
 SN	1st fragments:	2
 SN	last fragments:	2
 SN	reads mapped:	4
@@ -420,7 +420,3 @@ LRL	35	2
 MAPQ	40	4
 # Indel distribution. Use `grep ^ID | cut -f 2-` to extract this part. The columns are: length, number of insertions, number of deletions
 # Indels per cycle. Use `grep ^IC | cut -f 2-` to extract this part. The columns are: cycle, number of insertions (fwd), .. (rev) , number of deletions (fwd), .. (rev)
-# Coverage distribution. Use `grep ^COV | cut -f 2-` to extract this part.
-COV	[1-1]	1	70
-# GC-depth. Use `grep ^GCD | cut -f 2-` to extract this part. The columns are: GC%, unique sequence percentiles, 10th, 25th, 50th, 75th and 90th depth percentile
-GCD	0.0	100.000	0.000	0.000	0.000	0.000	0.000

--- a/test/stat/10_map_cigar.sam_s1_a_1.expected.bamstat
+++ b/test/stat/10_map_cigar.sam_s1_a_1.expected.bamstat
@@ -5,7 +5,7 @@ CHK	1a1c1362	29c426ae	f4bab09e
 SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	1
 SN	reads mapped:	2

--- a/test/stat/10_map_cigar.sam_s1_b_1.expected.bamstat
+++ b/test/stat/10_map_cigar.sam_s1_b_1.expected.bamstat
@@ -5,7 +5,7 @@ CHK	1a1c1362	29c426ae	f4bab09e
 SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	1
 SN	reads mapped:	2

--- a/test/stat/11.stats.expected
+++ b/test/stat/11.stats.expected
@@ -5,7 +5,7 @@ CHK	cb2d2d82	bcd83869	d22eda06
 SN	raw total sequences:	26	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	26
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	14
 SN	last fragments:	12
 SN	reads mapped:	26

--- a/test/stat/11.stats.g4.expected
+++ b/test/stat/11.stats.g4.expected
@@ -5,7 +5,7 @@ CHK	cb2d2d82	bcd83869	d22eda06
 SN	raw total sequences:	26	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	26
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	14
 SN	last fragments:	12
 SN	reads mapped:	26

--- a/test/stat/12.2reads.nooverlap.expected
+++ b/test/stat/12.2reads.nooverlap.expected
@@ -5,7 +5,7 @@ CHK	5b31676a	b0edee94	8dfedb9c
 SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	1
 SN	reads mapped:	2

--- a/test/stat/12.2reads.overlap.expected
+++ b/test/stat/12.2reads.overlap.expected
@@ -5,7 +5,7 @@ CHK	5b31676a	b0edee94	8dfedb9c
 SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	1
 SN	reads mapped:	2

--- a/test/stat/12.3reads.nooverlap.expected
+++ b/test/stat/12.3reads.nooverlap.expected
@@ -5,7 +5,7 @@ CHK	09f8b87f	140798ec	db2d0e25
 SN	raw total sequences:	3	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	3
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	2
 SN	reads mapped:	3

--- a/test/stat/12.3reads.overlap.expected
+++ b/test/stat/12.3reads.overlap.expected
@@ -5,7 +5,7 @@ CHK	09f8b87f	140798ec	db2d0e25
 SN	raw total sequences:	3	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	3
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	2
 SN	reads mapped:	3

--- a/test/stat/13.barcodes.bc.ok.expected
+++ b/test/stat/13.barcodes.bc.ok.expected
@@ -5,7 +5,7 @@ CHK	00b48ec6	e5330ff5	c4badc06
 SN	raw total sequences:	2696	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2696
-SN	is sorted:	0
+SN	is sorted:	0	# not sorted by coordinate
 SN	1st fragments:	1348
 SN	last fragments:	1348
 SN	reads mapped:	336
@@ -205,7 +205,3 @@ ID	1	36	1
 IC	4	0	0	0	1
 IC	5	6	1	0	0
 IC	6	14	15	0	0
-# Coverage distribution. Use `grep ^COV | cut -f 2-` to extract this part.
-COV	[2-2]	2	22
-# GC-depth. Use `grep ^GCD | cut -f 2-` to extract this part. The columns are: GC%, unique sequence percentiles, 10th, 25th, 50th, 75th and 90th depth percentile
-GCD	0.0	100.000	0.000	0.000	0.000	0.000	0.000

--- a/test/stat/13.barcodes.ox.ok.expected
+++ b/test/stat/13.barcodes.ox.ok.expected
@@ -5,7 +5,7 @@ CHK	00b48ec6	e5330ff5	c4badc06
 SN	raw total sequences:	2696	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2696
-SN	is sorted:	0
+SN	is sorted:	0	# not sorted by coordinate
 SN	1st fragments:	1348
 SN	last fragments:	1348
 SN	reads mapped:	336
@@ -240,7 +240,3 @@ ID	1	36	1
 IC	4	0	0	0	1
 IC	5	6	1	0	0
 IC	6	14	15	0	0
-# Coverage distribution. Use `grep ^COV | cut -f 2-` to extract this part.
-COV	[2-2]	2	22
-# GC-depth. Use `grep ^GCD | cut -f 2-` to extract this part. The columns are: GC%, unique sequence percentiles, 10th, 25th, 50th, 75th and 90th depth percentile
-GCD	0.0	100.000	0.000	0.000	0.000	0.000	0.000

--- a/test/stat/14.rg.Sample.expected
+++ b/test/stat/14.rg.Sample.expected
@@ -5,7 +5,7 @@ CHK	cb2d2d82	bcd83869	d22eda06
 SN	raw total sequences:	26	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	26
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	14
 SN	last fragments:	12
 SN	reads mapped:	26

--- a/test/stat/14.rg.grp2.expected
+++ b/test/stat/14.rg.grp2.expected
@@ -5,7 +5,7 @@ CHK	2640041e	c45785f6	5d1e6d03
 SN	raw total sequences:	13	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	13
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	7
 SN	last fragments:	6
 SN	reads mapped:	13

--- a/test/stat/14.rg.grp3.expected
+++ b/test/stat/14.rg.grp3.expected
@@ -5,7 +5,7 @@ CHK	00000000	00000000	00000000
 SN	raw total sequences:	0	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	0
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	0
 SN	last fragments:	0
 SN	reads mapped:	0

--- a/test/stat/14.rg.s1.expected
+++ b/test/stat/14.rg.s1.expected
@@ -5,7 +5,7 @@ CHK	1a1c1362	29c426ae	f4bab09e
 SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	1
 SN	reads mapped:	2

--- a/test/stat/15.stats.expected
+++ b/test/stat/15.stats.expected
@@ -5,7 +5,7 @@ CHK	0d0e09b1	c6b1072c	6e349efa
 SN	raw total sequences:	1	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	1
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	0
 SN	reads mapped:	1

--- a/test/stat/1_map_cigar.sam_s1_a_1.expected.bamstat
+++ b/test/stat/1_map_cigar.sam_s1_a_1.expected.bamstat
@@ -5,7 +5,7 @@ CHK	1a1c1362	29c426ae	f4bab09e
 SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	1
 SN	reads mapped:	2

--- a/test/stat/2.stats.expected
+++ b/test/stat/2.stats.expected
@@ -5,7 +5,7 @@ CHK	1a1c1362	29c426ae	f4bab09e
 SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	1
 SN	reads mapped:	2

--- a/test/stat/2.stats.large.expected
+++ b/test/stat/2.stats.large.expected
@@ -5,7 +5,7 @@ CHK	1a1c1362	29c426ae	f4bab09e
 SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	1
 SN	reads mapped:	2

--- a/test/stat/3.stats.expected
+++ b/test/stat/3.stats.expected
@@ -5,7 +5,7 @@ CHK	1a1c1362	ce379e9a	f4bab09e
 SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	1
 SN	reads mapped:	2

--- a/test/stat/3.stats.large.expected
+++ b/test/stat/3.stats.large.expected
@@ -5,7 +5,7 @@ CHK	1a1c1362	ce379e9a	f4bab09e
 SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	1
 SN	reads mapped:	2

--- a/test/stat/4.stats.expected
+++ b/test/stat/4.stats.expected
@@ -5,7 +5,7 @@ CHK	1a1c1362	e7724556	f4bab09e
 SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	1
 SN	reads mapped:	2

--- a/test/stat/4.stats.large.expected
+++ b/test/stat/4.stats.large.expected
@@ -5,7 +5,7 @@ CHK	1a1c1362	e7724556	f4bab09e
 SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	1
 SN	reads mapped:	2

--- a/test/stat/5.stats.expected
+++ b/test/stat/5.stats.expected
@@ -5,7 +5,7 @@ CHK	1a1c1362	32507d92	f4bab09e
 SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	1
 SN	reads mapped:	2

--- a/test/stat/5.stats.large.expected
+++ b/test/stat/5.stats.large.expected
@@ -5,7 +5,7 @@ CHK	1a1c1362	32507d92	f4bab09e
 SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	1
 SN	reads mapped:	2

--- a/test/stat/6.stats.expected
+++ b/test/stat/6.stats.expected
@@ -5,7 +5,7 @@ CHK	1a1c1362	32507d92	f4bab09e
 SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	1
 SN	reads mapped:	2

--- a/test/stat/7.stats.expected
+++ b/test/stat/7.stats.expected
@@ -5,7 +5,7 @@ CHK	272a1d13	10b7aabd	f4baaf9e
 SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	1
 SN	reads mapped:	2

--- a/test/stat/7.stats.large.expected
+++ b/test/stat/7.stats.large.expected
@@ -5,7 +5,7 @@ CHK	272a1d13	10b7aabd	f4baaf9e
 SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	1
 SN	reads mapped:	2

--- a/test/stat/8.stats.expected
+++ b/test/stat/8.stats.expected
@@ -5,7 +5,7 @@ CHK	272a1d13	94e79452	ef1808ed
 SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	1
 SN	reads mapped:	2

--- a/test/stat/8.stats.large.expected
+++ b/test/stat/8.stats.large.expected
@@ -5,7 +5,7 @@ CHK	272a1d13	94e79452	ef1808ed
 SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	1
 SN	reads mapped:	2

--- a/test/stat/9.stats.expected
+++ b/test/stat/9.stats.expected
@@ -5,7 +5,7 @@ CHK	1a1c1362	29c426ae	f4bab09e
 SN	raw total sequences:	2	# excluding supplementary and secondary reads
 SN	filtered sequences:	0
 SN	sequences:	2
-SN	is sorted:	1
+SN	is sorted:	1	# sorted by coordinate
 SN	1st fragments:	1
 SN	last fragments:	1
 SN	reads mapped:	2


### PR DESCRIPTION
Added clarification to sort type. Removed COV and GCD entries from name sorted stats results.

Fixes #2177.