### PR TITLE
Ignore hard clips in template coordinate sort

### DIFF
--- a/bam.c
+++ b/bam.c
@@ -157,8 +157,10 @@ rmB_err:
     return -1;
 }
 
-/* Calculate the current read's start based on the stored cigar string. */
-hts_pos_t unclipped_start(bam1_t *b) {
+/* Calculate the current read's start based on the stored cigar string.
+   If include_hard_clips is true, both soft and hard clips are considered.
+   If false, only soft clips are considered. */
+hts_pos_t unclipped_start(bam1_t *b, int include_hard_clips) {
     uint32_t *cigar = bam_get_cigar(b);
     int64_t clipped = 0;
     uint32_t i;
@@ -166,9 +168,9 @@ hts_pos_t unclipped_start(bam1_t *b) {
     for (i = 0; i < b->core.n_cigar; i++) {
         char c = bam_cigar_opchr(cigar[i]);
 
-        if (c == 'S' || c == 'H') { // clips
+        if (c == 'S' || (include_hard_clips && c == 'H')) { // clips
             clipped += bam_cigar_oplen(cigar[i]);
-        } else {
+        } else if (c != 'H') {
             break;
         }
     }
@@ -176,8 +178,10 @@ hts_pos_t unclipped_start(bam1_t *b) {
     return b->core.pos - clipped + 1;
 }
 
-/* Calculate the mate's unclipped start based on position and cigar string from MC tag. */
-hts_pos_t unclipped_other_start(hts_pos_t op, char *cigar) {
+/* Calculate the mate's unclipped start based on position and cigar string from MC tag.
+   If include_hard_clips is true, both soft and hard clips are considered.
+   If false, only soft clips are considered. */
+hts_pos_t unclipped_other_start(hts_pos_t op, char *cigar, int include_hard_clips) {
     char *c = cigar;
     int64_t clipped = 0;
 
@@ -190,9 +194,9 @@ hts_pos_t unclipped_other_start(hts_pos_t op, char *cigar) {
             num = 1;
         }
 
-        if (*c == 'S' || *c == 'H') { // clips
+        if (*c == 'S' || (include_hard_clips && *c == 'H')) { // clips
             clipped += num;
-        } else {
+        } else if (*c != 'H') {
             break;
         }
 
@@ -202,8 +206,10 @@ hts_pos_t unclipped_other_start(hts_pos_t op, char *cigar) {
     return op - clipped + 1;
 }
 
-/* Calculate the current read's end based on the stored cigar string. */
-hts_pos_t unclipped_end(bam1_t *b) {
+/* Calculate the current read's end based on the stored cigar string.
+   If include_hard_clips is true, both soft and hard clips are considered.
+   If false, only soft clips are considered. */
+hts_pos_t unclipped_end(bam1_t *b, int include_hard_clips) {
     uint32_t *cigar = bam_get_cigar(b);
     hts_pos_t end_pos, clipped = 0;
     int32_t i;
@@ -216,9 +222,9 @@ hts_pos_t unclipped_end(bam1_t *b) {
     for (i = b->core.n_cigar - 1; i >= 0; i--) {
         char c = bam_cigar_opchr(cigar[i]);
 
-        if (c == 'S' || c == 'H') { // clips
+        if (c == 'S' || (include_hard_clips && c == 'H')) { // clips
             clipped += bam_cigar_oplen(cigar[i]);
-        } else {
+        } else if (c != 'H') {
             break;
         }
     }
@@ -227,8 +233,10 @@ hts_pos_t unclipped_end(bam1_t *b) {
 }
 
 
-/* Calculate the mate's unclipped end based on start position and cigar string from MC tag.*/
-hts_pos_t unclipped_other_end(int64_t op, char *cigar) {
+/* Calculate the mate's unclipped end based on start position and cigar string from MC tag.
+   If include_hard_clips is true, both soft and hard clips are considered.
+   If false, only soft clips are considered. */
+hts_pos_t unclipped_other_end(int64_t op, char *cigar, int include_hard_clips) {
     char *c = cigar;
     int64_t refpos = 0;
     int skip = 1;
@@ -253,10 +261,15 @@ hts_pos_t unclipped_other_end(int64_t op, char *cigar) {
             break;
 
             case 'S':
-            case 'H':
                 if (!skip) {
-                refpos += num;
-            }
+                    refpos += num;
+                }
+            break;
+
+            case 'H':
+                if (!skip && include_hard_clips) {
+                    refpos += num;
+                }
             break;
         }
 

--- a/bam.h
+++ b/bam.h
@@ -31,9 +31,9 @@ int bam_remove_B(bam1_t *b);
 
 const char *bam_get_library(sam_hdr_t *header, const bam1_t *b);
 
-hts_pos_t unclipped_start(bam1_t *b);
-hts_pos_t unclipped_other_start(hts_pos_t op, char *cigar);
-hts_pos_t unclipped_end(bam1_t *b);
-hts_pos_t unclipped_other_end(int64_t op, char *cigar);
+hts_pos_t unclipped_start(bam1_t *b, int include_hard_clips);
+hts_pos_t unclipped_other_start(hts_pos_t op, char *cigar, int include_hard_clips);
+hts_pos_t unclipped_end(bam1_t *b, int include_hard_clips);
+hts_pos_t unclipped_other_end(int64_t op, char *cigar, int include_hard_clips);
 
 #endif

--- a/bam_markdup.c
+++ b/bam_markdup.c
@@ -304,8 +304,8 @@ static int make_pair_key(md_param_t *param, key_data_t *key, bam1_t *bam, int rg
     this_ref    = bam->core.tid + 1; // avoid a 0 being put into the hash
     other_ref   = bam->core.mtid + 1;
 
-    this_coord = unclipped_start(bam);
-    this_end   = unclipped_end(bam);
+    this_coord = unclipped_start(bam, 1);
+    this_end   = unclipped_end(bam, 1);
 
     if ((data = bam_aux_get(bam, "MC"))) {
         if (!(cig = bam_aux2Z(data))) {
@@ -313,8 +313,8 @@ static int make_pair_key(md_param_t *param, key_data_t *key, bam1_t *bam, int rg
             return 1;
         }
 
-        other_end   = unclipped_other_end(bam->core.mpos, cig);
-        other_coord = unclipped_other_start(bam->core.mpos, cig);
+        other_end   = unclipped_other_end(bam->core.mpos, cig, 1);
+        other_coord = unclipped_other_start(bam->core.mpos, cig, 1);
     } else {
         print_error("markdup", "error, no MC tag. Please run samtools fixmate on file first.\n");
         return 1;
@@ -469,15 +469,15 @@ static int make_pair_key(md_param_t *param, key_data_t *key, bam1_t *bam, int rg
         }
 
         if (!bam_is_rev(bam)) {
-            this_coord = unclipped_start(bam);
+            this_coord = unclipped_start(bam, 1);
         } else {
-            this_coord = unclipped_end(bam);
+            this_coord = unclipped_end(bam, 1);
         }
 
         if (!bam_is_mrev(bam)) {
-            other_coord = unclipped_other_start(bam->core.mpos, cig);
+            other_coord = unclipped_other_start(bam->core.mpos, cig, 1);
         } else {
-            other_coord = unclipped_other_end(bam->core.mpos, cig);
+            other_coord = unclipped_other_end(bam->core.mpos, cig, 1);
         }
     }
 
@@ -565,10 +565,10 @@ static void make_single_key(md_param_t *param, key_data_t *key, bam1_t *bam, int
     this_ref = bam->core.tid + 1; // avoid a 0 being put into the hash
 
     if (bam_is_rev(bam)) {
-        this_coord = unclipped_end(bam);
+        this_coord = unclipped_end(bam, 1);
         orientation = O_RR;
     } else {
-        this_coord = unclipped_start(bam);
+        this_coord = unclipped_start(bam, 1);
         orientation = O_FF;
     }
 

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -2214,7 +2214,7 @@ static template_coordinate_key_t* template_coordinate_key(bam1_t *b, template_co
     if (!(b->core.flag & BAM_FUNMAP)) { // read is mapped, update coordinates
         key->tid1 = b->core.tid;
         key->neg1 = bam_is_rev(b);
-        key->pos1 = (key->neg1) ? unclipped_end(b) : unclipped_start(b);
+        key->pos1 = (key->neg1) ? unclipped_end(b, 0) : unclipped_start(b, 0);
     }
     if (b->core.flag & BAM_FPAIRED && !(b->core.flag & BAM_FMUNMAP)) { // mate is mapped, update coordinates
         char *cigar;
@@ -2229,7 +2229,7 @@ static template_coordinate_key_t* template_coordinate_key(bam1_t *b, template_co
         }
         key->tid2 = b->core.mtid;
         key->neg2 = bam_is_mrev(b);
-        key->pos2 = (key->neg2) ? unclipped_other_end(b->core.mpos, cigar) : unclipped_other_start(b->core.mpos, cigar);
+        key->pos2 = (key->neg2) ? unclipped_other_end(b->core.mpos, cigar, 0) : unclipped_other_start(b->core.mpos, cigar, 0);
     }
 
     if ((data = bam_aux_get(b, "CB"))) {

--- a/test/sort/template-coordinate-hardclip.sort.expected.sam
+++ b/test/sort/template-coordinate-hardclip.sort.expected.sam
@@ -1,0 +1,13 @@
+@HD	VN:1.6	SO:unsorted	GO:query	SS:unsorted:template-coordinate
+@SQ	SN:ref1	LN:200
+@RG	ID:grp1	LB:lib1
+pair_D	99	ref1	20	60	3S10M	=	50	40	AAAAAAAAAAAAA	*************	RG:Z:grp1	MC:Z:3S10M
+pair_D	147	ref1	50	60	3S10M	=	20	-40	AAAAAAAAAAAAA	*************	RG:Z:grp1	MC:Z:3S10M
+pair_E	99	ref1	20	60	5H3S10M	=	50	40	AAAAAAAAAAAAA	*************	RG:Z:grp1	MC:Z:5H3S10M
+pair_E	147	ref1	50	60	5H3S10M	=	20	-40	AAAAAAAAAAAAA	*************	RG:Z:grp1	MC:Z:5H3S10M
+pair_A	99	ref1	20	60	10M	=	50	40	AAAAAAAAAA	**********	RG:Z:grp1	MC:Z:10M
+pair_A	147	ref1	50	60	10M	=	20	-40	AAAAAAAAAA	**********	RG:Z:grp1	MC:Z:10M
+pair_B	99	ref1	20	60	5H10M	=	50	40	AAAAAAAAAA	**********	RG:Z:grp1	MC:Z:5H10M
+pair_B	147	ref1	50	60	5H10M	=	20	-40	AAAAAAAAAA	**********	RG:Z:grp1	MC:Z:5H10M
+pair_C	99	ref1	20	60	10H10M	=	50	40	AAAAAAAAAA	**********	RG:Z:grp1	MC:Z:10H10M
+pair_C	147	ref1	50	60	10H10M	=	20	-40	AAAAAAAAAA	**********	RG:Z:grp1	MC:Z:10H10M

--- a/test/sort/template-coordinate-hardclip.sort.sam
+++ b/test/sort/template-coordinate-hardclip.sort.sam
@@ -1,0 +1,13 @@
+@HD	VN:1.6	SO:unsorted
+@SQ	SN:ref1	LN:200
+@RG	ID:grp1	LB:lib1
+pair_A	99	ref1	20	60	10M	=	50	40	AAAAAAAAAA	**********	RG:Z:grp1	MC:Z:10M
+pair_A	147	ref1	50	60	10M	=	20	-40	AAAAAAAAAA	**********	RG:Z:grp1	MC:Z:10M
+pair_B	99	ref1	20	60	5H10M	=	50	40	AAAAAAAAAA	**********	RG:Z:grp1	MC:Z:5H10M
+pair_B	147	ref1	50	60	5H10M	=	20	-40	AAAAAAAAAA	**********	RG:Z:grp1	MC:Z:5H10M
+pair_C	99	ref1	20	60	10H10M	=	50	40	AAAAAAAAAA	**********	RG:Z:grp1	MC:Z:10H10M
+pair_C	147	ref1	50	60	10H10M	=	20	-40	AAAAAAAAAA	**********	RG:Z:grp1	MC:Z:10H10M
+pair_D	99	ref1	20	60	3S10M	=	50	40	AAAAAAAAAAAAA	*************	RG:Z:grp1	MC:Z:3S10M
+pair_D	147	ref1	50	60	3S10M	=	20	-40	AAAAAAAAAAAAA	*************	RG:Z:grp1	MC:Z:3S10M
+pair_E	99	ref1	20	60	5H3S10M	=	50	40	AAAAAAAAAAAAA	*************	RG:Z:grp1	MC:Z:5H3S10M
+pair_E	147	ref1	50	60	5H3S10M	=	20	-40	AAAAAAAAAAAAA	*************	RG:Z:grp1	MC:Z:5H3S10M

--- a/test/test.pl
+++ b/test/test.pl
@@ -3462,6 +3462,9 @@ sub test_sort
     # TemplateCoordinate sort with cell barcode (CB tag): reads group by cell then by molecule within cell
     test_cmd($opts, out=>"sort/template-coordinate.cell-barcode.sort.expected.sam", ignore_pg_header => 1, cmd=>"$$opts{bin}/samtools sort${threads} --template-coordinate -m 10M $$opts{path}/sort/template-coordinate.cell-barcode.sort.sam -O SAM -o -");
 
+    # TemplateCoordinate sort - verify hard clips are ignored (only soft clips affect sort position)
+    test_cmd($opts, out=>"sort/template-coordinate-hardclip.sort.expected.sam", ignore_pg_header => 1, cmd=>"$$opts{bin}/samtools sort${threads} --template-coordinate -m 10M $$opts{path}/sort/template-coordinate-hardclip.sort.sam -O SAM -o -");
+
     # Minimiser sort, basic
     test_cmd($opts, out=>"sort/minimiser-basic.sam", ignore_pg_header => 1, cmd=>"$$opts{bin}/samtools reset  --dupflag $$opts{path}/dat/auto_indexed.tmp.bam | $$opts{bin}/samtools sort${threads} -m 10M -M -K10 -O SAM -o -");
 


### PR DESCRIPTION
Hard clipping may be variable for reads from the same biochemical template, causing them to sort to different positions. Only soft clips are now considered when calculating unclipped coordinates for template coordinate sorting, matching fgbio behavior.

See: https://github.com/fulcrumgenomics/fgbio/pull/1065

The unclipped_start/end functions now take an include_hard_clips parameter. Template coordinate sort passes 0 (soft clips only), while markdup passes 1 to preserve existing behavior.

Adds test for hard clip handling in template coordinate sort.