### PR TITLE
updated to make consensus work with sam.gz along with threads and ite…

### DIFF
--- a/bam_consensus.c
+++ b/bam_consensus.c
@@ -2614,7 +2614,7 @@ int pileup_loop_parallel(consensus_opts *opts) {
         thread; filters requiring header also needs this irrespective of file
         type; it is easy to copy from tdata[0] rather than reading and parsing;
         will be released along with file close */
-        tdata[i].fp->bam_header = sam_hdr_dup(tdata[0].fp->bam_header);
+        sam_hdr_set(tdata[i].fp, opts->h, 0);
     }
 
     pool = hts_tpool_init(opts->nthreads);


### PR DESCRIPTION
Consensus crashes when sam.gz is used as input along with threads and iterators.
This happens due to the data validation attempt in sam_parse1 where fp->bam_header, which is null, is used for header.
To avoid this, each fp in thread data is set with a copy of already read header.
This is made for bam and cram as well, for filters to work fine where an expression needs to access the header (like rname, mrname, library etc.)