### PR TITLE
Add Github actions builds for Linux and Mac OS

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,0 +1,139 @@
+name: Linux CI
+on: [push, pull_request]
+
+jobs:
+  build-linux:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Fully declare each matrix entry here, as otherwise it's possible
+        # to get unexpected results due to the way the entries get expanded
+        # (See https://magmanu.github.io/blog/tech/matrices-github-actions/)
+        include:
+          # x86-64, clang, configure
+          - os: ubuntu-latest
+            use-configure: use-configure
+            htssrc: hidden-htslib
+            compiler: clang
+            sanitize: no-sanitize
+            run-extra-checks: no-extra-checks
+
+          # x86-64, gcc, configure, sanitize
+          - os: ubuntu-latest
+            use-configure: use-configure
+            htssrc: hidden-htslib
+            compiler: gcc
+            sanitize: sanitize
+            run-extra-checks: no-extra-checks
+
+          # x86-64, gcc, no configure, run extra checks
+          - os: ubuntu-latest
+            use-configure: no-configure
+            htssrc: htslib
+            compiler: gcc
+            sanitize: no-sanitize
+            run-extra-checks: run-extra-checks
+
+          # arm, gcc, configure
+          - os: ubuntu-24.04-arm
+            use-configure: use-configure
+            htssrc: hidden-htslib
+            compiler: gcc
+            sanitize: no-sanitize
+            run-extra-checks: no-extra-checks
+
+    defaults:
+      run:
+        working-directory: ./samtools
+
+    steps:
+    - name: Checkout
+      # This is actions/checkout@v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        persist-credentials: false
+        path: samtools
+
+    - name: Run apt
+      working-directory: .
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-suggests --no-install-recommends autoconf automake make ${{ matrix.compiler }} perl zlib1g-dev libbz2-dev liblzma-dev libcurl4-gnutls-dev libssl-dev libncurses5-dev libdeflate-dev
+
+    - name: Clone htslib
+      working-directory: .
+      run: |
+        mkdir -p ${{ matrix.htssrc }}
+        htslib_pr=`git log -2 --format='%s' | sed -n 's/.*htslib#\([0-9]*\).*/\1/p'`
+        ./samtools/.ci_helpers/clone ${GITHUB_REPOSITORY_OWNER} htslib ${{ matrix.htssrc }} ${GITHUB_HEAD_REF:-$GITHUB_REF_NAME} $htslib_pr
+
+    - name: Set build options
+      run: |
+        cc='clang'
+        configure_opts='--enable-werror'
+        cflags='-g -O3'
+        ldflags=''
+
+        if [ '${{ matrix.sanitize }}' = 'sanitize' ] ; then
+          cflags="-g -Og -fsanitize=address,undefined -Wno-format-truncation -Wno-format-overflow -DHTS_ALLOW_UNALIGNED=0"
+          ldflags='-fsanitize=address,undefined'
+        else
+          if [ '${{ matrix.use-configure}}' = 'use-configure' ] ; then
+            cflags="$cflags -std=c99 -pedantic"
+          fi
+        fi
+
+        echo "cc=${cc}" >> "$GITHUB_ENV"
+        echo "configure_opts=${configure_opts}" >> "$GITHUB_ENV"
+        echo "cflags=${cflags}" >> "$GITHUB_ENV"
+        echo "ldflags=${ldflags}" >> "$GITHUB_ENV"
+
+    - name: Build htslib
+      working-directory: ${{ matrix.htssrc }}
+      run: |
+        htsdir="`realpath ..`/installed-htslib"
+        echo "htsdir=${htsdir}" >> "$GITHUB_ENV"
+
+        autoreconf -i
+        { ./configure --prefix="$htsdir" ${configure_opts} ${cc:+CC="$cc"} ${cflags:+CFLAGS="$cflags"} ${ldflags:+LDFLAGS="$ldflags"} ||
+          { cat config.log ; false ; } ; } &&
+        make -j 5 &&
+        make install
+
+    - name: Configure samtools
+      if: ${{ matrix.use-configure == 'use-configure' }}
+      run: |
+        autoreconf -i
+
+        with_htslib="--with-htslib=$htsdir"
+        ldflags="${ldflags:+$ldflags }-Wl,-rpath=${htsdir}/lib"
+
+        printf "\nRunning ./configure ${with_htslib} ${configure_opts}${cc:+ CC='$cc'}${cflags:+ CFLAGS='$cflags'}${ldflags:+ LDFLAGS='$ldflags'} ...\n\n"
+
+        { ./configure $with_htslib ${configure_opts} ${cc:+CC="$cc"} ${cflags:+CFLAGS="$cflags"} ${ldflags:+LDFLAGS="$ldflags"} &&
+          { grep -qE 'CFLAGS *=.*-Werror' config.mk ||
+            { printf "\nStopping as -Werror was not set.\n" 1>&2 ; false ; } ;
+          } ;
+        } || { printf "\n### config.log content follows...\n\n" 1>&2 ; cat config.log ; false ; }
+
+    - name: Compile samtools
+      run: |
+        if [ '${{ matrix.use-configure }}' = 'use-configure' ] ; then
+          make -j5
+        else
+          make -j5 ${cc:+CC="$cc"} ${cflags:+CFLAGS="$cflags -Werror"}
+        fi
+
+    - name: Check
+      run: |
+        if [ '${{ matrix.use-configure }}' = 'use-configure' ] ; then
+          make check BGZIP=$htsdir/bin/bgzip
+        else
+          make check ${cc:+CC="$cc"} ${cflags:+CFLAGS="$cflags -Werror"}
+        fi
+
+    - name: Extra checks
+      if: ${{ matrix.run-extra-checks == 'run-extra-checks' }}
+      run: |
+        make maintainer-check

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -1,0 +1,112 @@
+name: Mac OS CI
+on: [push, pull_request]
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Fully declare each matrix entry here, as otherwise it's possible
+        # to get unexpected results due to the way the entries get expanded
+        # (See https://magmanu.github.io/blog/tech/matrices-github-actions/)
+        include:
+          # configure
+          - use-configure: use-configure
+            htssrc: hidden-htslib
+            sanitize: no-sanitize
+
+          # make only
+          - use-configure: no-configure
+            htssrc: htslib
+            sanitize: no-sanitize
+
+          # configure, sanitize
+          - use-configure: use-configure
+            htssrc: hidden-htslib
+            sanitize: sanitize
+
+    defaults:
+      run:
+        working-directory: ./samtools
+
+    steps:
+    - name: Checkout
+      # This is actions/checkout@v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        persist-credentials: false
+        path: samtools
+
+    - name: Install autotools
+      working-directory: .
+      run: |
+        brew install autoconf automake libtool
+
+    - name: Clone htslib
+      working-directory: .
+      run: |
+        mkdir -p ${{ matrix.htssrc }}
+        htslib_pr=`git log -2 --format='%s' | sed -n 's/.*htslib#\([0-9]*\).*/\1/p'`
+        ./samtools/.ci_helpers/clone ${GITHUB_REPOSITORY_OWNER} htslib ${{ matrix.htssrc }} ${GITHUB_HEAD_REF:-$GITHUB_REF_NAME} $htslib_pr
+
+    - name: Set build options
+      run: |
+        cc='clang'
+        configure_opts='--enable-werror'
+        cflags='-g -O3 -arch arm64 -arch x86_64'
+        ldflags='-arch arm64 -arch x86_64'
+
+        if [ '${{ matrix.sanitize }}' = 'sanitize' ] ; then
+          cflags="-g -Og -fsanitize=address,undefined -Wno-format-truncation -Wno-format-overflow -arch arm64 -arch x86_64 -DHTS_ALLOW_UNALIGNED=0"
+          ldflags='-fsanitize=address,undefined -arch arm64 -arch x86_64'
+        fi
+
+        echo "cc=${cc}" >> "$GITHUB_ENV"
+        echo "configure_opts=${configure_opts}" >> "$GITHUB_ENV"
+        echo "cflags=${cflags}" >> "$GITHUB_ENV"
+        echo "ldflags=${ldflags}" >> "$GITHUB_ENV"
+
+    - name: Build htslib
+      working-directory: ${{ matrix.htssrc }}
+      run: |
+        htsdir="`realpath ..`/installed-htslib"
+        echo "htsdir=${htsdir}" >> "$GITHUB_ENV"
+
+        autoreconf -i
+        { ./configure --prefix="$htsdir" ${configure_opts} ${cc:+CC="$cc"} ${cflags:+CFLAGS="$cflags"} ${ldflags:+LDFLAGS="$ldflags"} ||
+          { cat config.log ; false ; } ; } &&
+        make -j 5 &&
+        make install
+
+    - name: Configure samtools
+      if: ${{ matrix.use-configure == 'use-configure' }}
+      run: |
+        autoreconf -i
+
+        with_htslib="--with-htslib=$htsdir"
+        ldflags="${ldflags:+$ldflags }-Wl,-rpath,${htsdir}/lib"
+
+        printf "\nRunning ./configure ${with_htslib} ${configure_opts}${cc:+ CC='$cc'}${cflags:+ CFLAGS='$cflags'}${ldflags:+ LDFLAGS='$ldflags'} ...\n\n"
+
+        { ./configure $with_htslib ${configure_opts} ${cc:+CC="$cc"} ${cflags:+CFLAGS="$cflags"} ${ldflags:+LDFLAGS="$ldflags"} &&
+          { grep -qE 'CFLAGS *=.*-Werror' config.mk ||
+            { printf "\nStopping as -Werror was not set.\n" 1>&2 ; false ; } ;
+          } ;
+        } || { printf "\n### config.log content follows...\n\n" 1>&2 ; cat config.log ; false ; }
+
+    - name: Compile samtools
+      run: |
+        if [ '${{ matrix.use-configure }}' = 'use-configure' ] ; then
+          make -j5
+        else
+          make -j5 ${cc:+CC="$cc"} ${cflags:+CFLAGS="$cflags -Werror"}
+        fi
+
+    - name: Check
+      run: |
+        if [ '${{ matrix.use-configure }}' = 'use-configure' ] ; then
+          make check BGZIP=$htsdir/bin/bgzip
+        else
+          make check ${cc:+CC="$cc"} ${cflags:+CFLAGS="$cflags -Werror"}
+        fi

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -2,11 +2,12 @@ name: Windows/MinGW-W64 CI
 on: [push, pull_request]
 
 jobs:
