### PR TITLE
Change nquals from 256 to 257 for samtools stats.

### DIFF
--- a/stats.c
+++ b/stats.c
@@ -1613,7 +1613,8 @@ void output_stats(FILE *to, stats_t *stats, int sparse)
 
     int ibase,iqual;
     if ( stats->max_len<stats->nbases ) stats->max_len++;
-    if ( stats->max_qual+1<stats->nquals ) stats->max_qual++;
+    if ( stats->max_qual+1<stats->nquals && stats->max_qual<255 )
+        stats->max_qual++;
     fprintf(to, "# First Fragment Qualities. Use `grep ^FFQ | cut -f 2-` to extract this part.\n");
     fprintf(to, "# Columns correspond to qualities and rows to cycles. First column is the cycle number.\n");
     for (ibase=0; ibase<stats->max_len_1st; ibase++)
@@ -2318,7 +2319,7 @@ stats_t* stats_init(void)
         return NULL;
 
     stats->ngc    = 200;
-    stats->nquals = 256;
+    stats->nquals = 257; // NB: 95 is better, but need to handle qual "*"
     stats->nbases = 300;
     stats->rseq_pos     = -1;
     stats->tid = -1;

--- a/stats.c
+++ b/stats.c
@@ -190,7 +190,7 @@ typedef struct
     int nindels;        // The maximum indel length for indel distribution
 
     // Arrays for the histogram data
-    uint64_t *quals_1st, *quals_2nd;
+    uint64_t **quals_1st, **quals_2nd;
     uint64_t *gc_1st, *gc_2nd;
     acgtno_count_t *acgtno_cycles_1st, *acgtno_cycles_2nd;
     acgtno_count_t *acgtno_revcomp;
@@ -205,6 +205,7 @@ typedef struct
     int max_len_1st;        // Maximum read length for forward reads
     int max_len_2nd;        // Maximum read length for reverse reads
     int max_qual;           // Maximum quality
+    int max_qual_alloc;     // Size of quals_1st / quals_2nd
     int is_sorted;
 
     // Summary numbers
@@ -651,19 +652,46 @@ void realloc_gcd_buffer(stats_t *stats, int seq_len)
     realloc_rseq_buffer(stats);
 }
 
