### PR TITLE
Improve multi-threaded scaling for merge, view -U, mpileup, bedcov and coverage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@ Release a.b
   merging many compressed files did not scale beyond about two CPUs regardless
   of the `-@` value.
 
+* `samtools view -U` now also uses the thread pool for the unaccounted-reads
+  output file, so that stream is no longer compressed single-threaded.
+
 Release 1.24 (9th July 2026)
 ----------------------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,10 @@ Release a.b
 * `samtools view -U` now also uses the thread pool for the unaccounted-reads
   output file, so that stream is no longer compressed single-threaded.
 
+* `samtools mpileup`, `samtools bedcov` and `samtools coverage` now accept the
+  `-@`/`--threads` option and use a thread pool to decompress their inputs.
+  These commands previously had no threading support.
+
 Release 1.24 (9th July 2026)
 ----------------------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 Release a.b
 -----------
 
+* `samtools merge` now decompresses its input files using the thread pool as
+  well as compressing the output.  Previously only the output was threaded, so
+  merging many compressed files did not scale beyond about two CPUs regardless
+  of the `-@` value.
+
 Release 1.24 (9th July 2026)
 ----------------------------
 

--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -43,6 +43,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <htslib/klist.h>
 #include <htslib/khash_str2int.h>
 #include <htslib/cram.h>
+#include <htslib/thread_pool.h>
 #include "samtools.h"
 #include "bedidx.h"
 #include "sam_opts.h"
@@ -482,6 +483,7 @@ static int mpileup(mplp_conf_t *conf, int nfn, char **fn, char **fn_idx)
     bam_sample_t *sm = NULL;
     kstring_t buf;
     mplp_pileup_t gplp;
+    htsThreadPool p = {NULL, 0};
 
     memset(&gplp, 0, sizeof(mplp_pileup_t));
     memset(&buf, 0, sizeof(kstring_t));
@@ -495,6 +497,15 @@ static int mpileup(mplp_conf_t *conf, int nfn, char **fn, char **fn_idx)
         exit(EXIT_FAILURE);
     }
 
+    // A shared thread pool attached to every input file lets mpileup use
+    // multiple threads for decompressing its (potentially many) inputs.
+    if (conf->ga.nthreads > 0) {
+        if (!(p.pool = hts_tpool_init(conf->ga.nthreads))) {
+            fprintf(stderr, "[%s] failed to set up thread pool\n", __func__);
+            exit(EXIT_FAILURE);
+        }
+    }
+
     // read the header of each file in the list and initialize data
     refs_t *refs = NULL;
     for (i = 0; i < nfn; ++i) {
@@ -506,6 +517,8 @@ static int mpileup(mplp_conf_t *conf, int nfn, char **fn, char **fn_idx)
             fprintf(stderr, "[%s] failed to open %s: %s\n", __func__, fn[i], strerror(errno));
             exit(EXIT_FAILURE);
         }
+        if (p.pool)
+            hts_set_opt(data[i]->fp, HTS_OPT_THREAD_POOL, &p);
         if (hts_set_opt(data[i]->fp, CRAM_OPT_DECODE_MD, 0)) {
             fprintf(stderr, "Failed to set CRAM_OPT_DECODE_MD value\n");
             exit(EXIT_FAILURE);
@@ -926,6 +939,7 @@ fail:
         if (data[i]->iter) hts_itr_destroy(data[i]->iter);
         free(data[i]);
     }
+    if (p.pool) hts_tpool_destroy(p.pool);
     free(data); free(plp); free(n_plp);
     free(mp_ref.ref[0]);
     free(mp_ref.ref[1]);
@@ -1062,7 +1076,7 @@ static void print_usage(FILE *fp, const mplp_conf_t *mplp)
 "  -a -a (or -aa)           output absolutely all positions, including unused ref. sequences\n"
 "\n"
 "Generic options:\n");
