### PR TITLE
Use canonical calloc arguments order for parsed_opts_t allocation

### DIFF
--- a/bam_split.c
+++ b/bam_split.c
@@ -512,7 +512,7 @@ static state_t* init(parsed_opts_t* opts, const char *arg_list)
 {
     kstring_t ss = KS_INITIALIZE;
     char ss_req[32] = {0};
-    state_t* retval = calloc(sizeof(state_t), 1);
+    state_t* retval = calloc(1, sizeof(state_t));
     if (!retval) {
         print_error_errno("split", "Initialisation failed");
         return NULL;


### PR DESCRIPTION
This commit should NOT produce any change in behavior; swapping the order of the arguments to `calloc()` does NOT affect the behavior of `calloc()`. Thus, the main purpose of this commit is to improve code readability and conformity.

---------

Background: The [C standard](https://en.cppreference.com/w/c/memory/calloc.html) defines the prototype as `calloc(size_t num, size_t size)`. Importantly, "If allocation succeeds, returns a pointer to the lowest (first) byte in the allocated memory block that is suitably aligned for any object type with fundamental alignment."

As `calloc()` only sees the quantity and size of the objects to allocate memory (but NOT the type of the data itself), alignment is not directly dependent on the `size` or `num` argument.