-  build:
+  build-windows:
     runs-on: windows-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      # This is actions/checkout@v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Set up MSYS2 MinGW-W64

--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,13 @@ dnl Flags to treat warnings as errors.  These need to be applied to CFLAGS
 dnl later as they can interfere with some of the tests (notably AC_SEARCH_LIBS)
 HTS_PROG_CC_WERROR(hts_late_cflags)
 
+# Define _XOPEN_SOURCE (for strdup, etc.) unless the user has already done
+# so via $CPPFLAGS.
+AC_CHECK_DECL([_XOPEN_SOURCE], [],
+  [AC_DEFINE([_XOPEN_SOURCE], [700], [Specify X/Open requirements])],
+  [])
+
+
 AC_SYS_LARGEFILE
 
 AX_WITH_HTSLIB

--- a/m4/hts_prog_cc_warnings.m4
+++ b/m4/hts_prog_cc_warnings.m4
@@ -65,79 +65,80 @@ dnl an option that includes a hash sign...
         # Tests for flags to enable C compiler warnings
         # GCC compatible
         AS_IF([test "x$GCC" = "xyes" &&
-               "$CC" -c -Wall conftest.c > /dev/null 2>&1 &&
+               $CC -c -Wall conftest.c >&AS_MESSAGE_LOG_FD 2>&1 &&
                test -f conftest.o],[dnl
           AS_IF([test "x$ansi" = "x"],
                 [hts_cv_prog_cc_warnings="-Wall"],
                 [hts_cv_prog_cc_warnings="-Wall -ansi -pedantic"])
         ],
         # Sun Studio or Solaris C compiler
-        ["$CC" -V 2>&1 | $GREP -i -E "WorkShop|Sun C" > /dev/null 2>&1 &&
-         "$CC" -c -v -Xc conftest.c > /dev/null 2>&1 &&
+        [$CC -V 2>&1 | $GREP -i -E "WorkShop|Sun C" >&AS_MESSAGE_LOG_FD 2>&1 &&
+         $CC -c -v -Xc conftest.c >&AS_MESSAGE_LOG_FD 2>&1 &&
          test -f conftest.o],[dnl
           AS_IF([test "x$ansi" = "x"],
                 [hts_cv_prog_cc_warnings="-v"],
                 [hts_cv_prog_cc_warnings="-v -Xc"])
         ],
         # Digital Unix C compiler
-        ["$CC" -V 2>&1 | $GREP -i "Digital UNIX Compiler" > /dev/null 2>&1 &&
-         "$CC" -c -verbose -w0 -warnprotos -std1 conftest.c > /dev/null 2>&1 &&
+        [$CC -V 2>&1 | $GREP -i "Digital UNIX Compiler" >&AS_MESSAGE_LOG_FD 2>&1 &&
+         $CC -c -verbose -w0 -warnprotos -std1 conftest.c >&AS_MESSAGE_LOG_FD 2>&1 &&
          test -f conftest.o],[dnl
           AS_IF([test "x$ansi" = "x"],
                 [hts_cv_prog_cc_warnings="-verbose -w0 -warnprotos"],
                 [hts_cv_prog_cc_warnings="-verbose -w0 -warnprotos -std1"])
         ],
         # C for AIX Compiler
-        ["$CC" 2>&1 | $GREP -i "C for AIX Compiler" > /dev/null 2>&1 &&
-         "$CC" -c -qlanglvl=ansi -qinfo=all conftest.c > /dev/null 2>&1 &&
+        [$CC 2>&1 | $GREP -i "C for AIX Compiler" >&AS_MESSAGE_LOG_FD 2>&1 &&
+         $CC -c -qlanglvl=ansi -qinfo=all conftest.c >&AS_MESSAGE_LOG_FD 2>&1 &&
          test -f conftest.o],[dnl
           AS_IF([test "x$ansi" = "x"],
                 [hts_cv_prog_cc_warnings="-qsrcmsg -qinfo=all:noppt:noppc:noobs:nocnd"],
                 [hts_cv_prog_cc_warnings="-qsrcmsg -qinfo=all:noppt:noppc:noobs:nocnd -qlanglvl=ansi"])
         ],
         # IRIX C compiler
-        ["$CC" -version 2>&1 | $GREP -i "MIPSpro Compilers" > /dev/null 2>&1 &&
-         "$CC" -c -fullwarn -ansi -ansiE conftest.c > /dev/null 2>&1 &&
+        [$CC -version 2>&1 | $GREP -i "MIPSpro Compilers" >&AS_MESSAGE_LOG_FD 2>&1 &&
+         $CC -c -fullwarn -ansi -ansiE conftest.c >&AS_MESSAGE_LOG_FD 2>&1 &&
          test -f conftest.o],[dnl
           AS_IF([test "x$ansi" = "x"],
                 [hts_cv_prog_cc_warnings="-fullwarn"],
                 [hts_cv_prog_cc_warnings="-fullwarn -ansi -ansiE"])
         ],
         # HP-UX C compiler
-        [what "$CC" 2>&1 | $GREP -i "HP C Compiler" > /dev/null 2>&1 &&
-         "$CC" -c -Aa +w1 conftest.c > /dev/null 2>&1 &&
+        [what "$CC" 2>&1 | $GREP -i "HP C Compiler" >&AS_MESSAGE_LOG_FD 2>&1 &&
+         $CC -c -Aa +w1 conftest.c >&AS_MESSAGE_LOG_FD 2>&1 &&
          test -f conftest.o],[dnl
           AS_IF([test "x$ansi" = "x"],
                 [hts_cv_prog_cc_warnings="+w1"],
                 [hts_cv_prog_cc_warnings="+w1 -Aa"])
         ],
         # The NEC SX series (Super-UX 10) C compiler
-        ["$CC" -V 2>&1 | $GREP "/SX" > /dev/null 2>&1 &&
-         "$CC" -c -pvctl[,]fullmsg -Xc conftest.c > /dev/null 2>&1 &&
+        [$CC -V 2>&1 | $GREP "/SX" >&AS_MESSAGE_LOG_FD 2>&1 &&
+         $CC -c -pvctl[,]fullmsg -Xc conftest.c >&AS_MESSAGE_LOG_FD 2>&1 &&
          test -f conftest.o],[dnl
           AS_IF([test "x$ansi" = "x"],
                 [hts_cv_prog_cc_warnings="-pvctl[,]fullmsg"],
                 [hts_cv_prog_cc_warnings="-pvctl[,]fullmsg -Xc"])
         ],
         # The Cray C compiler (Unicos)
-        ["$CC" -V 2>&1 | $GREP -i "Cray" > /dev/null 2>&1 &&
-         "$CC" -c -h msglevel_2 conftest.c > /dev/null 2>&1 &&
+        [$CC -V 2>&1 | $GREP -i "Cray" >&AS_MESSAGE_LOG_FD 2>&1 &&
+         $CC -c -h msglevel_2 conftest.c >&AS_MESSAGE_LOG_FD 2>&1 &&
          test -f conftest.o],[dnl
           AS_IF([test "x$ansi" = "x"],
                 [hts_cv_prog_cc_warnings="-h#msglevel_2"],
                 [hts_cv_prog_cc_warnings="-h#msglevel_2,conform"])
         ],
         # The Tiny C Compiler
-        ["$CC" -v 2>&1 | $GREP "tcc version" > /dev/null &&
-         "$CC" -Wall -c conftest.c > /dev/null 2>&1 &&
+        [$CC -v 2>&1 | $GREP "tcc version" >&AS_MESSAGE_LOG_FD &&
+         $CC -Wall -c conftest.c >&AS_MESSAGE_LOG_FD 2>&1 &&
          test -f conftest.o],[dnl
          hts_cv_prog_cc_warnings="-Wall"
         ])
         rm -f conftest.*
+        rm -rf conftest.dSYM
       ])
     ])
 
-    AS_IF([test "x$hts_cv_prog_cc_warnings" != "x"],[
+    AS_IF([test "x$hts_cv_prog_cc_warnings" != "x"],[dnl
 dnl Print result, with underscores as spaces
 ac_arg_result=`echo "$hts_cv_prog_cc_warnings" | tr '#' ' '`
 AC_MSG_RESULT($ac_arg_result)
@@ -183,22 +184,23 @@ EOF
          # Tests for flags to make the C compiler treat warnings as errors
          # GCC compatible
          [test "x$GCC" = "xyes" &&
-          "$CC" -c -Werror conftest.c > /dev/null 2>&1 &&
+          $CC -c -Werror conftest.c >&AS_MESSAGE_LOG_FD 2>&1 &&
           test -f conftest.o],[hts_cv_prog_cc_werror="-Werror"],
          # Sun Studio or Solaris C compiler
-         ["$CC" -V 2>&1 | $GREP -i -E "WorkShop|Sun C" > /dev/null 2>&1 &&
-          "$CC" -c -errwarn=%all conftest.c > /dev/null 2>&1 &&
+         [$CC -V 2>&1 | $GREP -i -E "WorkShop|Sun C" >&AS_MESSAGE_LOG_FD 2>&1 &&
+          $CC -c -errwarn=%all conftest.c >&AS_MESSAGE_LOG_FD 2>&1 &&
           test -f conftest.o],[hts_cv_prog_cc_werror="-errwarn=%all"],
          # The Tiny C Compiler
-         ["$CC" -v 2>&1 | $GREP "tcc version" > /dev/null &&
-          "$CC" -Wall -c conftest.c > /dev/null 2>&1 &&
+         [$CC -v 2>&1 | $GREP "tcc version" >&AS_MESSAGE_LOG_FD &&
+          $CC -Wall -c conftest.c >&AS_MESSAGE_LOG_FD 2>&1 &&
           test -f conftest.o],[hts_cv_prog_cc_werror="-Werror"]
          dnl TODO: Add more compilers
         )
         rm -f conftest.*
+        rm -rf conftest.dSYM
       ])
     ])
-    AS_IF([test "x$hts_cv_prog_cc_werror" != x],[dnl
+    AS_IF([test "x$hts_cv_prog_cc_werror" != x],[
       AC_MSG_RESULT($hts_cv_prog_cc_werror)
       AS_IF([test "x$1" != x],[eval AS_TR_SH([$1])="$hts_cv_prog_cc_werror"])
     ],[dnl


### PR DESCRIPTION
As Cirrus CI is closing down, tests need to migrate elsewhere.  As Windows tests already run using Github actions, using it for Linux and Mac OS builds is the easiest solution.

Adds Github actions workflows for Linux (specifically ubuntu as it's the only flavour supported natively), and Mac OS.

Updates actions/checkout on the Windows build to the latest release.  The reference to it is also changed from a tag name to a sha hash to reduce the risk of supply-chain attack.

Fixes some issues with the existing tests found while checking the new builds:

* Adds a configure check for `_XOPEN_SOURCE` to make compilation with `-std=c99` work.

* Adjusts `HTS_PROG_CC_WARNINGS` and `HTS_PROG_CC_WERROR` to remove a directory left behind by the Mac OS compiler, and to redirect compiler messages to the log file.

* Remove quotes around `$CC` invocations in `HTS_PROG_CC_WARNINGS` and `HTS_PROG_CC_WERROR`.  `AC_PROG_CC` may add flags after the C compiler path to `$CC`, so it needs to be used unquoted so that field splitting can be done on the value.

The Cirrus CI tests are left enabled for now so we can run both side-by-side for a bit. They can be removed once we're confident that the new ones are working. Unfortunately we will lose the Rocky Linux test when we turn Cirrus off, although it may be possible to do something with containers to get it back again.