### PR TITLE
Add seq_cache_populate.py to MISC_SCRIPTS for installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ MISC_SCRIPTS = \
 	misc/fasta-sanitize.pl misc/interpolate_sam.pl misc/novo2sam.pl \
 	misc/plot-ampliconstats misc/plot-bamstats misc/psl2sam.pl \
 	misc/sam2vcf.pl misc/samtools.pl misc/seq_cache_populate.pl \
+	misc/seq_cache_populate.py \
 	misc/soap2sam.pl misc/wgsim_eval.pl misc/zoom2sam.pl
 
 TEST_PROGRAMS = \


### PR DESCRIPTION
The faster python script contributed by @rhpvorderman in #2231 is currently available only in the source tree. It should be installed to `{prefix}/bin/` along with the other scripts so that it can be used with common installation like `brew install samtools`.
