### PR TITLE
Ensure indirect function calls have the correct type.

### DIFF
--- a/bam_ampliconclip.c
+++ b/bam_ampliconclip.c
@@ -104,7 +104,7 @@ int load_bed_file_multi_ref(char *infile, int get_strand, int sort_by_pos, khash
     }
 
 
-    while (line.l = 0, kgetline(&line, (kgets_func *)hgets, fp) >= 0) {
+    while (line.l = 0, khgetline(&line, fp) >= 0) {
         line_count++;
         int hret;
 

--- a/bam_checksum.c
+++ b/bam_checksum.c
@@ -852,7 +852,7 @@ static int sums_parse(opts *o, char *fn, sums_t *sums, sums_t *noRG,
     } header[11] = {-1,-1,-1,-1,-1, -1,-1,-1,-1,-1, -1};
     crcs_t crcs = {1,1,1,1,1,1,1};
 
-    while (line.l = 0, kgetline(&line, (kgets_func *)fgets, fp) >= 0) {
+    while (line.l = 0, kfgetline(&line, fp) >= 0) {
         if (strncmp(line.s, "# Checksum", 10) == 0) {
             int major, minor;
             if (sscanf(line.s, "# Checksum %d.%d", &major, &minor) == 2) {

--- a/bam_consensus.c
+++ b/bam_consensus.c
@@ -699,7 +699,7 @@ int load_qcal(qcal_t *q, const char *fn) {
     kstring_t line = KS_INITIALIZE;
     int max = 0;
     int last_qual = 0;
-    while (line.l = 0, kgetline(&line, (kgets_func *)hgets, fp) >= 0) {
+    while (line.l = 0, khgetline(&line, fp) >= 0) {
         int v, s, u, o;
         if (*line.s == '#')
             continue;

--- a/bam_fastq.c
+++ b/bam_fastq.c
@@ -218,7 +218,7 @@ static int add_tag_file(bam2fq_opts_t *opts, char *fn) {
         return -1;
     }
 
-    while (ks.l = 0, kgetline(&ks, (kgets_func *)fgets, fp) >= 0) {
+    while (ks.l = 0, kfgetline(&ks, fp) >= 0) {
         if (add_tag_value(opts, ks.s) < 0) {
             ks_free(&ks);
             return -1;

--- a/faidx.c
+++ b/faidx.c
@@ -353,7 +353,7 @@ static int read_regions_from_file(faidx_t *faid, hFILE *in_file, output *out, co
     kstring_t line = {0, 0, NULL};
     int ret = EXIT_FAILURE;
 
-    while (line.l = 0, kgetline(&line, (kgets_func *)hgets, in_file) >= 0) {
+    while (line.l = 0, khgetline(&line, in_file) >= 0) {
         if ((ret = write_output(faid, out, line.s, ignore, length, rev, pos_strand_name, neg_strand_name, format)) == EXIT_FAILURE) {
             break;
         }

--- a/stats.c
+++ b/stats.c
@@ -1924,7 +1924,7 @@ static void init_regions(stats_t *stats, const char *file, stats_info_t* info)
     int warned = 0, r, p, new_p;
     int prev_tid=-1;
     hts_pos_t prev_pos=-1LL;
-    while (line.l = 0, kgetline(&line, (kgets_func *)fgets, fp) >= 0)
+    while (line.l = 0, kfgetline(&line, fp) >= 0)
     {
         if ( line.s[0] == '#' ) continue;
 

--- a/test/merge/test_bam_translate.c
+++ b/test/merge/test_bam_translate.c
@@ -386,7 +386,7 @@ int main(int argc, char**argv)
     // check result
     check = fopen(tempfname, "r");
     res.l = 0;
-    if (kgetline(&res, (kgets_func *)fgets, check) < 0 &&
+    if (kfgetline(&res, check) < 0 &&
         (feof(check) || res.l == 0) ) {
         ++success;
     } else {
@@ -424,7 +424,7 @@ int main(int argc, char**argv)
     // check result
     check = fopen(tempfname, "r");
     res.l = 0;
-    if (kgetline(&res, (kgets_func *)fgets, check) < 0 &&
+    if (kfgetline(&res, check) < 0 &&
         (feof(check) || res.l == 0) ) {
         ++success;
     } else {
@@ -462,7 +462,7 @@ int main(int argc, char**argv)
     // check result
     check = fopen(tempfname, "r");
     res.l = 0;
-    if (kgetline(&res, (kgets_func *)fgets, check) < 0 &&
+    if (kfgetline(&res, check) < 0 &&
         (feof(check) || res.l == 0)) {
         ++success;
     } else {
@@ -499,7 +499,7 @@ int main(int argc, char**argv)
     // check result
     check = fopen(tempfname, "r");
     res.l = 0;
-    if (kgetline(&res, (kgets_func *)fgets, check) >= 0 &&
+    if (kfgetline(&res, check) >= 0 &&
         strcmp("[bam_translate] RG tag \"rg4hello\" on read \"123456789\" encountered with no corresponding entry in header, tag lost. Unknown tags are only reported once per input file for each tag ID.",res.s) == 0) {
         ++success;
     } else {
@@ -536,7 +536,7 @@ int main(int argc, char**argv)
     // check result
     check = fopen(tempfname, "r");
     res.l = 0;
-    if (kgetline(&res, (kgets_func *)fgets, check) >= 0 &&
+    if (kfgetline(&res, check) >= 0 &&
         strcmp("[bam_translate] PG tag \"pg5hello\" on read \"123456789\" encountered with no corresponding entry in header, tag lost. Unknown tags are only reported once per input file for each tag ID.",res.s) == 0) {
         ++success;
     } else {
@@ -574,7 +574,7 @@ int main(int argc, char**argv)
     // check result
     check = fopen(tempfname, "r");
     res.l = 0;
-    if (kgetline(&res, (kgets_func *)fgets, check) < 0 &&
+    if (kfgetline(&res, check) < 0 &&
         (feof(check) || res.l == 0) ) {
         ++success;
     } else {

--- a/test/split/test_count_rg.c
+++ b/test/split/test_count_rg.c
@@ -96,7 +96,7 @@ int main(int argc, char**argv)
     // check result
     check = fopen(tempfname, "r");
     if (result_1 && count == 1 && !strcmp(output[0], "fish")
-        && kgetline(&res, (kgets_func *)fgets, check) < 0
+        && kfgetline(&res, check) < 0
         && (feof(check) || res.l == 0)) {
         ++success;
     } else {

--- a/test/split/test_expand_format_string.c
+++ b/test/split/test_expand_format_string.c
@@ -77,7 +77,7 @@ void run_test(TestState *state, const char* format_string, const char* basename,
     if (expected != NULL) {
         // Good input, should produce a file name
         if (check && output != NULL && !strcmp(output, expected)
-            && kgetline(&state->res, (kgets_func *)fgets, check) < 0
+            && kfgetline(&state->res, check) < 0
             && (feof(check) || state->res.l == 0)) {
             ++state->success;
         } else {
@@ -87,7 +87,7 @@ void run_test(TestState *state, const char* format_string, const char* basename,
     } else {
         // Bad input, should return NULL and print an error message
         if (check && output == NULL
-            && kgetline(&state->res, (kgets_func *)fgets, check) == 0
+            && kfgetline(&state->res, check) == 0
             && state->res.l > 0) {
             ++state->success;
         } else {

--- a/test/split/test_filter_header_rg.c
+++ b/test/split/test_filter_header_rg.c
@@ -211,7 +211,7 @@ int main(int argc, char *argv[])
     check = fopen(tempfname, "r");
     if ( result_1
         && check_test_1(hdr1)
-        && kgetline(&res, (kgets_func *)fgets, check) < 0
+        && kfgetline(&res, check) < 0
         && (feof(check) || res.l == 0)) {
         ++success;
     } else {
@@ -254,7 +254,7 @@ int main(int argc, char *argv[])
     check = fopen(tempfname, "r");
     if ( result_2
         && check_test_2(hdr2)
-        && kgetline(&res, (kgets_func *)fgets, check) < 0
+        && kfgetline(&res, check) < 0
         && (feof(check) || res.l == 0)) {
         ++success;
     } else {
@@ -296,7 +296,7 @@ int main(int argc, char *argv[])
     check = fopen(tempfname, "r");
     if ( result_3
         && check_test_3(hdr3)
-        && kgetline(&res, (kgets_func *)fgets, check) < 0
+        && kfgetline(&res, check) < 0
         && (feof(check) || res.l == 0)) {
         ++success;
     } else {

--- a/test/split/test_parse_args.c
+++ b/test/split/test_parse_args.c
@@ -128,10 +128,10 @@ int main(int argc, char**argv)
     check_stdout = fopen(tempfname_stdout, "r");
     check_stderr = fopen(tempfname_stderr, "r");
     if ( !result_1
-        && kgetline(&res_stdout, (kgets_func *)fgets, check_stdout) >= 0
+        && kfgetline(&res_stdout, check_stdout) >= 0
         && !feof(check_stdout)
         && res_stdout.l > 0
-        && kgetline(&res_stderr, (kgets_func *)fgets, check_stderr) < 0
+        && kfgetline(&res_stderr, check_stderr) < 0
         && (feof(check_stderr) || res_stderr.l == 0)) {
         ++success;
     } else {
@@ -180,9 +180,9 @@ int main(int argc, char**argv)
     check_stderr = fopen(tempfname_stderr, "r");
     if ( result_2
         && check_test_2(result_2)
-        && kgetline(&res_stdout, (kgets_func *)fgets, check_stdout) < 0
+        && kfgetline(&res_stdout, check_stdout) < 0
         && (feof(check_stdout) || res_stdout.l == 0)
-        && kgetline(&res_stderr, (kgets_func *)fgets, check_stderr) < 0
+        && kfgetline(&res_stderr, check_stderr) < 0
         && (feof(check_stderr) || res_stderr.l == 0)) {
         ++success;
     } else {


### PR DESCRIPTION
Use new HTSlib interfaces khgetline() and kfgetline() in place of kgetline().  Fixes complaints about undefined behaviour from clang's UBsan due to function pointers passed to kgetline() having the wrong type for the last parameter (it wants a void *, but was given functions taking either FILE * or hFILE *). The new interfaces wrap the calls to kgetline() so there is no need to pass a function pointer.