### PR TITLE
Add a link to samtools.1 manpage for global opts in usage.

### DIFF
--- a/sam_opts.c
+++ b/sam_opts.c
@@ -173,6 +173,8 @@ void sam_global_opt_help(FILE *fp, const char *shortopts) {
             fprintf(fp,"verbosity INT\n"
                     "               Set level of verbosity\n");
     }
+
+    fprintf(fp, "\nSee https://www.htslib.org/doc/samtools.html#GLOBAL_COMMAND_OPTIONS\nfor more details.\n");
 }
 
 void sam_global_args_init(sam_global_args *ga) {


### PR DESCRIPTION
Addresses issue raised in #2236 with a pointer to where to find the list of acceptable input-fmt-option and output-fmt-option keywords. Many people don't think to look at the global samtools.1 man-page for such things.  Arguably we should edit every manpage too referring back to this, but this is an easy and more discoverable fix.