### PR TITLE
Fix for the footgun of repeated use of "samtools view --subsample" with the same (or default) seed

### DIFF
--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -470,10 +470,14 @@ Subsampling seed used to influence
 subset of reads is kept.
 .\" Reads are retained based on a score computed by hashing their QNAME
 .\" field and the seed value.
-When subsampling data that has previously been subsampled, be sure to use
-a different seed value from those used previously; otherwise more reads
-will be retained than expected.
-[0]
+By default, the seed is derived from a hash of the input file's header text.
+Since each subsampling run adds a @PG header line, re-subsampling a file will
+automatically produce a different seed value, ensuring the expected fraction
+of reads is retained at each step.
+When subsampling data that has previously been subsampled using an explicit
+seed, be sure to use a different seed value from those used previously;
+otherwise more reads will be retained than expected.
+[hash of header text]
 .TP
 .BI "-s " FLOAT
 Subsampling shorthand option:

--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -464,20 +464,28 @@ Output only a proportion of the input alignments, as specified by 0.0 \(<=
 This subsampling acts in the same way on all of the alignment records in
 the same template or read pair, so it never keeps a read but not its mate.
 .TP
-.BI "--subsample-seed " INT
+.BI "--subsample-seed " INT | auto
 Subsampling seed used to influence
 .I which
 subset of reads is kept.
 .\" Reads are retained based on a score computed by hashing their QNAME
 .\" field and the seed value.
-By default, the seed is derived from a hash of the input file's header text.
-Since each subsampling run adds a @PG header line, re-subsampling a file will
-automatically produce a different seed value, ensuring the expected fraction
-of reads is retained at each step.
+If the value is the literal string
+.BR auto ,
+the seed is derived from a hash of the input file's header text.  Because
+each subsampling run appends an
+.B @CO
+header line recording the fraction and seed used (and, unless
+.B --no-PG
+is given, a
+.B @PG
+line as well), re-subsampling a file in \fBauto\fR mode will automatically
+produce a different seed at each step, ensuring the expected fraction of
+reads is retained.
 When subsampling data that has previously been subsampled using an explicit
 seed, be sure to use a different seed value from those used previously;
 otherwise more reads will be retained than expected.
-[hash of header text]
+[auto]
 .TP
 .BI "-s " FLOAT
 Subsampling shorthand option:
@@ -485,6 +493,9 @@ Subsampling shorthand option:
 is equivalent to
 .BI "--subsample-seed " INT " --subsample"
 .RI 0. FRAC .
+.I INT
+may also be the literal string
+.BR auto .
 .TP
 .BI "-@ " INT ", --threads " INT
 Number of BAM compression threads to use in addition to main thread [0].

--- a/sam_view.c
+++ b/sam_view.c
@@ -68,7 +68,7 @@ typedef struct samview_settings {
     int min_qlen;
     int remove_B;
     uint32_t subsam_seed;
-    int subsam_seed_set;
+    int subsam_seed_auto;  // 1 if seed should be derived from input header
     double subsam_frac;
     char* library;
     void* bed;
@@ -884,6 +884,7 @@ int main_samview(int argc, char *argv[])
 
     memset(&settings,0,sizeof(settings));
     settings.subsam_frac = -1.0;
+    settings.subsam_seed_auto = 1;  // default: derive seed from input header
     settings.count_rf = SAM_FLAG; // don't want 0, and this is quick
 
     static const struct option lopts[] = {
@@ -969,19 +970,27 @@ int main_samview(int argc, char *argv[])
                             lopts, NULL)) >= 0) {
         switch (c) {
         case 's':
-            settings.subsam_seed = strtol(optarg, &tmp, 10);
-            if (tmp && *tmp == '.') {
-                settings.subsam_frac = strtod(tmp, &tmp);
+            if (strncasecmp(optarg, "auto", 4) == 0 && optarg[4] == '.') {
+                // "auto.FRAC" -- derive the seed from the input header
+                settings.subsam_seed = 0;
+                settings.subsam_seed_auto = 1;
+                settings.subsam_frac = strtod(optarg + 4, &tmp);
                 if (*tmp) ret = 1;
             } else {
-                ret = 1;
+                settings.subsam_seed = strtol(optarg, &tmp, 10);
+                if (tmp && *tmp == '.') {
+                    settings.subsam_frac = strtod(tmp, &tmp);
+                    if (*tmp) ret = 1;
+                } else {
+                    ret = 1;
+                }
+                if (!ret) settings.subsam_seed_auto = 0;
             }
 
             if (ret == 1) {
                 print_error("view", "Incorrect sampling argument \"%s\"", optarg);
                 goto view_end;
             }
-            settings.subsam_seed_set = 1;
             settings.count_rf |= SAM_QNAME;
             break;
         case LONGOPT('s'):
@@ -993,12 +1002,17 @@ int main_samview(int argc, char *argv[])
             settings.count_rf |= SAM_QNAME;
             break;
         case LONGOPT('S'):
-            if (!parse_long_value(optarg, &temp_value, 0)) {
-                print_error("view", "Incorrect seed argument \"%s\"", optarg);
-                goto view_end;
+            if (strcasecmp(optarg, "auto") == 0) {
+                settings.subsam_seed = 0;
+                settings.subsam_seed_auto = 1;
+            } else {
+                if (!parse_long_value(optarg, &temp_value, 0)) {
+                    print_error("view", "Incorrect seed argument \"%s\"", optarg);
+                    goto view_end;
+                }
+                settings.subsam_seed = temp_value;
+                settings.subsam_seed_auto = 0;
             }
-            settings.subsam_seed = temp_value;
-            settings.subsam_seed_set = 1;
             break;
         case 'm':
             if (!parse_int_value(optarg, &settings.min_qlen)) {
@@ -1343,19 +1357,33 @@ int main_samview(int argc, char *argv[])
         sam_hdr_remove_lines(settings.header, "RG", "ID", settings.rghash);
     }
 
-    // Compute the subsampling seed.  If the user did not set a seed
-    // explicitly, derive one from the input header text.  This means
-    // identical inputs always produce the same subsample, but
-    // re-subsampling a file gets a different seed because the prior
-    // run's @PG line changed the header.
-    if (settings.subsam_frac > 0. && !settings.subsam_seed_set) {
-        const char *header_text = sam_hdr_str(settings.header);
-        if (header_text)
-            settings.subsam_seed = __ac_X31_hash_string(header_text);
+    // Compute the subsampling seed and record the parameters in a @CO
+    // header line.  In "auto" mode (the default), the seed is derived
+    // from a hash of the input header so identical inputs produce the
+    // same subsample, but serial re-subsampling of a file uses a
+    // different seed at each step because the added @CO line (and
+    // @PG line, if not suppressed) changes the header.
+    if (settings.subsam_frac > 0.) {
+        if (settings.subsam_seed_auto) {
+            const char *header_text = sam_hdr_str(settings.header);
+            if (header_text)
+                settings.subsam_seed = __ac_FNV1a_hash_string(header_text);
+        }
+
+        kstring_t co = KS_INITIALIZE;
+        if (ksprintf(&co, "Sub-sampled fraction=%g seed=%" PRIu32,
+                     settings.subsam_frac, settings.subsam_seed) < 0
+            || sam_hdr_add_line(settings.header, "CO", co.s, NULL) < 0) {
+            print_error("view", "failed to add subsample @CO header line");
+            ks_free(&co);
+            ret = 1;
+            goto view_end;
+        }
+        ks_free(&co);
     }
     if (settings.subsam_seed != 0) {
-        // Convert likely small user input (1, 2, ...) or header hash
-        // to pseudo-random values with more entropy and more bits set
+        // Scramble likely small user input (1, 2, ...) to a pseudo-random
+        // value with more entropy and more bits set.
         srand(settings.subsam_seed);
         settings.subsam_seed = rand();
     }
@@ -1653,8 +1681,12 @@ static int usage(FILE *fp, int exit_status, int is_long_help)
 "                             ...have some of the FLAGs present\n"
 "  -G FLAG                    EXCLUDE reads with all of the FLAGs present\n"  // !(F&x == x)  TODO long option
 "      --subsample FLOAT      Keep only FLOAT fraction of templates/read pairs\n"
-"      --subsample-seed INT   Influence WHICH reads are kept in subsampling [hash of header]\n"
+"      --subsample-seed INT|auto\n"
+"                             Seed used to influence WHICH reads are kept in\n"
+"                             subsampling.  \"auto\" derives the seed from a\n"
+"                             hash of the input header [auto]\n"
 "  -s INT.FRAC                Same as --subsample 0.FRAC --subsample-seed INT\n"
+"                             (INT may be \"auto\")\n"
 "\n"
 "Processing options:\n"
 "      --add-flags FLAG       Add FLAGs to reads\n"

--- a/sam_view.c
+++ b/sam_view.c
@@ -68,6 +68,7 @@ typedef struct samview_settings {
     int min_qlen;
     int remove_B;
     uint32_t subsam_seed;
+    int subsam_seed_set;
     double subsam_frac;
     char* library;
     void* bed;
@@ -980,6 +981,7 @@ int main_samview(int argc, char *argv[])
                 print_error("view", "Incorrect sampling argument \"%s\"", optarg);
                 goto view_end;
             }
+            settings.subsam_seed_set = 1;
             settings.count_rf |= SAM_QNAME;
             break;
         case LONGOPT('s'):
@@ -996,6 +998,7 @@ int main_samview(int argc, char *argv[])
                 goto view_end;
             }
             settings.subsam_seed = temp_value;
+            settings.subsam_seed_set = 1;
             break;
         case 'm':
             if (!parse_int_value(optarg, &settings.min_qlen)) {
@@ -1317,13 +1320,6 @@ int main_samview(int argc, char *argv[])
         goto view_end;
     }
 
-    if (settings.subsam_seed != 0) {
-        // Convert likely user input 1,2,... to pseudo-random
-        // values with more entropy and more bits set
-        srand(settings.subsam_seed);
-        settings.subsam_seed = rand();
-    }
-
     settings.fn_in = (optind < argc)? argv[optind] : "-";
     if ((settings.in = sam_open_format(settings.fn_in, "r", &ga.in)) == 0) {
         print_error_errno("view", "failed to open \"%s\" for reading", settings.fn_in);
@@ -1346,6 +1342,24 @@ int main_samview(int argc, char *argv[])
     if (settings.rghash) {
         sam_hdr_remove_lines(settings.header, "RG", "ID", settings.rghash);
     }
+
+    // Compute the subsampling seed.  If the user did not set a seed
+    // explicitly, derive one from the input header text.  This means
+    // identical inputs always produce the same subsample, but
+    // re-subsampling a file gets a different seed because the prior
+    // run's @PG line changed the header.
+    if (settings.subsam_frac > 0. && !settings.subsam_seed_set) {
+        const char *header_text = sam_hdr_str(settings.header);
+        if (header_text)
+            settings.subsam_seed = __ac_X31_hash_string(header_text);
+    }
+    if (settings.subsam_seed != 0) {
+        // Convert likely small user input (1, 2, ...) or header hash
+        // to pseudo-random values with more entropy and more bits set
+        srand(settings.subsam_seed);
+        settings.subsam_seed = rand();
+    }
+
     if (!settings.is_count) {
         if ((settings.out = sam_open_format(settings.fn_out? settings.fn_out : "-", out_mode, &ga.out)) == 0) {
             print_error_errno("view", "failed to open \"%s\" for writing", settings.fn_out? settings.fn_out : "standard output");
@@ -1639,7 +1653,7 @@ static int usage(FILE *fp, int exit_status, int is_long_help)
 "                             ...have some of the FLAGs present\n"
 "  -G FLAG                    EXCLUDE reads with all of the FLAGs present\n"  // !(F&x == x)  TODO long option
 "      --subsample FLOAT      Keep only FLOAT fraction of templates/read pairs\n"
-"      --subsample-seed INT   Influence WHICH reads are kept in subsampling [0]\n"
+"      --subsample-seed INT   Influence WHICH reads are kept in subsampling [hash of header]\n"
 "  -s INT.FRAC                Same as --subsample 0.FRAC --subsample-seed INT\n"
 "\n"
 "Processing options:\n"

--- a/test/test.pl
+++ b/test/test.pl
@@ -2616,6 +2616,56 @@ sub test_view
         }
     }
 
+    # Repeated subsampling without an explicit seed.  The default seed is
+    # derived from the header, which changes each round (new @PG line), so
+    # each round should further reduce the read count.
+    {
+        printf "\t%s ", "$test: Repeated subsampling reduces reads";
+
+        my $input = $big_bam;
+        my $frac  = 0.5;
+        my $prev_count = $big_sam_count;
+        my $res = 0;
+
+        for my $round (1 .. 3) {
+            my $output = sprintf("%s.test%03d.round%d.bam", $out, $test, $round);
+            my @cmd = ("$$opts{bin}/samtools", "view", "-b",
+                       "--subsample", $frac, $input,
+                       "-o", $output);
+            system(@cmd) == 0 || die "Error running @cmd\n";
+
+            # Count reads in the output
+            my $count = 0;
+            open(my $fh, '-|', "$$opts{bin}/samtools", "view", "-c", $output)
+                || die "Couldn't count reads in $output: $!\n";
+            $count = <$fh>;
+            chomp $count;
+            close($fh);
+
+            my $expected = $prev_count * $frac;
+            my $min = $expected * 0.7;
+            my $max = $expected * 1.3;
+
+            if ($count < $min || $count > $max) {
+                printf("\n\tRound %d: expected ~%.0f reads (%.0f..%.0f), got %d\n",
+                       $round, $expected, $min, $max, $count);
+                $res = 1;
+                last;
+            }
+
+            print ".";
+            $prev_count = $count;
+            $input = $output;
+        }
+
+        if (!$res) {
+            passed($opts, msg => "$test: Repeated subsampling reduces reads");
+        } else {
+            failed($opts, msg => "$test: Repeated subsampling reduces reads");
+        }
+        $test++;
+    }
+
     my $b_pg_sam      = "$$opts{path}/dat/view.001.sam";
     my $b_pg_expected = "$$opts{path}/dat/view.004.expected.sam";
     run_view_test($opts,

--- a/test/test.pl
+++ b/test/test.pl
@@ -2616,11 +2616,18 @@ sub test_view
         }
     }
 
-    # Repeated subsampling without an explicit seed.  The default seed is
-    # derived from the header, which changes each round (new @PG line), so
-    # each round should further reduce the read count.
-    {
-        printf "\t%s ", "$test: Repeated subsampling reduces reads";
+    # Repeated subsampling in "auto" seed mode.  The seed is derived from a
+    # hash of the input header, which changes each round (new @CO line
+    # recording the seed, plus the @PG line), so each round should further
+    # reduce the read count.  Exercise the default, the explicit
+    # "--subsample-seed auto" form, and the "-s auto.FRAC" shorthand.
+    for my $variant (
+        { name => 'default seed',           args => sub { ('--subsample', $_[0]) } },
+        { name => '--subsample-seed auto',  args => sub { ('--subsample', $_[0], '--subsample-seed', 'auto') } },
+        { name => '-s auto.FRAC',           args => sub { ('-s', 'auto.' . (int($_[0] * 10))) } },
+    ) {
+        my $label = "Repeated subsampling reduces reads ($variant->{name})";
+        printf "\t%s ", "$test: $label";
 
         my $input = $big_bam;
         my $frac  = 0.5;
@@ -2630,11 +2637,10 @@ sub test_view
         for my $round (1 .. 3) {
             my $output = sprintf("%s.test%03d.round%d.bam", $out, $test, $round);
             my @cmd = ("$$opts{bin}/samtools", "view", "-b",
-                       "--subsample", $frac, $input,
+                       $variant->{args}->($frac), $input,
                        "-o", $output);
             system(@cmd) == 0 || die "Error running @cmd\n";
 
-            # Count reads in the output
             my $count = 0;
             open(my $fh, '-|', "$$opts{bin}/samtools", "view", "-c", $output)
                 || die "Couldn't count reads in $output: $!\n";
@@ -2659,9 +2665,36 @@ sub test_view
         }
 
         if (!$res) {
-            passed($opts, msg => "$test: Repeated subsampling reduces reads");
+            passed($opts, msg => "$test: $label");
         } else {
-            failed($opts, msg => "$test: Repeated subsampling reduces reads");
+            failed($opts, msg => "$test: $label");
+        }
+        $test++;
+    }
+
+    # Verify that the @CO line recording the subsample fraction and seed is
+    # present in the output header.
+    {
+        my $label = "Subsample adds \@CO line with fraction and seed";
+        printf "\t%s ", "$test: $label";
+
+        my $output = sprintf("%s.test%03d.subsample_co.bam", $out, $test);
+        my @cmd = ("$$opts{bin}/samtools", "view", "-b",
+                   "--subsample", "0.5", "--subsample-seed", "42",
+                   $big_bam, "-o", $output);
+        system(@cmd) == 0 || die "Error running @cmd\n";
+
+        my $header = '';
+        open(my $fh, '-|', "$$opts{bin}/samtools", "view", "-H", $output)
+            || die "Couldn't read header from $output: $!\n";
+        { local $/; $header = <$fh>; }
+        close($fh);
+
+        if ($header =~ /^\@CO\tSub-sampled fraction=0\.5 seed=42$/m) {
+            passed($opts, msg => "$test: $label");
+        } else {
+            printf("\n\tHeader did not contain expected \@CO line:\n%s\n", $header);
+            failed($opts, msg => "$test: $label");
         }
         $test++;
     }


### PR DESCRIPTION
Changes the default seed from 0, to a value derived from the hash of the incoming file's header. The idea is that the default seed should be deterministic given the same input, but different for different inputs.  This ensures the seed is the same regardless of format (SAM/BAM/CRAM) or compression level, but will generally cause the seed to vary for files that have been processed differently due to the differing @PG lines (and possibly others) in the header.  Since "samtools view" will insert a @PG line into the header, serial downsampling of file A to file B to file C will now use different seeds at each step.

I think this is my first PR in samtools, and this changes the a command line default, so I am mindful that this may not be accepted, or not accepted without changes.  I'm very open to feedback here, but would love to fix this footgun, and this seems like a reasonable way to do it.

Fixes #1201, which is something I also run into once in a while when I forget about the default behavior.