### PR TITLE
Input validation on some numeric command-line values

### DIFF
--- a/bam_fastq.c
+++ b/bam_fastq.c
@@ -323,19 +323,19 @@ static bool parse_opts(int argc, char *argv[], bam2fq_opts_t** opts_out)
             case '1': opts->fnr[1] = optarg; break;
             case '2': opts->fnr[2] = optarg; break;
             case 'o': opts->fnr[1] = optarg; opts->fnr[2] = optarg; break;
-            case 'f': 
+            case 'f':
                 if (!parse_long_value(optarg, &parsed_number, 0)) {
-                    print_error("fastq", 
-                    "invalid -f value \"%s\"", 
+                    print_error("fastq",
+                    "invalid -f value \"%s\"",
                     optarg);
                     return false;
                 }
                 opts->flag_on |= parsed_number;
                 break;
-            case 'F': 
+            case 'F':
                 if (!parse_long_value(optarg, &parsed_number, 0)) {
-                    print_error("fastq", 
-                    "invalid -F value \"%s\"", 
+                    print_error("fastq",
+                    "invalid -F value \"%s\"",
                     optarg);
                     return false;
                 }
@@ -344,19 +344,19 @@ static bool parse_opts(int argc, char *argv[], bam2fq_opts_t** opts_out)
                 opts->flag_off = parsed_number;
                 break;
 
-            case 'G': 
+            case 'G':
                 if (!parse_long_value(optarg, &parsed_number, 0)) {
-                    print_error("fastq", 
-                    "invalid -f value \"%s\"", 
+                    print_error("fastq",
+                    "invalid -f value \"%s\"",
                     optarg);
                     return false;
                 }
                 opts->flag_alloff |= parsed_number;
                 break;
-            case LONGOPT('g'): 
+            case LONGOPT('g'):
                 if (!parse_long_value(optarg, &parsed_number, 0)) {
-                    print_error("fastq", 
-                    "invalid -f value \"%s\"", 
+                    print_error("fastq",
+                    "invalid -f value \"%s\"",
                     optarg);
                     return false;
                 }
@@ -372,7 +372,7 @@ static bool parse_opts(int argc, char *argv[], bam2fq_opts_t** opts_out)
             case 'U': opts->UMI = true; break;
             case LONGOPT('U'): opts->UMI_tag = optarg; break;
 
-            case 'c': 
+            case 'c':
                 opts->compression_level = atoi(optarg);
                 if (opts->compression_level < 0)
                     opts->compression_level = 0;
@@ -380,11 +380,11 @@ static bool parse_opts(int argc, char *argv[], bam2fq_opts_t** opts_out)
                     opts->compression_level = 9;
                 break;
             case 'T': opts->extra_tags = optarg; break;
-            case 'v': 
+            case 'v':
                 if (!parse_int_value(optarg, &opts->def_qual)) {
                     print_error("fastq",
                                 "Invalid -v value: \"%s\"",
-                                optarg);                    
+                                optarg);
                     free_opts(opts);
                     return false;
                 }

--- a/bam_index.c
+++ b/bam_index.c
@@ -93,7 +93,7 @@ int bam_index(int argc, char *argv[])
         switch (c) {
         case 'b': csi = 0; break;
         case 'c': csi = 1; break;
-        case 'm': 
+        case 'm':
             csi = 1;
             if (!parse_int_value(optarg, &min_shift)) {
                 print_error("index", "invalid min_shift");
@@ -103,7 +103,7 @@ int bam_index(int argc, char *argv[])
             break;
         case 'M': multiple = 1; break;
         case 'o': fn_idx = optarg; break;
-        case '@': 
+        case '@':
             if (!parse_int_value(optarg, &n_threads)) {
                 print_error("index", "invalid thread count");
                 index_usage(stderr);

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -1651,7 +1651,7 @@ int bam_merge(int argc, char *argv[])
         case '1': flag |= MERGE_LEVEL1; level = 1; break;
         case 'u': flag |= MERGE_UNCOMP; level = 0; break;
         case 'R': reg = strdup(optarg); break;
-        case 'l': 
+        case 'l':
             if (!parse_int_value(optarg, &level)) {
                 fprintf(stderr, "Invalid compression level\n");
                 ret = 1; goto end;
@@ -1659,12 +1659,12 @@ int bam_merge(int argc, char *argv[])
             break;
         case 'c': flag |= MERGE_COMBINE_RG; break;
         case 'p': flag |= MERGE_COMBINE_PG; break;
-        case 's': 
+        case 's':
             if (!parse_long_value(optarg, &random_seed, 10)) {
                 fprintf(stderr, "Invalid random seed\n");
                 ret = 1; goto end;
             }
-            break;        
+            break;
         case 'X': has_index_file = 1; break; // -X flag for index filename
         case 'L': fn_bed = optarg; break;
         case 'b': {
@@ -3788,7 +3788,7 @@ int bam_sort(int argc, char *argv[])
                 break;
             }
         case 'T': kputs(optarg, &tmpprefix); break;
-        case 'l': 
+        case 'l':
             if (!parse_int_value(optarg, &level)) {
                 fprintf(stderr, "Invalid compression level\n");
                 sort_usage(stderr); ret = EXIT_FAILURE; goto sort_end;
@@ -3804,7 +3804,7 @@ int bam_sort(int argc, char *argv[])
             break;
         case 'H': no_squash = 0; break;
 
-        case 'w': 
+        case 'w':
             if (!parse_int_value(optarg, &window)) {
                 fprintf(stderr, "Invalid window\n");
                 sort_usage(stderr); ret = EXIT_FAILURE; goto sort_end;

--- a/sam_opts.c
+++ b/sam_opts.c
@@ -32,7 +32,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include "sam_opts.h"
 
 /*
- * Parse an integer from a value passed on the command-line. Return true on 
+ * Parse an integer from a value passed on the command-line. Return true on
  * success, false if the string was not a valid integer.
 */
 bool parse_int_value(const char *optarg, int *value) {
@@ -49,7 +49,7 @@ bool parse_int_value(const char *optarg, int *value) {
 }
 
 /*
- * Parse an long int from a value passed on the command-line. Return true on 
+ * Parse an long int from a value passed on the command-line. Return true on
  * success, false if the string was not a valid long int.
 */
 bool parse_long_value(const char *optarg, long *value, int base) {
@@ -124,7 +124,7 @@ int parse_sam_global_opt(int c, const char *optarg, const struct option *lopt,
             free(ref);
             break;
         } else if (strcmp(lopt->name, "threads") == 0) {
-            if (!parse_int_value(optarg, &ga->nthreads)) 
+            if (!parse_int_value(optarg, &ga->nthreads))
             {
                 fprintf(stderr, "Invalid threads value.\n");
                 return -1;
@@ -134,11 +134,11 @@ int parse_sam_global_opt(int c, const char *optarg, const struct option *lopt,
             ga->write_index = 1;
             break;
         } else if (strcmp(lopt->name, "verbosity") == 0) {
-            if (!parse_int_value(optarg, &hts_verbose)) 
+            if (!parse_int_value(optarg, &hts_verbose))
             {
                 fprintf(stderr, "Invalid verbosity value.\n");
                 return -1;
-            }            
+            }
             break;
         }
     }

--- a/sam_opts.h
+++ b/sam_opts.h
@@ -87,13 +87,13 @@ int parse_sam_global_opt(int c, const char *optarg, const struct option *lopt,
                          sam_global_args *ga);
 
 /*
- * Parse an integer from a value passed on the command-line. Return true on 
+ * Parse an integer from a value passed on the command-line. Return true on
  * success, false if the string was not a valid integer.
 */
 bool parse_int_value(const char *optarg, int *value);
 
 /*
- * Parse an long int from a value passed on the command-line. Return true on 
+ * Parse an long int from a value passed on the command-line. Return true on
  * success, false if the string was not a valid long int.
 */
 bool parse_long_value(const char *optarg, long *value, int base);

--- a/sam_view.c
+++ b/sam_view.c
@@ -990,7 +990,7 @@ int main_samview(int argc, char *argv[])
             }
             settings.count_rf |= SAM_QNAME;
             break;
-        case LONGOPT('S'): 
+        case LONGOPT('S'):
             if (!parse_long_value(optarg, &temp_value, 0)) {
                 print_error("view", "Incorrect seed argument \"%s\"", optarg);
                 goto view_end;


### PR DESCRIPTION
Sanity-check some numeric values passed on the command-line, and error out on malformed strings. 

Motivating example: Raise an error on the bogus command-line `samtools sort -@ -n input.bam -O bam -o sorted.bam` which is missing a thread count after -@. (The current behavior is to set thread count to 0 and drop the `-n` flag, since `atoi("-n")` simply returns zero)

There's more that could be done to validate inputs, but this adds some safety railings to prevent unpleasant surprises.