### PR TITLE
Add shared helper for samtools @PG lines; fix reset/rmdup provenance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ faidx.o: faidx.c config.h $(htslib_faidx_h) $(htslib_hts_h) $(htslib_hfile_h) $(
 padding.o: padding.c config.h $(htslib_kstring_h) $(htslib_sam_h) $(htslib_faidx_h) $(sam_opts_h) $(samtools_h)
 phase.o: phase.c config.h $(htslib_hts_h) $(htslib_sam_h) $(htslib_kstring_h) $(sam_opts_h) $(samtools_h) $(htslib_hts_os_h) $(htslib_kseq_h) $(htslib_khash_h) $(htslib_ksort_h)
 reference.o: reference.c config.h $(htslib_sam_h) $(htslib_cram_h) $(samtools_h) $(sam_opts_h)
-sam_opts.o: sam_opts.c config.h $(sam_opts_h)
+sam_opts.o: sam_opts.c config.h $(sam_opts_h) $(samtools_h)
 sam_utils.o: sam_utils.c config.h $(sam_utils_h)
 sam_view.o: sam_view.c config.h $(htslib_sam_h) $(htslib_faidx_h) $(htslib_khash_h) $(htslib_kstring_h) $(htslib_hfile_h) $(htslib_thread_pool_h) $(htslib_hts_expr_h) $(samtools_h) $(sam_opts_h) $(bam_h) $(bedidx_h) $(sam_utils_h)
 sample.o: sample.c config.h $(sample_h) $(htslib_khash_h)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,20 @@
 Release a.b
 -----------
 
+New work and changes:
+
+* CHANGE.  When the HTSlib version in use cannot be deduced from the SAMtools
+  version, the `@PG` `VN` field now records it too, for example
+  `VN:1.24.1 (with HTSlib 1.25)`.  As SAMtools and HTSlib are released together
+  with matching major and minor version numbers, `VN` is unchanged in the usual
+  case.  All subcommands now add their `@PG` line via a single shared helper.
+
+* FIX.  `samtools reset` now records the version (`VN`) in its `@PG` line, as
+  every other subcommand does; previously it wrote only the command line.
+
+* NEW.  `samtools rmdup` now adds a `@PG` line and accepts `--no-PG` to
+  suppress it, matching the other subcommands.
+
 Release 1.24 (9th July 2026)
 ----------------------------
 

--- a/bam_addrprg.c
+++ b/bam_addrprg.c
@@ -438,11 +438,7 @@ static bool init(const parsed_opts_t* opts, state_t** state_out) {
 static bool readgroupise(parsed_opts_t *opts, state_t* state, char *arg_list)
 {
     // Write PG line to header
-    if (!opts->no_pg && sam_hdr_add_pg(state->output_header, "samtools",
-                                       "VN", samtools_version(),
-                                       arg_list ? "CL": NULL,
-                                       arg_list ? arg_list : NULL,
-                                       NULL))
+    if (samtools_add_pg_line(state->output_header, arg_list, opts->no_pg))
         return false;
 
     // Write header to output

--- a/bam_ampliconclip.c
+++ b/bam_ampliconclip.c
@@ -48,7 +48,7 @@ typedef enum {
 } clipping_type;
 
 typedef struct {
-    int add_pg;
+    int no_pg;
     int use_strand;
     int write_clipped;
     int mark_fail;
@@ -727,10 +727,7 @@ static int bam_clip(samFile *in, samFile *out, samFile *reject, char *bedfile,
 
     ks_free(&str);
 
-    if (param->add_pg && sam_hdr_add_pg(header, "samtools", "VN", samtools_version(),
-                        param->arg_list ? "CL" : NULL,
-                        param->arg_list ? param->arg_list : NULL,
-                        NULL) != 0) {
+    if (samtools_add_pg_line(header, param->arg_list, param->no_pg) != 0) {
         fprintf(stderr, "[ampliconclip] warning: unable to add @PG line to header.\n");
     }
     if (sam_hdr_write(out, header) < 0) {
@@ -1083,7 +1080,7 @@ int amplicon_clip_main(int argc, char **argv) {
     htsThreadPool p = {NULL, 0};
     samFile *in = NULL, *out = NULL, *reject = NULL;
     clipping_type clipping = soft_clip;
-    cl_param_t param = {1, 0, 0, 0, 0, -1, -1, 0, 0, 1, 5, 0, NULL, NULL, NULL};
+    cl_param_t param = {0, 0, 0, 0, 0, -1, -1, 0, 0, 1, 5, 0, NULL, NULL, NULL};
 
     static const struct option lopts[] = {
         SAM_OPT_GLOBAL_OPTIONS('-', 0, 'O', 0, 0, '@'),
@@ -1112,7 +1109,7 @@ int amplicon_clip_main(int argc, char **argv) {
             case 'o': fnout = optarg; break;
             case 'f': param.stats_file = optarg; break;
             case 'u': wmode[2] = '0'; break;
-            case 1002: param.add_pg = 0; break;
+            case 1002: param.no_pg = 1; break;
             case 1003: clipping = soft_clip; break;
             case 1004: clipping = hard_clip; break;
             case 1005: param.use_strand = 1; break;

--- a/bam_cat.c
+++ b/bam_cat.c
@@ -420,11 +420,7 @@ int cram_cat(samFile * const firstfile, int nfn, char * const *fn,
     out_c = out->fp.cram;
     cram_set_option(out_c, CRAM_OPT_VERSION, vers);
 
-    if (!no_pg && sam_hdr_add_pg(new_h, "samtools",
-                                 "VN", samtools_version(),
-                                 arg_list ? "CL": NULL,
-                                 arg_list ? arg_list : NULL,
-                                 NULL))
+    if (samtools_add_pg_line(new_h, arg_list, no_pg))
         goto closefiles;
 
     if (sam_hdr_write(out, new_h) < 0) {
@@ -721,11 +717,7 @@ int bam_cat(samFile * const firstfile, int nfn, char * const *fn, sam_hdr_t *h, 
         goto fail;
     }
 
-    if (!no_pg && sam_hdr_add_pg(new_h, "samtools",
-                                    "VN", samtools_version(),
-                                    arg_list ? "CL": NULL,
-                                    arg_list ? arg_list : NULL,
-                                    NULL))
+    if (samtools_add_pg_line(new_h, arg_list, no_pg))
         goto fail;
 
     if (bam_hdr_write(fp, new_h) < 0) {

--- a/bam_import.c
+++ b/bam_import.c
@@ -282,11 +282,7 @@ static int import_fastq(int argc, char **argv, opts_t *opts) {
             print_error("view", "failed to create arg_list");
             goto err;
         }
-        if (sam_hdr_add_pg(hdr_out, "samtools",
-                           "VN", samtools_version(),
-                           arg_list ? "CL" : NULL,
-                           arg_list ? arg_list : NULL,
-                           NULL)) {
+        if (samtools_add_pg_line(hdr_out, arg_list, 0)) {
             fprintf(stderr, "Failed to add PG line to the header");
             free(arg_list);
             goto err;

--- a/bam_markdup.c
+++ b/bam_markdup.c
@@ -1611,10 +1611,7 @@ static int bam_mark_duplicates(md_param_t *param) {
     }
     ks_free(&str);
 
-    if (!param->no_pg && sam_hdr_add_pg(header, "samtools", "VN", samtools_version(),
-                        param->arg_list ? "CL" : NULL,
-                        param->arg_list ? param->arg_list : NULL,
-                        NULL) != 0) {
+    if (samtools_add_pg_line(header, param->arg_list, param->no_pg) != 0) {
         print_error("markdup", "warning, unable to add @PG line to header.\n");
     }
 

--- a/bam_mate.c
+++ b/bam_mate.c
@@ -1027,11 +1027,7 @@ static int bam_mating_core(samFile *in, samFile *out, int remove_reads,
     }
     ks_free(&str);
 
-    if (!no_pg && sam_hdr_add_pg(header, "samtools",
-                                 "VN", samtools_version(),
-                                 arg_list ? "CL": NULL,
-                                 arg_list ? arg_list : NULL,
-                                 NULL))
+    if (samtools_add_pg_line(header, arg_list, no_pg))
         goto fail;
 
     if (sam_hdr_write(out, header) < 0) goto write_fail;

--- a/bam_md.c
+++ b/bam_md.c
@@ -423,11 +423,7 @@ int bam_fillmd(int argc, char *argv[])
         print_error_errno("calmd", "Failed to open output");
         goto fail;
     }
-    if (!no_pg && sam_hdr_add_pg(header, "samtools",
-                                 "VN", samtools_version(),
-                                 arg_list ? "CL": NULL,
-                                 arg_list ? arg_list : NULL,
-                                 NULL)) {
+    if (samtools_add_pg_line(header, arg_list, no_pg)) {
         print_error("calmd", "failed to add PG line to header");
         goto fail;
     }

--- a/bam_reheader.c
+++ b/bam_reheader.c
@@ -77,11 +77,7 @@ int bam_reheader(BGZF *in, sam_hdr_t *h, int fd,
         goto fail;
     }
 
-    if (!no_pg && sam_hdr_add_pg(h, "samtools",
-                           "VN", samtools_version(),
-                           arg_list ? "CL": NULL,
-                           arg_list ? arg_list : NULL,
-                           NULL) != 0)
+    if (samtools_add_pg_line(h, arg_list, no_pg) != 0)
             goto fail;
 
     if (bam_hdr_write(fp, h) < 0) {
@@ -140,11 +136,7 @@ int cram_reheader(cram_fd *in, sam_hdr_t *h, const char *arg_list, int no_pg)
     if (!cram_h)
         return -1;
     cram_fd_set_header(out, cram_h);
-    if (!no_pg && sam_hdr_add_pg(cram_fd_get_header(out), "samtools",
-                           "VN", samtools_version(),
-                           arg_list ? "CL": NULL,
-                           arg_list ? arg_list : NULL,
-                           NULL))
+    if (samtools_add_pg_line(cram_fd_get_header(out), arg_list, no_pg))
             goto err;
 
     if (sam_hdr_write(h_out, cram_h) != 0)
@@ -212,10 +204,7 @@ int cram_reheader_inplace2(cram_fd *fd, sam_hdr_t *h, const char *arg_list,
     if (!cram_h)
         goto err;
 
-    if (!no_pg && sam_hdr_add_pg(cram_h, "samtools", "VN", samtools_version(),
-                                 arg_list ? "CL": NULL,
-                                 arg_list ? arg_list : NULL,
-                                 NULL))
+    if (samtools_add_pg_line(cram_h, arg_list, no_pg))
         goto err;
 
     int header_len = sam_hdr_length(cram_h);
@@ -311,10 +300,7 @@ int cram_reheader_inplace3(cram_fd *fd, sam_hdr_t *h, const char *arg_list,
     if (!cram_h)
         goto err;
 
-    if (!no_pg && sam_hdr_add_pg(cram_h, "samtools", "VN", samtools_version(),
-                                 arg_list ? "CL": NULL,
-                                 arg_list ? arg_list : NULL,
-                                 NULL))
+    if (samtools_add_pg_line(cram_h, arg_list, no_pg))
         goto err;
 
     int header_len = sam_hdr_length(cram_h);

--- a/bam_rmdup.c
+++ b/bam_rmdup.c
@@ -260,6 +260,8 @@ static int rmdup_usage(void) {
     fprintf(stderr, "Usage:  samtools rmdup [-sS] <input.srt.bam> <output.bam>\n\n");
     fprintf(stderr, "Option: -s    rmdup for SE reads\n");
     fprintf(stderr, "        -S    treat PE reads as SE in rmdup (force -s)\n");
+    fprintf(stderr, "        --no-PG\n"
+                    "              do not add a PG line\n");
 
     sam_global_opt_help(stderr, "-....--.");
     return 1;
@@ -267,14 +269,16 @@ static int rmdup_usage(void) {
 
 int bam_rmdup(int argc, char *argv[])
 {
-    int c, ret, is_se = 0, force_se = 0;
+    int c, ret, is_se = 0, force_se = 0, no_pg = 0;
     samFile *in, *out;
     sam_hdr_t *header;
     char wmode[3] = {'w', 'b', 0};
+    char *arg_list = NULL;
     sam_global_args ga = SAM_GLOBAL_ARGS_INIT;
 
     static const struct option lopts[] = {
         SAM_OPT_GLOBAL_OPTIONS('-', 0, 0, 0, 0, '-'),
+        {"no-PG", no_argument, NULL, 1},
         { NULL, 0, NULL, 0 }
     };
 
@@ -282,6 +286,7 @@ int bam_rmdup(int argc, char *argv[])
         switch (c) {
         case 's': is_se = 1; break;
         case 'S': force_se = is_se = 1; break;
+        case 1: no_pg = 1; break;
         default:  if (parse_sam_global_opt(c, optarg, lopts, &ga) == 0) break;
             /* else fall-through */
         case '?': return rmdup_usage();
@@ -307,14 +312,28 @@ int bam_rmdup(int argc, char *argv[])
         print_error_errno("rmdup", "failed to open \"%s\" for output", argv[optind+1]);
         return 1;
     }
+    if (!no_pg) {
+        if (!(arg_list = stringify_argv(argc + 1, argv - 1))) {
+            print_error("rmdup", "failed to create arg_list");
+            return 1;
+        }
+    }
+    if (samtools_add_pg_line(header, arg_list, no_pg)) {
+        print_error("rmdup", "failed to add PG line to header");
+        free(arg_list);
+        return 1;
+    }
+
     if (sam_hdr_write(out, header) < 0) {
         print_error_errno("rmdup", "failed to write header");
+        free(arg_list);
         return 1;
     }
 
     if (is_se) ret = bam_rmdupse_core(in, header, out, force_se);
     else ret = bam_rmdup_core(in, header, out);
 
+    free(arg_list);
     sam_hdr_destroy(header);
     sam_close(in);
     if (sam_close(out) < 0) {

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -1430,11 +1430,7 @@ int bam_merge_core2(SamOrder sam_order, char* sort_tag, const char *out, const c
         return -1;
     }
     hts_set_opt(fpout, HTS_OPT_BLOCK_SIZE, BAM_BLOCK_SIZE);
-    if (!no_pg && sam_hdr_add_pg(hout, "samtools",
-                                 "VN", samtools_version(),
-                                 arg_list ? "CL": NULL,
-                                 arg_list ? arg_list : NULL,
-                                 NULL)) {
+    if (samtools_add_pg_line(hout, arg_list, no_pg)) {
         print_error(cmd, "failed to add PG line to the header of \"%s\"", out);
         sam_close(fpout);
         return -1;
@@ -1926,11 +1922,7 @@ static int bam_merge_simple(SamOrder sam_order, char *sort_tag, const char *out,
     }
     hts_set_opt(fpout, HTS_OPT_BLOCK_SIZE, BAM_BLOCK_SIZE);
 
-    if (!no_pg && sam_hdr_add_pg(hout, "samtools",
-                                 "VN", samtools_version(),
-                                 arg_list ? "CL": NULL,
-                                 arg_list ? arg_list : NULL,
-                                 NULL)) {
+    if (samtools_add_pg_line(hout, arg_list, no_pg)) {
         print_error(cmd, "failed to add PG line to the header of \"%s\"", out);
         sam_close(fpout);
         return -1;
@@ -2355,10 +2347,7 @@ static int write_buffer(const char *fn, const char *mode, size_t l, bam1_tag *bu
     fp = sam_open_format(fn, mode, fmt);
     if (fp == NULL) return -1;
     hts_set_opt(fp, HTS_OPT_BLOCK_SIZE, BAM_BLOCK_SIZE);
-    if (!no_pg && sam_hdr_add_pg((sam_hdr_t *)h, "samtools", "VN", samtools_version(),
-                                 arg_list ? "CL": NULL,
-                                 arg_list ? arg_list : NULL,
-                                 NULL)) {
+    if (samtools_add_pg_line((sam_hdr_t *)h, arg_list, no_pg)) {
         goto fail;
     }
     if (sam_hdr_write(fp, h) != 0) goto fail;

--- a/bam_split.c
+++ b/bam_split.c
@@ -401,11 +401,7 @@ static khiter_t prep_sam_file(parsed_opts_t *opts, state_t *state,
         print_error_errno("split", "Duplicating header for file \"%s\" failed", new_file_name);
         goto fail;
     }
-    if (!opts->no_pg && sam_hdr_add_pg(new_hdr, "samtools",
-                                       "VN", samtools_version(),
-                                       arg_list ? "CL": NULL,
-                                       arg_list ? arg_list : NULL,
-                                       NULL)) {
+    if (samtools_add_pg_line(new_hdr, arg_list, opts->no_pg)) {
         print_error_errno("split", "Adding PG line to file \"%s\" failed", new_file_name);
         goto fail;
     }
@@ -577,11 +573,7 @@ static state_t* init(parsed_opts_t* opts, const char *arg_list)
             }
         } else {
             retval->unaccounted_header = sam_hdr_dup(retval->merged_input_header);
-            if (!opts->no_pg && sam_hdr_add_pg(retval->unaccounted_header, "samtools",
-                                               "VN", samtools_version(),
-                                               arg_list ? "CL": NULL,
-                                               arg_list ? arg_list : NULL,
-                                               NULL)) {
+            if (samtools_add_pg_line(retval->unaccounted_header, arg_list, opts->no_pg)) {
                 print_error("split", "Could not rewrite header for \"%s\"", opts->unaccounted_name);
                 cleanup_state(retval, false);
                 return NULL;
@@ -691,12 +683,7 @@ static state_t* init(parsed_opts_t* opts, const char *arg_list)
         // Set and edit header
         retval->output_header[i] = sam_hdr_dup(retval->merged_input_header);
         if (sam_hdr_remove_except(retval->output_header[i], "RG", "ID", retval->tag_vals[i]) ||
-            (!opts->no_pg &&
-             sam_hdr_add_pg(retval->output_header[i], "samtools",
-                            "VN", samtools_version(),
-                            arg_list ? "CL": NULL,
-                            arg_list ? arg_list : NULL,
-                            NULL))) {
+            samtools_add_pg_line(retval->output_header[i], arg_list, opts->no_pg)) {
             print_error("split", "Could not rewrite header for \"%s\"", output_filename);
             cleanup_state(retval, false);
             free(input_base_name);

--- a/bamshuf.c
+++ b/bamshuf.c
@@ -250,11 +250,7 @@ static int bamshuf(const char *fn, int n_files, const char *pre, int clevel,
     }
     if (p.pool) hts_set_opt(fpw, HTS_OPT_THREAD_POOL, &p);
 
-    if (!no_pg && sam_hdr_add_pg(h, "samtools",
-                                 "VN", samtools_version(),
-                                 arg_list ? "CL": NULL,
-                                 arg_list ? arg_list : NULL,
-                                 NULL)) {
+    if (samtools_add_pg_line(h, arg_list, no_pg)) {
         print_error("collate", "failed to add PG line to header of \"%s\"", output_file);
         goto fail;
     }

--- a/doc/samtools-rmdup.1
+++ b/doc/samtools-rmdup.1
@@ -67,6 +67,9 @@ paired-end reads only.
 .TP 8
 .B -S
 Treat paired-end reads and single-end reads.
+.TP 8
+.B --no-PG
+Do not add a @PG line to the header of the output file.
 
 .SH LIMITATIONS
 .IP o 2

--- a/padding.c
+++ b/padding.c
@@ -543,11 +543,7 @@ int main_pad2unpad(int argc, char *argv[])
             goto depad_end;
             }
 
-        if (sam_hdr_add_pg(h_fix, "samtools",
-                           "VN", samtools_version(),
-                           arg_list ? "CL": NULL,
-                           arg_list ? arg_list : NULL,
-                           NULL)) {
+        if (samtools_add_pg_line(h_fix, arg_list, 0)) {
             fprintf(stderr, "[depad] failed to add PG line to header\n");
             ret = 1;
             goto depad_end;

--- a/phase.c
+++ b/phase.c
@@ -584,11 +584,7 @@ static int start_output(phaseg_t *g, int c, const char *middle, const htsFormat 
     }
 
     g->out_hdr[c] = sam_hdr_dup(g->fp_hdr);
-    if (!g->no_pg && sam_hdr_add_pg(g->out_hdr[c], "samtools",
-                                    "VN", samtools_version(),
-                                    g->arg_list ? "CL": NULL,
-                                    g->arg_list ? g->arg_list : NULL,
-                                    NULL)) {
+    if (samtools_add_pg_line(g->out_hdr[c], g->arg_list, g->no_pg)) {
         print_error("phase", "failed to add PG line to header");
         return -1;
     }

--- a/reset.c
+++ b/reset.c
@@ -263,9 +263,9 @@ int getPGlines(sam_hdr_t *in_samhdr, sam_hdr_t *out_samhdr, conf_data *config, c
         }
     }
 
-    if (!ret && !config->noPGentry) {
-        //add PG entry with reset command
-        if (-1 == (ret = sam_hdr_add_pg(out_samhdr, "samtools", "CL", argdump, NULL))) {
+    if (!ret) {
+        //add PG entry with reset command (records VN, htslib version and CL)
+        if (-1 == (ret = samtools_add_pg_line(out_samhdr, argdump, config->noPGentry))) {
             fprintf(stderr, "Failed to set PG entry!\n");
         }
     }

--- a/sam_opts.c
+++ b/sam_opts.c
@@ -30,6 +30,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <limits.h>
 #include <stdbool.h>
 #include "sam_opts.h"
+#include "samtools.h"
 
 /*
  * Parse an integer from a value passed on the command-line. Return true on
@@ -226,6 +227,40 @@ void sam_global_args_init(sam_global_args *ga) {
         return;
 
     memset(ga, 0, sizeof(*ga));
+}
+
+/*
+ * Add the standard samtools @PG provenance line.  See samtools.h for details.
+ */
+int samtools_add_pg_line(sam_hdr_t *h, const char *arg_list, int no_pg) {
+    if (no_pg)
+        return 0;
+
+    const char *sam_ver = samtools_version(), *hts_ver = hts_version();
+    const char *version = sam_ver;
+    char version_buf[256];
+    int sam_maj, sam_min, hts_maj, hts_min;
+
+    // SAMtools and HTSlib are released together and have matching major and
+    // minor version numbers, so the HTSlib version can normally be deduced from
+    // the SAMtools one.  Only record it when it cannot be, i.e. when the major
+    // or minor numbers differ.
+    if (!(sscanf(sam_ver, "%d.%d", &sam_maj, &sam_min) == 2 &&
+          sscanf(hts_ver, "%d.%d", &hts_maj, &hts_min) == 2 &&
+          sam_maj == hts_maj && sam_min == hts_min)) {
+        snprintf(version_buf, sizeof(version_buf), "%s (with HTSlib %s)",
+                 sam_ver, hts_ver);
+        version = version_buf;
+    }
+
+    if (sam_hdr_add_pg(h, "samtools",
+                       "VN", version,
+                       arg_list ? "CL" : NULL,
+                       arg_list ? arg_list : NULL,
+                       NULL) == -1)
+        return -1;
+
+    return 0;
 }
 
 void sam_global_args_free(sam_global_args *ga) {

--- a/sam_view.c
+++ b/sam_view.c
@@ -1409,11 +1409,7 @@ int main_samview(int argc, char *argv[])
                 ret = 1;
                 goto view_end;
             }
-            if (sam_hdr_add_pg(settings.header, "samtools",
-                                         "VN", samtools_version(),
-                                         arg_list ? "CL": NULL,
-                                         arg_list ? arg_list : NULL,
-                                         NULL)) {
+            if (samtools_add_pg_line(settings.header, arg_list, 0)) {
                 print_error("view", "failed to add PG line to the header");
                 ret = 1;
                 goto view_end;

--- a/samtools.h
+++ b/samtools.h
@@ -31,6 +31,26 @@ DEALINGS IN THE SOFTWARE.  */
 
 const char *samtools_version(void);
 
+/*
+ * Add the standard samtools @PG line to header h, recording the program
+ * (PN:samtools), the version (VN) and, when arg_list is not NULL, the command
+ * line (CL).  htslib assigns a collision-free ID and links PP: to the previous
+ * @PG record.
+ *
+ * VN holds the samtools version.  As SAMtools and HTSlib are released together
+ * with matching major and minor version numbers, the HTSlib version can usually
+ * be deduced from it; when it cannot (the major or minor numbers differ) it is
+ * appended, e.g. "1.23.1 (with HTSlib 1.24)".
+ *
+ * When no_pg is non-zero this is a no-op (the --no-PG opt-out), so callers can
+ * unconditionally call it and pass their opt-out flag through.  arg_list may be
+ * NULL if no command line is available.
+ *
+ * Returns 0 on success,
+ *        -1 on failure.
+ */
+int samtools_add_pg_line(sam_hdr_t *h, const char *arg_list, int no_pg);
+
 /* BAM sanitizer options */
 #define FIX_POS     2
 #define FIX_MQUAL   4


### PR DESCRIPTION
## Summary

Consolidates the duplicated `@PG`-adding code into one shared helper and fixes two subcommands whose `@PG` records were incomplete or missing.

## What changed

**Shared helper.** Every subcommand that writes an alignment file called `sam_hdr_add_pg()` directly with a near-identical block. Those copies are replaced by `samtools_add_pg_line()` (declared in `samtools.h`, implemented in `sam_opts.c`, which is already linked into every subcommand and into `libst.a`). It also folds in the `--no-PG` check, so callers pass their opt-out flag through instead of repeating the condition.

**HTSlib version in `VN`.** When the HTSlib version cannot be deduced from the SAMtools version it is appended to `VN`, e.g. `VN:1.24.1 (with HTSlib 1.25)`. Since the two are released together with matching major and minor version numbers, **`VN` is unchanged in the usual case** and no expected test outputs move.

**Provenance fixes.**
- `reset` wrote a `@PG` line with a command line but no `VN`, unlike every other subcommand. Fixed.
- `rmdup`/`rmdupse` wrote no `@PG` line at all. They now add one and accept `--no-PG`.

**Consistency.** `ampliconclip`'s inverted `add_pg` flag is renamed to the `no_pg` convention used everywhere else.

## Testing

- `make test` — 1000 passed, 0 failures.
- `make maintainer-check` — PASS.
- `test/test.pl` is untouched: because `VN` is unchanged when the versions match, no harness change or expected-output regeneration is needed.
- The version-mismatch branch cannot be exercised through the CLI (`hts_version()` is fixed at link time), so its logic was verified separately across matching, patch-differing (`1.23.1`/`1.23.2`), major/minor-differing, and unparseable-version cases.

## Changes from the first revision

Addresses @daviesrob's review:
- HTSlib version moved from a `DS` field to being appended to `VN`, and omitted when it can be deduced from the SAMtools version.
- Dropped `REPRODUCIBILITY.md`, the `README.md` change, and the sort thread-comparison test.