### PR TITLE
Fix variable expansion error in seq_cache_populate.py

### DIFF
--- a/misc/seq_cache_populate.py
+++ b/misc/seq_cache_populate.py
@@ -329,7 +329,7 @@ def main():
         number_of_subdirs=args.subdirs,
     )
     logging.info(
-        f"\nUse environment REF_CACHE=$root_dir{'/%2s' * args.subdirs}/%s for "
+        f"\nUse environment REF_CACHE={os.path.normpath(args.root)}{'/%2s' * args.subdirs}/%s for "
         f"accessing these files."
     )
     logging.info(


### PR DESCRIPTION
In an effort to mimick `seq_cache_populate.pl` the output messages are kept the same as much as possible. Unfortunately I missed a perl variable expansion back then.