### PR TITLE
Fix URL to online documentation in `seq_cache_populate.pl`

### DIFF
--- a/misc/seq_cache_populate.pl
+++ b/misc/seq_cache_populate.pl
@@ -99,7 +99,7 @@ if ($find) {
 print "\n";
 print "Use environment REF_CACHE=$root_dir" . "/%2s" x $subdirs .
     "/%s for accessing these files.\n";
-print "See also https://www.htslib.org/workflow/#the-ref_path-and-ref_cache for\nfurther information.\n";
+print "See also https://www.htslib.org/workflow/cram#the-ref_path-and-ref_cache for\nfurther information.\n";
 exit;
 
 sub find_files {


### PR DESCRIPTION
<https://www.htslib.org/workflow/#the-ref_path-and-ref_cache> returns 404 but <https://www.htslib.org/workflow/cram#the-ref_path-and-ref_cache> works…