### PR TITLE
Don't use consensus N for "*" calls that are of insufficient depth.

### DIFF
--- a/bam_consensus.c
+++ b/bam_consensus.c
@@ -2141,7 +2141,7 @@ int consensus_base(consensus_opts *opts,
         calculate_consensus_gap5m(pos, opts->use_mqual ? CONS_MQUAL : 0,
                                   depth, p, opts, &cons, opts->default_qual,
                                   &cons_prob_recall, &cons_prob_precise);
-        if (cons.depth < opts->min_depth) {
+        if (cons.depth < opts->min_depth && cons.call != 4) {
             //  && cons.call != 4.  See #2167
             cb = 'N';
             cq = 0;


### PR DESCRIPTION
The intention of the -d depth parameter is to only call a base when we have sufficient confidence in the number of observations to call the base type.  If it's insufficient depth then we call N.  However this is an assertion that there is a base, we just don't wish to say which.

A column with mostly "*" (absent) and one single base (eg an overcall error) should not be changed to N even when the depth is low as this is asserting there is a base of some description there, which is unlikely.

Fixes #2167