### PR TITLE
Upgrade to _XOPEN_SOURCE=700, to match HTSlib

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -85,7 +85,7 @@ gcc_task:
     DO_MAINTAINER_CHECKS: yes
     # gcc ubsan is incompatible with some -Wformat options, but they're checked
     # in other tests.  See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=87884
-    CFLAGS: -g -Og -std=c99 -D_XOPEN_SOURCE=600 -pedantic -fsanitize=address,undefined -Wno-format-truncation -Wno-format-overflow
+    CFLAGS: -g -Og -std=c99 -D_XOPEN_SOURCE=700 -pedantic -fsanitize=address,undefined -Wno-format-truncation -Wno-format-overflow
     CPPFLAGS: -DHTS_ALLOW_UNALIGNED=0
     LDFLAGS: -fsanitize=address,undefined
     UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ CC       = gcc
 AR       = ar
 AWK      = awk
 CPPFLAGS =
-#CFLAGS   = -g -Wall -O2 -pedantic -std=c99 -D_XOPEN_SOURCE=600
+#CFLAGS   = -g -Wall -O2 -pedantic -std=c99 -D_XOPEN_SOURCE=700
 CFLAGS   = -g -Wall -O2
 LDFLAGS  =
 LIBS     =

--- a/bam_consensus.c
+++ b/bam_consensus.c
@@ -2717,7 +2717,8 @@ int pileup_loop_parallel(consensus_opts *opts) {
             }
 
             if (blk == -1) {
-                usleep(1000);
+                struct timespec req = { 0, 1000000 };
+                nanosleep(&req, NULL);
             } else {
                 c = NULL;
                 sub_start += opts->span;
@@ -2726,8 +2727,10 @@ int pileup_loop_parallel(consensus_opts *opts) {
         }
 
         while (received < counter) {
-            while (!(r = hts_tpool_next_result(q)))
-                usleep(1000);
+            while (!(r = hts_tpool_next_result(q))) {
+                struct timespec req = { 0, 1000000 };
+                nanosleep(&req, NULL);
+            }
             ctx *c = (ctx *)hts_tpool_result_data(r);
             if (opts->fmt == PILEUP) {
                 kstring_t *ks = &c->ks_pileup;
@@ -2758,8 +2761,10 @@ int pileup_loop_parallel(consensus_opts *opts) {
 
     // Discard any inflight jobs.  Can this happen?  Perhaps on error.
     while (received < counter) {
-        while (!(r = hts_tpool_next_result(q)))
-            usleep(1000);
+        while (!(r = hts_tpool_next_result(q))) {
+            struct timespec req = { 0, 1000000 };
+            nanosleep(&req, NULL);
+        }
         ctx *c = (ctx *)hts_tpool_result_data(r);
         ks_free(&c->ks_pileup);
         ks_free(&c->ks_ins_seq);

--- a/configure.ac
+++ b/configure.ac
@@ -137,7 +137,7 @@ case $host_alias in
     # This also sets __USE_MINGW_ANSI_STDIO which in turn makes PRId64,
     # %lld and %z printf formats work.  It also enforces the snprintf to
     # be C99 compliant so it returns the correct values (in kstring.c).
-    CPPFLAGS="$CPPFLAGS -D_XOPEN_SOURCE=600"
+    CPPFLAGS="$CPPFLAGS -D_XOPEN_SOURCE=700"
     ;;
 esac
 


### PR DESCRIPTION
HTSlib now needs `_XOPEN_SOURCE=700`, mainly for `ref-cache`.  Upgrade SAMtools to match.  This mainly affects the CI builds, and Windows with an embedded HTSlib, where SAMtools' setting could override the one expected by HTSlib.

Replace a few instances of `usleep()` with `nanosleep()` as the former was deprecated and removed from `_XOPEN_SOURCE=700` onwards.