-    sam_global_opt_help(fp, "-.--.--.");
+    sam_global_opt_help(fp, "-.--.@-.");
 
     fprintf(fp, "\n"
 "Note that using \"samtools mpileup\" to generate BCF or VCF files has been\n"
@@ -1095,7 +1109,7 @@ int bam_mpileup(int argc, char *argv[])
 
     static const struct option lopts[] =
     {
-        SAM_OPT_GLOBAL_OPTIONS('-', 0, '-', '-', 0, '-'),
+        SAM_OPT_GLOBAL_OPTIONS('-', 0, '-', '-', 0, '@'),
         {"rf", required_argument, NULL, 1},   // require flag
         {"ff", required_argument, NULL, 2},   // filter flag
         {"incl-flags", required_argument, NULL, 1},
@@ -1146,7 +1160,7 @@ int bam_mpileup(int argc, char *argv[])
         {NULL, 0, NULL, 0}
     };
 
-    while ((c = getopt_long(argc, argv, "Af:r:l:q:Q:RC:Bd:b:o:EG:6OsxXaM",lopts,NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "Af:r:l:q:Q:RC:Bd:b:o:EG:6OsxXaM@:",lopts,NULL)) >= 0) {
         switch (c) {
         case 'x': mplp.flag &= ~MPLP_SMART_OVERLAPS; break;
         case  1 :

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -1138,6 +1138,7 @@ int bam_merge_core2(SamOrder sam_order, char* sort_tag, const char *out, const c
     template_coordinate_keys_t *keys = NULL;
     khash_t(const_c2c) *lib_lookup = NULL;
     int refs_out_shared = 1;
+    htsThreadPool p = {NULL, 0};
 
     // Is there a specified pre-prepared header to use for output?
     if (headers) {
@@ -1201,6 +1202,17 @@ int bam_merge_core2(SamOrder sam_order, char* sort_tag, const char *out, const c
         if (res) return -1; // FIXME: memory leak
     }
 
+    // Create a shared thread pool for input decompression and output
+    // compression.  Attaching it to every input file (below) as well as the
+    // output is what allows merge to scale beyond ~2 CPUs; previously only the
+    // output was threaded, leaving all input decompression single-threaded.
+    if (n_threads > 1) {
+        if (!(p.pool = hts_tpool_init(n_threads))) {
+            print_error(cmd, "failed to set up thread pool");
+            goto fail;
+        }
+    }
+
     // open and read the header from each file
     for (i = 0; i < n; ++i) {
         sam_hdr_t *hin;
@@ -1210,6 +1222,8 @@ int bam_merge_core2(SamOrder sam_order, char* sort_tag, const char *out, const c
             goto fail;
         }
         hts_set_opt(fp[i], HTS_OPT_BLOCK_SIZE, BAM_BLOCK_SIZE);
+        if (p.pool)
+            hts_set_opt(fp[i], HTS_OPT_THREAD_POOL, &p);
         hin = sam_hdr_read(fp[i]);
         if (hin == NULL) {
             print_error(cmd, "failed to read header from \"%s\"", fn[i]);
@@ -1450,7 +1464,8 @@ int bam_merge_core2(SamOrder sam_order, char* sort_tag, const char *out, const c
             return -1;
         }
     }
-    if (!(flag & MERGE_UNCOMP)) hts_set_threads(fpout, n_threads);
+    if (p.pool)
+        hts_set_opt(fpout, HTS_OPT_THREAD_POOL, &p);
 
     if (refs_out && hts_set_opt(fpout, CRAM_OPT_SHARED_REF, refs_out))
         goto fail;
@@ -1524,8 +1539,10 @@ int bam_merge_core2(SamOrder sam_order, char* sort_tag, const char *out, const c
     free(RG); free(translation_tbl); free(fp); free(heap); free(iter); free(hdr);
     if (sam_close(fpout) < 0) {
         print_error_errno(cmd, "error closing output file \"%s\"", out);
+        if (p.pool) hts_tpool_destroy(p.pool);
         return -1;
     }
+    if (p.pool) hts_tpool_destroy(p.pool);
     if (keys != NULL) {
         for (i = 0; i < keys->m; ++i) {
             free(keys->buffers[i]);
@@ -1553,6 +1570,7 @@ int bam_merge_core2(SamOrder sam_order, char* sort_tag, const char *out, const c
         if (fp && fp[i]) sam_close(fp[i]);
         if (heap && heap[i].entry.bam_record) bam_destroy1(heap[i].entry.bam_record);
     }
+    if (p.pool) hts_tpool_destroy(p.pool);
     if (hout) sam_hdr_destroy(hout);
     free(RG);
     free(translation_tbl);

--- a/bedcov.c
+++ b/bedcov.c
@@ -136,15 +136,16 @@ int main_bedcov(int argc, char *argv[])
         hdr = 0;
 
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
+    htsThreadPool p = {NULL, 0};
     static const struct option lopts[] = {
         {"min-MQ", required_argument, NULL, 'Q'},
         {"min-mq", required_argument, NULL, 'Q'},
         {"max-depth", required_argument, NULL, 'd'+1000},
-        SAM_OPT_GLOBAL_OPTIONS('-', 0, '-', '-', 0, '-'),
+        SAM_OPT_GLOBAL_OPTIONS('-', 0, '-', '-', 0, '@'),
         { NULL, 0, NULL, 0 }
     };
 
-    while ((c = getopt_long(argc, argv, "Q:Xg:G:jd:Hc", lopts, NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "Q:Xg:G:jd:Hc@:", lopts, NULL)) >= 0) {
         switch (c) {
         case 'Q': min_mapQ = atoi(optarg); break;
         case 'X': has_index_file = 1; break;
@@ -189,7 +190,7 @@ int main_bedcov(int argc, char *argv[])
                         "                          including this value will be displayed in a separate column\n");
         fprintf(stderr, "      -c                  add an additional column showing read count\n");
         fprintf(stderr, "      -H                  print a comment/header line with column information.\n");
-        sam_global_opt_help(stderr, "-.--.--.");
+        sam_global_opt_help(stderr, "-.--.@-.");
         return 1;
     }
     if (has_index_file) {
@@ -208,10 +209,18 @@ int main_bedcov(int argc, char *argv[])
     memset(&str, 0, sizeof(kstring_t));
     aux = calloc(n, sizeof(aux_t*));
     idx = calloc(n, sizeof(hts_idx_t*));
+    if (ga.nthreads > 0) {
+        if (!(p.pool = hts_tpool_init(ga.nthreads))) {
+            print_error("bedcov", "failed to set up thread pool");
+            return 2;
+        }
+    }
     for (i = 0; i < n; ++i) {
         aux[i] = calloc(1, sizeof(aux_t));
         aux[i]->min_mapQ = min_mapQ;
         aux[i]->fp = sam_open_format(argv[i+optind+1], "r", &ga.in);
+        if (aux[i]->fp && p.pool)
+            hts_set_opt(aux[i]->fp, HTS_OPT_THREAD_POOL, &p);
         if (aux[i]->fp) {
             // If index filename has not been specfied, look in BAM folder
             if (has_index_file) {
@@ -375,6 +384,7 @@ bed_error:
     }
     free(aux); free(idx);
     free(str.s);
+    if (p.pool) hts_tpool_destroy(p.pool);
     sam_global_args_free(&ga);
     return status;
 }

--- a/coverage.c
+++ b/coverage.c
@@ -52,6 +52,7 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include "htslib/sam.h"
 #include "htslib/hts.h"
+#include "htslib/thread_pool.h"
 #include "samtools.h"
 #include "sam_opts.h"
 
@@ -132,7 +133,7 @@ static int usage(void) {
             "  -h, --help              help (this page)\n");
 
     fprintf(stdout, "\nGeneric options:\n");
-    sam_global_opt_help(stdout, "-.--.--.");
+    sam_global_opt_help(stdout, "-.--.@-.");
 
     fprintf(stdout,
             "\nSee manpage for additional details.\n"
@@ -340,8 +341,9 @@ int main_coverage(int argc, char *argv[]) {
     FILE *file_out = stdout;
 
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
+    htsThreadPool p = {NULL, 0};
     static const struct option lopts[] = {
-        SAM_OPT_GLOBAL_OPTIONS('-', 0, '-', '-', 0, '-'),
+        SAM_OPT_GLOBAL_OPTIONS('-', 0, '-', '-', 0, '@'),
         {"rf", required_argument, NULL, 1}, // require flag
         {"ff", required_argument, NULL, 2}, // filter flag
         {"incl-flags", required_argument, NULL, 1}, // require flag
@@ -368,7 +370,7 @@ int main_coverage(int argc, char *argv[]) {
     // parse the command line
     int c;
     opterr = 0;
-    while ((c = getopt_long(argc, argv, "Ao:l:q:Q:hHw:r:b:md:D", lopts, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, "Ao:l:q:Q:hHw:r:b:md:D@:", lopts, NULL)) != -1) {
         switch (c) {
             case 1:
                 if ((required_flags = bam_str2flag(optarg)) < 0) {
@@ -482,6 +484,14 @@ int main_coverage(int argc, char *argv[]) {
         goto coverage_end;
     }
 
+    if (ga.nthreads > 0) {
+        if (!(p.pool = hts_tpool_init(ga.nthreads))) {
+            print_error("coverage", "Failed to set up thread pool");
+            status = EXIT_FAILURE;
+            goto coverage_end;
+        }
+    }
+
     for (i = 0; i < n_bam_files; ++i) {
         int rf;
         data[i] = (bam_aux_t *) calloc(1, sizeof(bam_aux_t));
@@ -497,6 +507,8 @@ int main_coverage(int argc, char *argv[]) {
             status = EXIT_FAILURE;
             goto coverage_end;
         }
+        if (p.pool)
+            hts_set_opt(data[i]->fp, HTS_OPT_THREAD_POOL, &p);
         rf = SAM_FLAG | SAM_RNAME | SAM_POS | SAM_MAPQ | SAM_CIGAR | SAM_SEQ;
         if (opt_min_baseQ) rf |= SAM_QUAL;
 
@@ -725,6 +737,7 @@ coverage_end:
             free(fn[i]);
         free(fn);
     }
+    if (p.pool) hts_tpool_destroy(p.pool);
     sam_global_args_free(&ga);
 
     return status;

--- a/doc/samtools-bedcov.1
+++ b/doc/samtools-bedcov.1
@@ -115,6 +115,9 @@ copied to the output. When it is not available, a header is created with field
 names matching the fields listed in the GA4GH BED specification.
 The \fB-c\fR and \fB-d\fR options can add further per-file columns named
 .IR in1.sam "_count and " in1.sam "_depth along with " in1.sam "_count."
+.TP
+.BI "-@ " INT ", --threads " INT
+Number of input decompression threads to use in addition to the main thread [0].
 
 .SH AUTHOR
 .PP

--- a/doc/samtools-coverage.1
+++ b/doc/samtools-coverage.1
@@ -128,6 +128,9 @@ Show specified region. Format: chr:start-end.
 .TP
 .BI -h,\ --help
 Shows command help.
+.TP
+.BI "-@ " INT ", --threads " INT
+Number of input decompression threads to use in addition to the main thread [0].
 
 .SH EXAMPLES
 

--- a/doc/samtools-mpileup.1
+++ b/doc/samtools-mpileup.1
@@ -522,6 +522,9 @@ Output absolutely all positions, including unused reference sequences.
 Note that when used in conjunction with a BED file the -a option may
 sometimes operate as if -aa was specified if the reference sequence
 has coverage outside of the region specified in the BED file.
+.TP
+.BI "-@ " INT ", --threads " INT
+Number of input decompression threads to use in addition to the main thread [0].
 .PP
 .B BAQ (Base Alignment Quality)
 .PP

--- a/sam_view.c
+++ b/sam_view.c
@@ -1487,6 +1487,7 @@ int main_samview(int argc, char *argv[])
         }
         hts_set_opt(settings.in,  HTS_OPT_THREAD_POOL, &p);
         if (settings.out) hts_set_opt(settings.out, HTS_OPT_THREAD_POOL, &p);
+        if (settings.un_out) hts_set_opt(settings.un_out, HTS_OPT_THREAD_POOL, &p);
     }
     if (is_header_only) goto view_end; // no need to print alignments
 

--- a/test/test.pl
+++ b/test/test.pl
@@ -957,6 +957,8 @@ sub test_mpileup
 
     # print "$$opts{bin}samtools mpileup -gb $$opts{tmp}/mpileup.list -f $$opts{tmp}/$args{ref}.gz > $$opts{tmp}/mpileup.bcf\n";
     test_cmd($opts,out=>'dat/mpileup.out.1',err=>'dat/mpileup.err.1',cmd=>"$$opts{bin}/samtools mpileup -b $$opts{tmp}/mpileup.bam.list -f $$opts{tmp}/mpileup.ref.fa.gz -r17:100-150");
+    # Threaded input decoding must give identical output to the single-threaded run.
+    test_cmd($opts,out=>'dat/mpileup.out.1',err=>'dat/mpileup.err.1',cmd=>"$$opts{bin}/samtools mpileup -\@2 -b $$opts{tmp}/mpileup.bam.list -f $$opts{tmp}/mpileup.ref.fa.gz -r17:100-150");
     test_cmd($opts,out=>'dat/mpileup.out.1',err=>'dat/mpileup.err.1',cmd=>"$$opts{bin}/samtools mpileup -b $$opts{tmp}/mpileup.cram.list -f $$opts{tmp}/mpileup.ref.fa.gz -r17:100-150");
     test_cmd($opts,out=>'dat/mpileup.out.1',err=>'dat/mpileup.err.1',cmd=>"$$opts{bin}/samtools mpileup -b $$opts{tmp}/mpileup.bam.urllist -f $$opts{tmp}/mpileup.ref.fa.gz -r17:100-150");
     test_cmd($opts,out=>'dat/mpileup.out.1',err=>'dat/mpileup.err.1',cmd=>"$$opts{bin}/samtools mpileup -b $$opts{tmp}/mpileup.cram.urllist -f $$opts{tmp}/mpileup.ref.fa.gz -r17:100-150");
@@ -3826,6 +3828,8 @@ sub test_bedcov
 
     test_cmd($opts,out=>'bedcov/bedcov.expected',cmd=>"$$opts{bin}/samtools bedcov $$opts{path}/bedcov/bedcov.bed $$opts{path}/bedcov/bedcov.bam");
     test_cmd($opts,out=>'bedcov/bedcov_j.expected',cmd=>"$$opts{bin}/samtools bedcov -j $$opts{path}/bedcov/bedcov.bed $$opts{path}/bedcov/bedcov.bam");
+    # Threaded input decoding must give identical output to the single-threaded run.
+    test_cmd($opts,out=>'bedcov/bedcov.expected',cmd=>"$$opts{bin}/samtools bedcov -\@2 $$opts{path}/bedcov/bedcov.bed $$opts{path}/bedcov/bedcov.bam");
     test_cmd($opts,out=>'bedcov/bedcov_gG.expected',cmd=>"$$opts{bin}/samtools bedcov -g512 -G2048 $$opts{path}/bedcov/bedcov_gG.bed $$opts{path}/bedcov/bedcov.bam");
     test_cmd($opts,out=>'bedcov/bedcov_c.expected',cmd=>"$$opts{bin}/samtools bedcov -c $$opts{path}/bedcov/bedcov_gG.bed $$opts{path}/bedcov/bedcov.bam");
     #with header
@@ -4151,6 +4155,8 @@ sub test_coverage
 
     #basic / existing
     test_cmd($opts, out=>"coverage/1.expected", cmd=>"$$opts{bin}/samtools coverage $$opts{path}/dat/sample.sam");
+    #threaded input decoding must give identical output to the single-threaded run
+    test_cmd($opts, out=>"coverage/1.expected", cmd=>"$$opts{bin}/samtools coverage -\@2 $$opts{path}/dat/sample.sam");
     #coverage --min-depth 1
     test_cmd($opts, out=>"coverage/1.expected", cmd=>"$$opts{bin}/samtools coverage --min-depth 1 $$opts{path}/dat/sample.sam");
     #coverage --min-depth 2


### PR DESCRIPTION
Several subcommands did not scale past ~2 CPUs even when given a large
`-@`, because the htslib thread pool was not attached to every file
handle involved in the heavy read/write work.

This PR addresses that in three related but self-contained commits:

* **merge**: `bam_merge_core2()` only threaded the output file (via
  `hts_set_threads(fpout)`), leaving all input decompression on the main
  thread. Merging many compressed BAM/CRAM files therefore capped at
  about two CPUs regardless of `-@`. A single shared `htsThreadPool` is
  now attached to every input as well as the output, mirroring what
  `bam_merge_simple()` (used by `sort`) already does.

* **view -U**: the `-U` unaccounted-reads output file was opened without
  the shared pool, so that stream compressed single-threaded. It now
  gets the pool alongside the main input/output.

* **mpileup, bedcov, coverage**: these read (potentially many) inputs but
  had no threading support at all (`-@` was disabled in their
  `SAM_OPT_GLOBAL_OPTIONS`). They now accept `-@`/`--threads` and attach
  a shared pool to each input for decompression. All three write plain
  text, so no output-side threading is needed. Man pages and threaded
  regression cases (asserting output identical to the single-threaded
  run) are added.

`sort` is intentionally not touched here: it already wires its pool
correctly and its remaining ceiling is architectural (a serial
`sam_read1` reader loop and a single-threaded k-way merge), which would
require a larger redesign.

Tested with `make test` (all pass, including new `-@2` cases) and
`make maintainer-check`; threaded output verified byte-identical to the
single-threaded output for each command.

Assisted-by: Claude:claude-opus-4-8
