### PR TITLE
Version.sh: cope with .git being present but no git executable

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -27,7 +27,7 @@
 VERSION=1.23.1
 
 # If we have a git clone, then check against the current tag
-if [ -e .git ]
+if [ -e .git -a "x`which git`" != "x" ]
 then
     # If we ever get to 10.x this will need to be more liberal
     VERSION=`git describe --match '[0-9].[0-9]*' --dirty --always`


### PR DESCRIPTION
This can happen if we've cloned outside of a VM and copied the files into it, as happens with the vmactions/freebsd-vm action.