+void realloc_qual_buffers(stats_t *stats, int old_len, int new_len,
+                          int new_max_qual) {
+    int n = new_len+1;
+    int mq = new_max_qual+2; // we have a stats->max_qual++ when printing
+    if (mq < stats->max_qual_alloc)
+        abort();
+    int old_max_qual = stats->max_qual_alloc;
+    stats->max_qual_alloc = mq;
+
+    stats->quals_1st = realloc(stats->quals_1st, mq*sizeof(*stats->quals_1st));
+    stats->quals_2nd = realloc(stats->quals_2nd, mq*sizeof(*stats->quals_2nd));
+    if (!stats->quals_1st || !stats->quals_2nd)
+        error("Could not realloc buffers, the sequence too long: %d (%ld)\n", n,n*stats->nquals*sizeof(uint64_t));
+    memset(&stats->quals_1st[old_max_qual], 0,
+           (mq-old_max_qual)*sizeof(*stats->quals_1st));
+    memset(&stats->quals_2nd[old_max_qual], 0,
+           (mq-old_max_qual)*sizeof(*stats->quals_2nd));
+
+    for (int q = 0; q < mq; q++) {
+        if (!(stats->quals_1st[q] = realloc(stats->quals_1st[q],
+                                            n * sizeof(**stats->quals_1st))) ||
+            !(stats->quals_2nd[q] = realloc(stats->quals_2nd[q],
+                                            n * sizeof(**stats->quals_2nd))))
+            error("Could not realloc buffers, the sequence too long: %d (%ld)\n", n,n*stats->nquals*sizeof(uint64_t));
+
+        // Clear new extension if len has increased, or clear entire array
+        // if max qual has increased.
+        int pstart = q >= old_max_qual ? 0 : old_len;
+        memset(&stats->quals_1st[q][pstart], 0,
+               (new_len-pstart)*sizeof(**stats->quals_1st));
+        memset(&stats->quals_2nd[q][pstart], 0,
+               (new_len-pstart)*sizeof(**stats->quals_2nd));
+    }
+}
+
 void realloc_buffers(stats_t *stats, int seq_len)
 {
     int n = 2*(1 + seq_len - stats->nbases) + stats->nbases;
 
-    stats->quals_1st = realloc(stats->quals_1st, n*stats->nquals*sizeof(uint64_t));
-    if ( !stats->quals_1st )
-        error("Could not realloc buffers, the sequence too long: %d (%ld)\n", seq_len,n*stats->nquals*sizeof(uint64_t));
-    memset(stats->quals_1st + stats->nbases*stats->nquals, 0, (n-stats->nbases)*stats->nquals*sizeof(uint64_t));
-
-    stats->quals_2nd = realloc(stats->quals_2nd, n*stats->nquals*sizeof(uint64_t));
-    if ( !stats->quals_2nd )
-        error("Could not realloc buffers, the sequence too long: %d (2x%ld)\n", seq_len,n*stats->nquals*sizeof(uint64_t));
-    memset(stats->quals_2nd + stats->nbases*stats->nquals, 0, (n-stats->nbases)*stats->nquals*sizeof(uint64_t));
+    realloc_qual_buffers(stats, stats->nbases, n, stats->max_qual);
 
     if ( stats->mpc_buf )
     {
@@ -950,7 +978,7 @@ void collect_orig_read_stats(bam1_t *bam_line, stats_t *stats, int* gc_count_out
     // Determine which array (1st or 2nd read) will these stats go to,
     //  trim low quality bases from end the same way BWA does,
     //  fill GC histogram
-    uint64_t *quals = NULL;
+    uint64_t **quals = NULL;
     uint8_t *bam_quals = bam_get_qual(bam_line);
 
     switch (order) {
@@ -981,10 +1009,15 @@ void collect_orig_read_stats(bam1_t *bam_line, stats_t *stats, int* gc_count_out
             uint8_t qual = bam_quals[ reverse ? seq_len-i-1 : i];
             if ( qual>=stats->nquals )
                 error("TODO: quality too high %d>=%d (%s %"PRIhts_pos" %s)\n", qual, stats->nquals, sam_hdr_tid2name(stats->info->sam_header, bam_line->core.tid), bam_line->core.pos+1, bam_get_qname(bam_line));
-            if ( qual>stats->max_qual )
+            if ( qual>stats->max_qual ) {
+                realloc_qual_buffers(stats, stats->nbases, stats->nbases, qual);
+                quals = order==READ_ORDER_FIRST
+                    ? stats->quals_1st
+                    : stats->quals_2nd;
                 stats->max_qual = qual;
+            }
 
-            quals[ i*stats->nquals+qual ]++;
+            quals[qual][i]++;
             stats->sum_qual += qual;
         }
     }
@@ -1622,7 +1655,7 @@ void output_stats(FILE *to, stats_t *stats, int sparse)
         fprintf(to, "FFQ\t%d",ibase+1);
         for (iqual=0; iqual<=stats->max_qual; iqual++)
         {
-            fprintf(to, "\t%ld", (long)stats->quals_1st[ibase*stats->nquals+iqual]);
+            fprintf(to, "\t%ld", (long)stats->quals_1st[iqual][ibase]);
         }
         fprintf(to, "\n");
     }
@@ -1633,7 +1666,7 @@ void output_stats(FILE *to, stats_t *stats, int sparse)
         fprintf(to, "LFQ\t%d",ibase+1);
         for (iqual=0; iqual<=stats->max_qual; iqual++)
         {
-            fprintf(to, "\t%ld", (long)stats->quals_2nd[ibase*stats->nquals+iqual]);
+            fprintf(to, "\t%ld", (long)stats->quals_2nd[iqual][ibase]);
         }
         fprintf(to, "\n");
     }
@@ -2195,6 +2228,10 @@ void cleanup_stats_info(stats_info_t* info){
 void cleanup_stats(stats_t* stats)
 {
     free(stats->cov_rbuf.buffer); free(stats->cov);
+    for (int q = 0; q < stats->max_qual_alloc; q++) {
+        free(stats->quals_1st[q]);
+        free(stats->quals_2nd[q]);
+    }
     free(stats->quals_1st); free(stats->quals_2nd);
     free(stats->gc_1st); free(stats->gc_2nd);
     stats->isize->isize_free(stats->isize->data);
@@ -2372,10 +2409,7 @@ static void init_stat_structs(stats_t* stats, stats_info_t* info, const char* gr
     if (!stats->cov_rbuf.buffer) goto nomem;
     if ( group_id ) init_group_id(stats, info, group_id);
     // .. arrays
-    stats->quals_1st      = calloc(stats->nquals*stats->nbases,sizeof(uint64_t));
-    if (!stats->quals_1st) goto nomem;
-    stats->quals_2nd      = calloc(stats->nquals*stats->nbases,sizeof(uint64_t));
-    if (!stats->quals_2nd) goto nomem;
+    realloc_qual_buffers(stats, 0, stats->nbases, 0);
     stats->gc_1st         = calloc(stats->ngc,sizeof(uint64_t));
     if (!stats->gc_1st) goto nomem;
     stats->gc_2nd         = calloc(stats->ngc,sizeof(uint64_t));


### PR DESCRIPTION
The maximum quality in ASCII is 94 (127-33) so anything else is outside of the legal range.  However even if we wanted to handle illegal BAM and ignore the unprintable nature of SAM, using 256 is a bad choice.

The reason is down to how CPU caches work.  They're typically an N-way associative hash when each hash bucket can cache results for N addresses and the hash index is just the last bits of the memory address.  This means a power of 2 in the memory address will put a lot pile many addresses into the same bucket, saturating "N".

A trivial workaround is to multiply by 257 instead of 256, causing the bottom bits of the address to not repeatedly collide.  95 is a better multiplier however as it uses less memory and hence with it further reduces cache miss rates.

Benchmarks from perf stat:

nquals=256:

         267540049      cache-misses              #   11.334 % of all cache refs
        2360568687      cache-references

      20.572468682 seconds time elapsed

nquals=257:

          78089279      cache-misses              #    3.391 % of all cache refs
        2302704223      cache-references

      15.710843218 seconds time elapsed

nquals=95:

          45394053      cache-misses              #    2.102 % of all cache refs
        2159597370      cache-references

      13.713247565 seconds time elapsed

Quite a good speed up for such a tiny change.
*However* setting nquals=95 isn't sufficient as qual "*" is an array of 255 values in BAM (sigh).  So it needs to be >= 256.  We could fix this by mapping 255 to 95 say or better still using a generic mapping table based on real data which would vastly reduce memory for NovaSeq, but this needs buffering and multi-pass, or the ability to add new entries to the lookup table and shuffle around existing entries.  Hence this PR is the trivial win only.

The actual code in CPU cycles for the original was:

```
  0.12 │       addsd    0x218(%r15),%xmm0                                                                        
       │     quals[ i*stats->nquals+qual ]++;                                                                    
  0.22 │       addq     $0x1,(%rdx,%r8,8)                                                                        
       │     stats->sum_qual += qual;                                                                            
 52.52 │       movsd    %xmm0,0x218(%r15)                                                                        
       │     for (i=0; i<seq_len; i++)                                                                           
```

With nquals=95 the change it is:

```
(as above)
 35.44 │       movsd    %xmm0,0x218(%r15)
```

(perf stats -n showed 37176 counts to 18470 counts).  I didn't record it for nquals=257 as I didn't notice the qual "*" issue until later, however the elapsed time is the key indicator.