### PR TITLE
Added fish completions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ bindir      = $(exec_prefix)/bin
 datarootdir = $(prefix)/share
 mandir      = $(datarootdir)/man
 man1dir     = $(mandir)/man1
+fishcompdir = $(datarootdir)/fish/vendor_completions.d
 
 # Installation location for $(MISC_PROGRAMS) and $(MISC_SCRIPTS)
 misc_bindir = $(bindir)
@@ -325,11 +326,12 @@ misc/maq2sam-long.o: misc/maq2sam.c config.h version.h
 
 
 install: $(PROGRAMS) $(MISC_PROGRAMS)
-	$(INSTALL_DIR) $(DESTDIR)$(bindir) $(DESTDIR)$(misc_bindir) $(DESTDIR)$(man1dir)
+	$(INSTALL_DIR) $(DESTDIR)$(bindir) $(DESTDIR)$(misc_bindir) $(DESTDIR)$(man1dir) $(DESTDIR)$(fishcompdir)
 	$(INSTALL_PROGRAM) $(PROGRAMS) $(DESTDIR)$(bindir)
 	$(INSTALL_PROGRAM) $(MISC_PROGRAMS) $(DESTDIR)$(misc_bindir)
 	$(INSTALL_SCRIPT) $(MISC_SCRIPTS) $(DESTDIR)$(misc_bindir)
 	$(INSTALL_MAN) doc/samtools*.1 misc/wgsim.1 $(DESTDIR)$(man1dir)
+	$(INSTALL_DATA) misc/samtools_tab_completion.fish $(DESTDIR)$(fishcompdir)/samtools.fish
 
 
 testclean:

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@ New work and changes:
 * `samtools consensus` now supports proper multi-threading.  Previously
   this was restricted to decompression only, but it should now scale better.
 
+* Added fish shell completions. For full functionality they require
+  Python3.5+ and installed samtools manpages.
+
 Bug fixes:
 
 * `samtools consensus` previously could give different results for BAM and

--- a/misc/samtools_tab_completion.fish
+++ b/misc/samtools_tab_completion.fish
@@ -1,0 +1,79 @@
+################################################################################
+#
+# The MIT License
+#
+# Copyright 2025 LunarEclipse <luna@lunareclipse.zone>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the “Software”), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+################################################################################
+
+# Collect subcommands and their descriptions into a variable for later use
+# Exclude "help" because "samtools help help" won't work (and wouldn't parse correctly)
+set -l __fish_samtools_subcommands (samtools 2>&1 \
+    | string match --entire --regex '^   ' \
+    | string trim \
+    | string replace --regex '\s{2,}' \t \
+    | string match --invert 'help*' \
+    | string escape \
+)
+# Add "help" back to an extra helper variable
+set -l __fish_samtools_subcommands_with_help $__fish_samtools_subcommands
+set -la __fish_samtools_subcommands_with_help "help\\t'print help for a subcommand'"
+
+# Subcommands
+complete -c samtools --no-files --condition __fish_use_subcommand -a "$__fish_samtools_subcommands_with_help"
+complete -c samtools --no-files --condition '__fish_seen_subcommand_from help' --require-parameter -a "$__fish_samtools_subcommands"
+
+# Generation from manpages doesn't work well for root options
+complete -c samtools --condition __fish_use_subcommand -l help -d 'Print help for a subcommand.' --no-files --require-parameter -a "$__fish_samtools_subcommands"
+complete -c samtools --condition __fish_use_subcommand -l version -d 'Display the version numbers and copyright information for samtools and the libraries it uses.'
+complete -c samtools --condition __fish_use_subcommand -l version-only -d 'Display the full version number in a machine-readable format.'
+
+# Determine if and where the samtools manpages are installed
+which python3 &>/dev/null
+and python3 -c "import sys, os; sys.path.append('$__fish_data_dir/tools'); from create_manpage_completions import get_paths_from_man_locations; print(os.path.dirname([x for x in get_paths_from_man_locations() if 'samtools.1' in x][0]))" 2>/dev/null | read -l __fish_samtools_man_path
+and set -l __fish_samtools_manpages "$__fish_samtools_man_path"/samtools-*
+
+# Generate completions for subcommands from manpages if they're available
+# Otherwise fall back to the approach bash completions take
+if count $__fish_samtools_manpages &>/dev/null
+    "$__fish_data_dir"/tools/create_manpage_completions.py --stdout $__fish_samtools_manpages \
+        | string replace --regex -- '-c samtools-(\w+)' '-c samtools -n \'__fish_seen_subcommand_from $1\'' \
+        | read -lz __fish_samtools_subcommand_completions
+    eval "$__fish_samtools_subcommand_completions"
+else
+    for subcommand in (string unescape $__fish_samtools_subcommands | string match --regex '.*\t' | string trim);
+        for line in $(samtools help "$subcommand" 2>&1);
+            # Note: this will only use the last version of a long argument
+            # Note: this will ignore long commands containing braces or other special characters
+            # https://regex101.com/r/4IYuNh/5
+            string match --quiet --regex '(?J)(?:(?:[ ,]-(?<short>[\w@?])[ ,])*(?=.*?)(?:[ ,]--(?<long>[-\w_]+)(?:[ ,]|$))|(?:^|Options?:?) *(?:[ ,]?(?:\(or )?-(?<short>[\w@?]{1,2})[ ,)])+)' "$line"; or continue
+
+            if count $short &>/dev/null
+                set arg_short --short-option "$short"
+                test (string length $short) -gt 1; and set arg_short --old-option "$short"
+            end
+            count $long &>/dev/null; and set arg_long --long-option "$long"
+
+            complete -c samtools --condition "__fish_seen_subcommand_from $subcommand" $arg_short $arg_long
+        end
+    end
+end
+


### PR DESCRIPTION
## Introduction

This PR adds comprehensive completions for use with the [fish shell](https://fishshell.com/).

This includes:
- finding all subcommands and their descriptions from the output of `samtools`
- if `python3` is available and samtools manpages are installed, generates comprehensive completions with descriptions for the subcommands
- otherwise generates barebones completions for subcommands from the outputs of `samtools help $subcommand` (slightly better than the already provided bash completions)

I also added an entry in the changelog.

## Demonstration of the full capabilities
![image](https://github.com/user-attachments/assets/4dee62af-abc8-4e84-ad53-cca7bce1ac91)
![image](https://github.com/user-attachments/assets/83b88129-d08f-4e9b-a252-5da77b537a76)

## Notes
I initially tried using the fallback approach as the primary one but after half a day of work realized that the `samtools help` outputs aren't consistent enough to write a regex to parse them reliably and which could extract all the data (all versions of each flag, what kind of value they take if any, descriptions).  
Or if it can be done it's so complex I decided it's now worth it.  
Doing that somewhat reasonably would require enforcing a strict style guide for help pages like "exactly one space between a flag and its value" and "at least two spaces between the flags/values and descriptions" and I feel like that's not feasible, so I went for extremely limited parsing in this regard and instead used a script bundled with fish to generate high quality completions from manpages (somehow this only worked well for the subcommands, not the main samtools command).

In any case, I'm quite happy with how this turned out and hope that I've fixed all the little bugs in it by now.
