### PR TITLE
Add missing sam_global_args_free calls.

### DIFF
--- a/amplicon_stats.c
+++ b/amplicon_stats.c
@@ -1770,6 +1770,7 @@ int main_ampliconstats(int argc, char **argv) {
 
     free(args.argv);
     destroy_bed_hash(bed_hash);
+    sam_global_args_free(&args.ga);
 
     return ret;
 }

--- a/bam_checksum.c
+++ b/bam_checksum.c
@@ -1318,5 +1318,7 @@ int main_checksum(int argc, char **argv) {
     if (ret)
         fprintf(stderr, "[checksum] Failed to process data\n");
 
+    sam_global_args_free(&ga);
+
     return ret;
 }

--- a/bam_import.c
+++ b/bam_import.c
@@ -539,5 +539,7 @@ int main_import(int argc, char *argv[]) {
     if (opts.p.pool)
         hts_tpool_destroy(opts.p.pool);
 
+    sam_global_args_free(&opts.ga);
+
     return ret;
 }

--- a/bam_md.c
+++ b/bam_md.c
@@ -515,6 +515,7 @@ int bam_fillmd(int argc, char *argv[])
         return 1;
     }
     if (p.pool) hts_tpool_destroy(p.pool);
+    sam_global_args_free(&ga);
 
     return 0;
 
@@ -527,6 +528,7 @@ int bam_fillmd(int argc, char *argv[])
     if (fp) sam_close(fp);
     if (fpout) sam_close(fpout);
     if (p.pool) hts_tpool_destroy(p.pool);
+    sam_global_args_free(&ga);
 
     return 1;
 }

--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -1220,5 +1220,6 @@ int bam_mpileup(int argc, char *argv[])
     if (mplp.fai) fai_destroy(mplp.fai);
     if (mplp.bed) bed_destroy(mplp.bed);
     if (mplp.auxlist) kl_destroy(auxlist, (klist_t(auxlist) *)mplp.auxlist);
+    sam_global_args_free(&mplp.ga);
     return ret;
 }

--- a/bam_tview.c
+++ b/bam_tview.c
@@ -550,5 +550,7 @@ int bam_tview_main(int argc, char *argv[])
     tv->my_loop(tv);
     tv->my_destroy(tv);
 
+    sam_global_args_free(&ga);
+
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
These are a memory leak if we use e.g. --input-fmt-options decode_md. Some tools still leak if they get errors and return early, but this is true in many other ways too (for example calmd doesn't destroy the thread pool if it gets an error closing fpout; one among many). However I focused on removing memory leaks on successful execution (albeit harmless due to immediately exiting anyway) as it's more likely to trip up testing.