### PR TITLE
minor wording update and typo corrections (partly fixes #1209)

### DIFF
--- a/bam_index.c
+++ b/bam_index.c
@@ -52,7 +52,7 @@ static void index_usage(FILE *fp)
 "  -m, --min-shift INT  Set minimum interval size for CSI indices to 2^INT [%d]\n"
 "  -M                   Interpret all filename arguments as files to be indexed\n"
 "  -o, --output FILE    Write index to FILE [alternative to <out.index> in args]\n"
-"  -@, --threads INT    Sets the number of threads [none]\n", BAM_LIDX_SHIFT);
+"  -@, --threads INT    Sets the number of additional threads [0]\n", BAM_LIDX_SHIFT);
 }
 
 // Returns 1 if the file does not exist or can be positively

--- a/doc/samtools-reset.1
+++ b/doc/samtools-reset.1
@@ -114,11 +114,11 @@ By default the PG entry for reset will be present in the output.
 Keep the duplicate flag as it is. This option is absent by default and alignments are marked non-duplicates.
 
 .TP
-.BI -@,--thread\  N
+.BI "-@, --threads " N
 This gives the number of worker threads to be used.
 
 .TP
-.BI -O,--output-fmt\  FMT[,options]
+.BI "-O, --output-fmt " FMT[,options]
 Sets the format of the output file and any associated format-specific options.
 If this option is not present, the format is identified from the output file name extension.
 


### PR DESCRIPTION
Updated wordings on samtools index to make it clear that it is the additional threads that are being set by -@ option. Partly fixes #1209. Other part was already fixed by #1872 as part of another issue.

Also updated samtools reset man page for a typo and spacing.