### PR TITLE
Remove pointless NULL checks

### DIFF
--- a/bam_consensus.c
+++ b/bam_consensus.c
@@ -2244,9 +2244,6 @@ static int basic_pileup(void *cd, samFile *fp, sam_hdr_t *h, pileup_t *p,
     if (consensus_base(opts, p, pos, depth, &cb, &cq) < 0)
         return -1;
 
-    if (!p)
-        return 0;
-
     if (!opts->show_del && cb == '*')
         return 0;
 
@@ -2403,9 +2400,6 @@ static int basic_fasta(void *cd, samFile *fp, sam_hdr_t *h, pileup_t *p,
 
     if (consensus_base(opts, p, pos, depth, &cb, &cq) < 0)
         return -1;
-
-    if (!p)
-        return 0;
 
     if (!opts->show_del && cb == '*') {
         c->last_pos = pos;


### PR DESCRIPTION
These happen long after the pointers have been dereferenced, and, in the case of `basic_pileup()`, before the loop that could result in `p` being set to NULL.

As far as I can tell, `basic_pileup()` and `basic_fasta()` are only ever [called via `pileup_loop()`](https://github.com/samtools/samtools/blob/8e8477146a449b564f08f53d6e49204bac1e52f7/consensus_pileup.c#L437), which will drop out of the while loop where they are called if [the pointer (`phead` in that function) is NULL](https://github.com/samtools/samtools/blob/8e8477146a449b564f08f53d6e49204bac1e52f7/consensus_pileup.c#L384).