### PR TITLE
reference file support for reset

### DIFF
--- a/doc/samtools-reset.1
+++ b/doc/samtools-reset.1
@@ -114,13 +114,25 @@ By default the PG entry for reset will be present in the output.
 Keep the duplicate flag as it is. This option is absent by default and alignments are marked non-duplicates.
 
 .TP
-.BI "-@, --threads " N
-This gives the number of worker threads to be used.
+.BI --input-fmt-option\  OPT=VAL
+Set the input format options.
 
 .TP
 .BI "-O, --output-fmt " FMT[,options]
 Sets the format of the output file and any associated format-specific options.
 If this option is not present, the format is identified from the output file name extension.
+
+.TP
+.BI --output-fmt-option\  OPT=VAL
+Set the output format options.
+
+.TP
+.BI "-T " FILE ", --reference " FILE
+A FASTA format reference file for cram files.
+
+.TP
+.BI "-@, --threads " N
+This gives the number of worker threads to be used.
 
 .SH EXAMPLES
 Basic usage, to reset the data:

--- a/reset.c
+++ b/reset.c
@@ -69,7 +69,7 @@ static void usage(FILE *fp)
       --dupflag\n\
                Keeps the duplicate flag as it is\n");
 
-    sam_global_opt_help(fp, "--O--@--");
+    sam_global_opt_help(fp, "-.O.T@--");
     return;
 }
 
@@ -462,7 +462,7 @@ returns 1 on failure 0 on success
 int main_reset(int argc, char *argv[])
 {
     static const struct option lopts[] = {
-        SAM_OPT_GLOBAL_OPTIONS('-', '-', 'O', '-', '-', '@'),       //let output format and thread count be given by user - long options
+        SAM_OPT_GLOBAL_OPTIONS('-', 0, 'O', 0, 'T', '@'),
         {"keep-tag", required_argument, NULL, LONG_OPT('x')},       //aux tags to be retained, supports ^ STR
         {"remove-tag", required_argument, NULL, 'x'},               //aux tags to be removed
         {"no-RG", no_argument, NULL, 1},                            //no RG lines in output, default is to keep them
@@ -480,8 +480,7 @@ int main_reset(int argc, char *argv[])
     char outmode[4] = "w", *args = NULL;
     conf_data resetconf = {1, 0, 0, NULL, NULL, NULL};              //keep RGs and PGs by default, ctrlflags = 0
 
-    //samtools reset -o outfile -x/--remove-tag ... --keep-tag ... --threads=n --output-fmt=fmt --no-RG --reject-PG pgid --no-PG [<infile>]
-    while ((c = getopt_long(argc, argv, "o:@:x:O:", lopts, NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "o:@:x:O:T:", lopts, NULL)) >= 0)
     {
         switch (c)
         {
@@ -581,7 +580,7 @@ int main_reset(int argc, char *argv[])
     sam_open_mode(outmode + 1, outname, NULL);
 
     //open input and output files
-    infile = sam_open(inname, "r");
+    infile = sam_open_format(inname, "r", &ga.in);
     outfile = sam_open_format(outname, outmode, &ga.out);
     if (!infile || !outfile) {
         fprintf(stderr, "Could not open %s%s%s\n", !infile ? inname : "", (!infile && !outfile)? ", " : "", !outfile ? outname : "");

--- a/test/reset/cram.expected
+++ b/test/reset/cram.expected
@@ -1,0 +1,13 @@
+@HD	VN:1.6
+@RG	ID:grp1	DS:Group 1	LB:Library 1	SM:Sample
+@RG	ID:grp2	DS:Group 2	LB:Library 2	SM:Sample
+@RG	ID:grp3	DS:Group 3	SM:Sample
+ref12_grp1_p001	77	*	0	0	*	*	0	0	TGCAGGCATG	AAAAAAAAAA	RG:Z:grp1
+ref1_grp1_p004	141	*	0	0	*	*	0	0	GCATGCCTGC	3333333333	RG:Z:grp1
+ref1_grp2_p004	141	*	0	0	*	*	0	0	TTGCATGCCT	4444444444	RG:Z:grp2
+ref1_grp1_p005	141	*	0	0	*	*	0	0	GCTTGCATGC	5555555555	RG:Z:grp1
+ref1_grp2_p005	141	*	0	0	*	*	0	0	AAGCTTGCAT	6666666666	RG:Z:grp2
+ref1_grp1_p006	141	*	0	0	*	*	0	0	TCAAGCTTGC	7777777777	RG:Z:grp1
+ref12_grp2_p001	77	*	0	0	*	*	0	0	CAAGCTTGAG	AAAAAAAAAA	RG:Z:grp2
+ref1_grp2_p006	141	*	0	0	*	*	0	0	ACTCAAGCTT	8888888888	RG:Z:grp2
+ref2_grp3_p002	77	*	0	0	*	*	0	0	CTGTTTCCTGTGTGA	{{{{{{{{{{{{{{{	RG:Z:grp3

--- a/test/test.pl
+++ b/test/test.pl
@@ -3983,6 +3983,12 @@ sub test_reset
     test_cmd($opts, out=>"reset/empty.expected", err=>"reset/empty.expected", hskip=>1, ignore_pg_header=>1, out_map=>{"reset/output" => "reset/output.flg.1.expected"}, cmd=>"$$opts{bin}/samtools reset  --dupflag $$opts{bin}/test/reset/seq.sam -o $$opts{bin}/test/reset/output");
     #flag update default
     test_cmd($opts, out=>"reset/empty.expected", err=>"reset/empty.expected", hskip=>1, ignore_pg_header=>1, out_map=>{"reset/output" => "reset/output.flg.2.expected"}, cmd=>"$$opts{bin}/samtools reset $$opts{bin}/test/reset/seq.sam -o $$opts{bin}/test/reset/output");
+    #cram reference support
+    cmd("cp $$opts{path}/dat/view.001.fa $$opts{bin}/test/reset/view.tmp.fa");
+    cmd("$$opts{bin}/samtools view $$opts{path}/dat/view.001.sam -T $$opts{bin}/test/reset/view.tmp.fa -o $$opts{bin}/test/reset/view.tmp.cram");
+    cmd("rm $$opts{bin}/test/reset/view.tmp.fa");
+    test_cmd($opts, out=>"reset/cram.expected", err=>"reset/empty.expected", hskip=>1, ignore_pg_header=>1, cmd=>"$$opts{bin}/samtools reset $$opts{bin}/test/reset/view.tmp.cram -T $$opts{path}/dat/view.001.fa --input-fmt-option=filter=\"pos>35\" --output-fmt-option=version=3.0 -o $$opts{bin}/test/reset/view30.tmp.cram; $$opts{bin}/samtools view -h $$opts{bin}/test/reset/view30.tmp.cram");
+    test_cmd($opts, out=>"reset/cram.expected", err=>"reset/empty.expected", hskip=>1, ignore_pg_header=>1, cmd=>"$$opts{bin}/samtools reset $$opts{bin}/test/reset/view.tmp.cram -T $$opts{path}/dat/view.001.fa --input-fmt-option=filter=\"pos>35\" --output-fmt-option=version=3.1 -o $$opts{bin}/test/reset/view31.tmp.cram; $$opts{bin}/samtools view -h $$opts{bin}/test/reset/view31.tmp.cram");
 }
 
 sub test_checksum


### PR DESCRIPTION
Fixes #2297 
Enabled the reference, input format and output format options for reset.
Reference file can be passed using either -T or --reference options and cram with external reference should work fine.
Input and output format options enabled to use customisation on input and output files.