### PR TITLE
Add mpileup --output-extra ENDPOS

### DIFF
--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -51,14 +51,117 @@ DEALINGS IN THE SOFTWARE.  */
 #define dummy_free(p)
 KLIST_INIT(auxlist, char *, dummy_free)
 
+#include "sample.h"
+
+#define MPLP_NO_COMP         (1<<2)
+#define MPLP_NO_ORPHAN       (1<<3)
+#define MPLP_REALN           (1<<4)
+#define MPLP_NO_INDEL        (1<<5)
+#define MPLP_REDO_BAQ        (1<<6)
+#define MPLP_ILLUMINA13      (1<<7)
+#define MPLP_IGNORE_RG       (1<<8)
+#define MPLP_SMART_OVERLAPS  (1<<10)
+
+#define MPLP_PRINT_MAPQ_CHAR (1<<11)
+#define MPLP_PRINT_QPOS      (1<<12)
+// Start of struct active_cols elements
+#define MPLP_PRINT_QNAME     (1<<13)
+#define MPLP_PRINT_FLAG      (1<<14)
+#define MPLP_PRINT_RNAME     (1<<15)
+#define MPLP_PRINT_POS       (1<<16)
+#define MPLP_PRINT_MAPQ      (1<<17)
+#define MPLP_PRINT_CIGAR     (1<<18)
+#define MPLP_PRINT_RNEXT     (1<<19)
+#define MPLP_PRINT_PNEXT     (1<<20)
+#define MPLP_PRINT_TLEN      (1<<21)
+#define MPLP_PRINT_SEQ       (1<<22)
+#define MPLP_PRINT_QUAL      (1<<23)
+#define MPLP_PRINT_RLEN      (1<<24)
+#define MPLP_PRINT_ENDPOS    (1<<25)
+// Must occur after struct active_cols element list
+#define MPLP_PRINT_MODS      (1<<26)
+#define MPLP_PRINT_QPOS5     (1<<27)
+
+#define MPLP_PRINT_LAST      (1<<28) // terminator for loop
+
+#define MPLP_MAX_DEPTH 8000
+#define MPLP_MAX_INDEL_DEPTH 250
+
+typedef struct {
+    int min_mq, flag, min_baseQ, capQ_thres, max_depth, max_indel_depth, all, rev_del;
+    int rflag_require, rflag_filter;
+    char *reg, *pl_list, *fai_fname, *output_fname;
+    faidx_t *fai;
+    void *bed, *rghash, *auxlist;
+    int argc;
+    char **argv;
+    char sep, empty, no_ins, no_ins_mods, no_del, no_ends;
+    sam_global_args ga;
+} mplp_conf_t;
+
+typedef struct {
+    char *ref[3];
+    int ref_id[3];
+    hts_pos_t ref_len[3];
+} mplp_ref_t;
+
+#define MPLP_REF_INIT {{NULL,NULL,NULL},{-1,-1,-1},{0,0,0}}
+
+typedef struct {
+    samFile *fp;
+    hts_itr_t *iter;
+    sam_hdr_t *h;
+    mplp_ref_t *ref;
+    const mplp_conf_t *conf;
+} mplp_aux_t;
+
+typedef struct {
+    int n;
+    int *n_plp, *m_plp;
+    bam_pileup1_t **plp;
+} mplp_pileup_t;
+
+typedef struct {
+    hts_base_mod_state *m;
+    hts_pos_t endpos;
+} pileup_cd;
+
+// Initialise and destroy the base modifier state data. This is called
+// as each new read is added or removed from the pileups.
+static
+int pileup_cd_create(void *data, const bam1_t *b, bam_pileup_cd *cd) {
+    cd->p = calloc(1, sizeof(pileup_cd));
+    return cd->p ? 0 : -1;
+}
+
+static
+int pileup_cd_destroy(void *data, const bam1_t *b, bam_pileup_cd *cd) {
+    if (((pileup_cd *)cd->p)->m)
+        hts_base_mod_state_free(((pileup_cd *)cd->p)->m);
+    free(cd->p);
+    return 0;
+}
+
 int pileup_seq(kstring_t *ks_seq, const bam_pileup1_t *p, hts_pos_t pos,
                hts_pos_t ref_len, const char *ref, kstring_t *ks_mod,
                int rev_del, int no_ins, int no_ins_mods,
-               int no_del, int no_ends)
+               int no_del, int no_ends, int flag)
 {
     no_ins_mods |= no_ins;
     int j, err = 0;
-    hts_base_mod_state *m = p->cd.p;
+    hts_base_mod_state *m = NULL;
+
+    // Cache modification data on first occurrence of this sequence
+    if (p->cd.p && (flag & MPLP_PRINT_MODS)) {
+        pileup_cd *cd = (pileup_cd *)(p->cd.p);
+        m = cd->m;
+        if (!m) {
+            m = cd->m = hts_base_mod_state_alloc();
+            if (!m || bam_parse_basemod(p->b, m) < 0)
+                return -1;
+        }
+    }
+
     if (!no_ends && p->is_head) {
         err |= kputc_('^', ks_seq) < 0;
         err |= kputc_(p->b->core.qual > 93 ? 126 : p->b->core.qual + 33,
@@ -168,75 +271,6 @@ int pileup_seq(kstring_t *ks_seq, const bam_pileup1_t *p, hts_pos_t pos,
     return -err;
 }
 
-#include "sample.h"
-
-#define MPLP_NO_COMP    (1<<2)
-#define MPLP_NO_ORPHAN  (1<<3)
-#define MPLP_REALN      (1<<4)
-#define MPLP_NO_INDEL   (1<<5)
-#define MPLP_REDO_BAQ   (1<<6)
-#define MPLP_ILLUMINA13 (1<<7)
-#define MPLP_IGNORE_RG  (1<<8)
-#define MPLP_SMART_OVERLAPS (1<<10)
-
-#define MPLP_PRINT_MAPQ_CHAR (1<<11)
-#define MPLP_PRINT_QPOS  (1<<12)
-// Start of struct active_cols elements
-#define MPLP_PRINT_QNAME (1<<13)
-#define MPLP_PRINT_FLAG  (1<<14)
-#define MPLP_PRINT_RNAME (1<<15)
-#define MPLP_PRINT_POS   (1<<16)
-#define MPLP_PRINT_MAPQ  (1<<17)
-#define MPLP_PRINT_CIGAR (1<<18)
-#define MPLP_PRINT_RNEXT (1<<19)
-#define MPLP_PRINT_PNEXT (1<<20)
-#define MPLP_PRINT_TLEN  (1<<21)
-#define MPLP_PRINT_SEQ   (1<<22)
-#define MPLP_PRINT_QUAL  (1<<23)
-#define MPLP_PRINT_RLEN  (1<<24)
-// Must occur after struct active_cols element list
-#define MPLP_PRINT_MODS  (1<<25)
-#define MPLP_PRINT_QPOS5 (1<<26)
-
-#define MPLP_PRINT_LAST  (1<<27) // terminator for loop
-
-#define MPLP_MAX_DEPTH 8000
-#define MPLP_MAX_INDEL_DEPTH 250
-
-typedef struct {
-    int min_mq, flag, min_baseQ, capQ_thres, max_depth, max_indel_depth, all, rev_del;
-    int rflag_require, rflag_filter;
-    char *reg, *pl_list, *fai_fname, *output_fname;
-    faidx_t *fai;
-    void *bed, *rghash, *auxlist;
-    int argc;
-    char **argv;
-    char sep, empty, no_ins, no_ins_mods, no_del, no_ends;
-    sam_global_args ga;
-} mplp_conf_t;
-
-typedef struct {
-    char *ref[3];
-    int ref_id[3];
-    hts_pos_t ref_len[3];
-} mplp_ref_t;
-
-#define MPLP_REF_INIT {{NULL,NULL,NULL},{-1,-1,-1},{0,0,0}}
-
-typedef struct {
-    samFile *fp;
-    hts_itr_t *iter;
-    sam_hdr_t *h;
-    mplp_ref_t *ref;
-    const mplp_conf_t *conf;
-} mplp_aux_t;
-
-typedef struct {
-    int n;
-    int *n_plp, *m_plp;
-    bam_pileup1_t **plp;
-} mplp_pileup_t;
-
 static int build_auxlist(mplp_conf_t *conf, char *optstring) {
     if (!optstring)
         return 0;
@@ -250,10 +284,10 @@ static int build_auxlist(mplp_conf_t *conf, char *optstring) {
         int supported;
     };
 
-    const struct active_cols colnames[12] = {
+    const struct active_cols colnames[13] = {
             {"QNAME", 1}, {"FLAG", 1}, {"RNAME", 1}, {"POS", 1}, {"MAPQ", 1},
             {"CIGAR", 0}, {"RNEXT", 1}, {"PNEXT", 1}, {"TLEN", 0}, {"SEQ", 0},
-            {"QUAL", 0},  {"RLEN", 1},
+            {"QUAL", 0},  {"RLEN", 1}, {"ENDPOS", 1}
     };
 
     int i, f = MPLP_PRINT_QNAME, colno = sizeof(colnames)/sizeof(*colnames);
@@ -349,23 +383,6 @@ static int mplp_get_ref(mplp_aux_t *ma, int tid, char **ref, hts_pos_t *ref_len)
     *ref = r->ref[0];
     *ref_len = r->ref_len[0];
     return 1;
-}
-
-// Initialise and destroy the base modifier state data. This is called
-// as each new read is added or removed from the pileups.
-static
-int pileup_cd_create(void *data, const bam1_t *b, bam_pileup_cd *cd) {
-    int ret;
-    hts_base_mod_state *m = hts_base_mod_state_alloc();
-    ret = bam_parse_basemod(b, m);
-    cd->p = m;
-    return ret;
-}
-
-static
-int pileup_cd_destroy(void *data, const bam1_t *b, bam_pileup_cd *cd) {
-    hts_base_mod_state_free(cd->p);
-    return 0;
 }
 
 //returns 0 on success and 1 on error
@@ -579,7 +596,7 @@ static int mpileup(mplp_conf_t *conf, int nfn, char **fn, char **fn_idx)
 
     // init pileup
     iter = bam_mplp_init(nfn, mplp_func, (void**)data);
-    if (conf->flag & MPLP_PRINT_MODS) {
+    if (conf->flag & (MPLP_PRINT_MODS | MPLP_PRINT_ENDPOS)) {
         bam_mplp_constructor(iter, pileup_cd_create);
         bam_mplp_destructor(iter, pileup_cd_destroy);
     }
@@ -681,7 +698,8 @@ static int mpileup(mplp_conf_t *conf, int nfn, char **fn, char **fn_idx)
                     err |= pileup_seq(&ks_seq, plp[i] + j, pos, ref_len,
                                       ref, &ks_mod, conf->rev_del,
                                       conf->no_ins, conf->no_ins_mods,
-                                      conf->no_del, conf->no_ends) < 0;
+                                      conf->no_del, conf->no_ends,
+                                      conf->flag) < 0;
 
                     // Build up qual
                     err |= kputc_(c+33 < 126 ? c+33 : 126, &ks_qual) < 0;
@@ -788,6 +806,17 @@ static int mpileup(mplp_conf_t *conf, int nfn, char **fn, char **fn_idx)
                             case MPLP_PRINT_RLEN:
                                 err |= kputw(p->b->core.l_qseq, &buf) < 0;
                                 break;
+                            case MPLP_PRINT_ENDPOS: {
+                                pileup_cd *cd = (pileup_cd *)(p->cd.p);
+                                // NB: technically this is zero-based so a 1bp
+                                // read starting at POS=1 could call this
+                                // multiple times, but being 1bp long we
+                                // have no benefit to caching anyway.
+                                if (!cd->endpos)
+                                    cd->endpos = bam_endpos(p->b);
+                                err |= kputw(cd->endpos, &buf) < 0;
+                                break;
+                            }
                             }
                         }
                         if (!n) err |= kputc_('*', &buf) < 0;

--- a/doc/samtools-mpileup.1
+++ b/doc/samtools-mpileup.1
@@ -171,7 +171,9 @@ The fields selected appear in the same order as in SAM:
 .BR PNEXT ,
 followed by
 .BR RLEN
-for unclipped read length.
+for unclipped read length, and
+.BR ENDPOS
+for the last reference base covered by the alignment.
 .IP \(ci 2
 Comma-separated 1-based positions within the alignments, in 5' to 3'
 orientation.  E.g., 5 indicates that it is the fifth base of the
@@ -401,7 +403,7 @@ mpileup command in the same order as in the document (i.e.
 The names are case sensitive. Currently, only the following fields are
 supported:
 .IP
-.B QNAME, FLAG, RNAME, POS, MAPQ, RNEXT, PNEXT, RLEN
+.B QNAME, FLAG, RNAME, POS, MAPQ, RNEXT, PNEXT, RLEN, ENDPOS
 .IP
 Anything that is not on this list is treated as a potential tag, although only
 two character tags are accepted. In the mpileup output, tag columns are

--- a/test/mpileup/expected/79.out
+++ b/test/mpileup/expected/79.out
@@ -1,116 +1,116 @@
-ref1	1	N	0	*	*	*	*	*	*	*	*
-ref1	2	N	0	*	*	*	*	*	*	*	*
-ref1	3	N	0	*	*	*	*	*	*	*	*
-ref1	4	N	0	*	*	*	*	*	*	*	*
-ref1	5	N	0	*	*	*	*	*	*	*	*
-ref1	6	N	0	*	*	*	*	*	*	*	*
-ref1	7	N	0	*	*	*	*	*	*	*	*
-ref1	8	N	0	*	*	*	*	*	*	*	*
-ref1	9	N	0	*	*	*	*	*	*	*	*
-ref1	10	N	0	*	*	*	*	*	*	*	*
-ref1	11	N	0	*	*	*	*	*	*	*	*
-ref1	12	N	0	*	*	*	*	*	*	*	*
-ref1	13	N	0	*	*	*	*	*	*	*	*
-ref1	14	N	0	*	*	*	*	*	*	*	*
-ref1	15	N	0	*	*	*	*	*	*	*	*
-ref1	16	N	0	*	*	*	*	*	*	*	*
-ref1	17	N	0	*	*	*	*	*	*	*	*
-ref1	18	N	0	*	*	*	*	*	*	*	*
-ref1	19	N	0	*	*	*	*	*	*	*	*
-ref1	20	N	0	*	*	*	*	*	*	*	*
-ref1	21	N	0	*	*	*	*	*	*	*	*
-ref1	22	N	0	*	*	*	*	*	*	*	*
-ref1	23	N	0	*	*	*	*	*	*	*	*
-ref1	24	N	0	*	*	*	*	*	*	*	*
-ref1	25	N	0	*	*	*	*	*	*	*	*
-ref1	26	N	0	*	*	*	*	*	*	*	*
-ref1	27	N	1	^.g	.	1	ref1_grp2_p001	147	27	0	grp2
-ref1	28	N	1	a	.	2	ref1_grp2_p001	147	27	0	grp2
-ref1	29	N	2	g^/g	./	3,1	ref1_grp2_p001,ref1_grp1_p002	147,147	27,29	0,0	grp2,grp1
-ref1	30	N	2	tt	./	4,2	ref1_grp2_p001,ref1_grp1_p002	147,147	27,29	0,0	grp2,grp1
-ref1	31	N	3	cc^0c	./0	5,3,1	ref1_grp2_p001,ref1_grp1_p002,ref1_grp2_p002	147,147,147	27,29,31	0,0,0	grp2,grp1,grp2
-ref1	32	N	3	ggg	./0	6,4,2	ref1_grp2_p001,ref1_grp1_p002,ref1_grp2_p002	147,147,147	27,29,31	0,0,0	grp2,grp1,grp2
-ref1	33	N	4	aaa^1a	./01	7,5,3,1	ref1_grp2_p001,ref1_grp1_p002,ref1_grp2_p002,ref1_grp1_p003	147,147,147,147	27,29,31,33	0,0,0,0	grp2,grp1,grp2,grp1
-ref1	34	N	4	cccc	./01	8,6,4,2	ref1_grp2_p001,ref1_grp1_p002,ref1_grp2_p002,ref1_grp1_p003	147,147,147,147	27,29,31,33	0,0,0,0	grp2,grp1,grp2,grp1
-ref1	35	N	5	cccc^2c	./012	9,7,5,3,1	ref1_grp2_p001,ref1_grp1_p002,ref1_grp2_p002,ref1_grp1_p003,ref1_grp2_p003	147,147,147,147,147	27,29,31,33,35	0,0,0,0,0	grp2,grp1,grp2,grp1,grp2
-ref1	36	N	5	t$tttt	./012	10,8,6,4,2	ref1_grp2_p001,ref1_grp1_p002,ref1_grp2_p002,ref1_grp1_p003,ref1_grp2_p003	147,147,147,147,147	27,29,31,33,35	0,0,0,0,0	grp2,grp1,grp2,grp1,grp2
-ref1	37	N	5	gggg^3g	/0123	9,7,5,3,1	ref1_grp1_p002,ref1_grp2_p002,ref1_grp1_p003,ref1_grp2_p003,ref1_grp1_p004	147,147,147,147,147	29,31,33,35,37	0,0,0,0,0	grp1,grp2,grp1,grp2,grp1
-ref1	38	N	5	c$cccc	/0123	10,8,6,4,2	ref1_grp1_p002,ref1_grp2_p002,ref1_grp1_p003,ref1_grp2_p003,ref1_grp1_p004	147,147,147,147,147	29,31,33,35,37	0,0,0,0,0	grp1,grp2,grp1,grp2,grp1
-ref1	39	N	5	aaaa^4a	01234	9,7,5,3,1	ref1_grp2_p002,ref1_grp1_p003,ref1_grp2_p003,ref1_grp1_p004,ref1_grp2_p004	147,147,147,147,147	31,33,35,37,39	0,0,0,0,0	grp2,grp1,grp2,grp1,grp2
-ref1	40	N	5	g$gggg	01234	10,8,6,4,2	ref1_grp2_p002,ref1_grp1_p003,ref1_grp2_p003,ref1_grp1_p004,ref1_grp2_p004	147,147,147,147,147	31,33,35,37,39	0,0,0,0,0	grp2,grp1,grp2,grp1,grp2
-ref1	41	N	5	gggg^5g	12345	9,7,5,3,1	ref1_grp1_p003,ref1_grp2_p003,ref1_grp1_p004,ref1_grp2_p004,ref1_grp1_p005	147,147,147,147,147	33,35,37,39,41	0,0,0,0,0	grp1,grp2,grp1,grp2,grp1
-ref1	42	N	5	c$cccc	12345	10,8,6,4,2	ref1_grp1_p003,ref1_grp2_p003,ref1_grp1_p004,ref1_grp2_p004,ref1_grp1_p005	147,147,147,147,147	33,35,37,39,41	0,0,0,0,0	grp1,grp2,grp1,grp2,grp1
-ref1	43	N	5	aaaa^6a	23456	9,7,5,3,1	ref1_grp2_p003,ref1_grp1_p004,ref1_grp2_p004,ref1_grp1_p005,ref1_grp2_p005	147,147,147,147,147	35,37,39,41,43	0,0,0,0,0	grp2,grp1,grp2,grp1,grp2
-ref1	44	N	5	t$tttt	23456	10,8,6,4,2	ref1_grp2_p003,ref1_grp1_p004,ref1_grp2_p004,ref1_grp1_p005,ref1_grp2_p005	147,147,147,147,147	35,37,39,41,43	0,0,0,0,0	grp2,grp1,grp2,grp1,grp2
-ref1	45	N	5	gggg^7g	34567	9,7,5,3,1	ref1_grp1_p004,ref1_grp2_p004,ref1_grp1_p005,ref1_grp2_p005,ref1_grp1_p006	147,147,147,147,147	37,39,41,43,45	0,0,0,0,0	grp1,grp2,grp1,grp2,grp1
-ref1	46	N	5	c$cccc	34567	10,8,6,4,2	ref1_grp1_p004,ref1_grp2_p004,ref1_grp1_p005,ref1_grp2_p005,ref1_grp1_p006	147,147,147,147,147	37,39,41,43,45	0,0,0,0,0	grp1,grp2,grp1,grp2,grp1
-ref1	47	N	5	aaaa^8a	45678	9,7,5,3,1	ref1_grp2_p004,ref1_grp1_p005,ref1_grp2_p005,ref1_grp1_p006,ref1_grp2_p006	147,147,147,147,147	39,41,43,45,47	0,0,0,0,0	grp2,grp1,grp2,grp1,grp2
-ref1	48	N	5	a$aaaa	45678	10,8,6,4,2	ref1_grp2_p004,ref1_grp1_p005,ref1_grp2_p005,ref1_grp1_p006,ref1_grp2_p006	147,147,147,147,147	39,41,43,45,47	0,0,0,0,0	grp2,grp1,grp2,grp1,grp2
-ref1	49	N	4	gggg	5678	9,7,5,3	ref1_grp1_p005,ref1_grp2_p005,ref1_grp1_p006,ref1_grp2_p006	147,147,147,147	41,43,45,47	0,0,0,0	grp1,grp2,grp1,grp2
-ref1	50	N	4	c$ccc	5678	10,8,6,4	ref1_grp1_p005,ref1_grp2_p005,ref1_grp1_p006,ref1_grp2_p006	147,147,147,147	41,43,45,47	0,0,0,0	grp1,grp2,grp1,grp2
-ref1	51	N	3	ttt	678	9,7,5	ref1_grp2_p005,ref1_grp1_p006,ref1_grp2_p006	147,147,147	43,45,47	0,0,0	grp2,grp1,grp2
-ref1	52	N	3	t$tt	678	10,8,6	ref1_grp2_p005,ref1_grp1_p006,ref1_grp2_p006	147,147,147	43,45,47	0,0,0	grp2,grp1,grp2
-ref1	53	N	2	gg	78	9,7	ref1_grp1_p006,ref1_grp2_p006	147,147	45,47	0,0	grp1,grp2
-ref1	54	N	2	a$a	78	10,8	ref1_grp1_p006,ref1_grp2_p006	147,147	45,47	0,0	grp1,grp2
-ref1	55	N	1	g	8	9	ref1_grp2_p006	147	47	0	grp2
-ref1	56	N	1	t$	8	10	ref1_grp2_p006	147	47	0	grp2
-ref2	1	N	1	^~a	~	1	ref2_grp3_p001	83	1	0	grp3
-ref2	2	N	1	t	~	2	ref2_grp3_p001	83	1	0	grp3
-ref2	3	N	1	t	~	3	ref2_grp3_p001	83	1	0	grp3
-ref2	4	N	1	c	~	4	ref2_grp3_p001	83	1	0	grp3
-ref2	5	N	1	t	~	5	ref2_grp3_p001	83	1	0	grp3
-ref2	6	N	1	a	~	6	ref2_grp3_p001	83	1	0	grp3
-ref2	7	N	1	t	~	7	ref2_grp3_p001	83	1	0	grp3
-ref2	8	N	1	a	~	8	ref2_grp3_p001	83	1	0	grp3
-ref2	9	N	1	g	~	9	ref2_grp3_p001	83	1	0	grp3
-ref2	10	N	1	t	~	10	ref2_grp3_p001	83	1	0	grp3
-ref2	11	N	1	g	~	11	ref2_grp3_p001	83	1	0	grp3
-ref2	12	N	1	t	~	12	ref2_grp3_p001	83	1	0	grp3
-ref2	13	N	1	c	~	13	ref2_grp3_p001	83	1	0	grp3
-ref2	14	N	1	a	~	14	ref2_grp3_p001	83	1	0	grp3
-ref2	15	N	1	c$	~	15	ref2_grp3_p001	83	1	0	grp3
-ref2	16	N	1	^~c	}	1	ref2_grp3_p002	147	16	0	grp3
-ref2	17	N	1	t	}	2	ref2_grp3_p002	147	16	0	grp3
-ref2	18	N	1	a	}	3	ref2_grp3_p002	147	16	0	grp3
-ref2	19	N	1	a	}	4	ref2_grp3_p002	147	16	0	grp3
-ref2	20	N	1	a	}	5	ref2_grp3_p002	147	16	0	grp3
-ref2	21	N	1	t	}	6	ref2_grp3_p002	147	16	0	grp3
-ref2	22	N	1	a	}	7	ref2_grp3_p002	147	16	0	grp3
-ref2	23	N	1	g	}	8	ref2_grp3_p002	147	16	0	grp3
-ref2	24	N	1	c	}	9	ref2_grp3_p002	147	16	0	grp3
-ref2	25	N	1	t	}	10	ref2_grp3_p002	147	16	0	grp3
-ref2	26	N	1	t	}	11	ref2_grp3_p002	147	16	0	grp3
-ref2	27	N	1	g	}	12	ref2_grp3_p002	147	16	0	grp3
-ref2	28	N	1	g	}	13	ref2_grp3_p002	147	16	0	grp3
-ref2	29	N	1	c	}	14	ref2_grp3_p002	147	16	0	grp3
-ref2	30	N	1	g$	}	15	ref2_grp3_p002	147	16	0	grp3
-ref2	31	N	1	^~C	|	1	ref2_grp3_p001	163	31	13	grp3
-ref2	32	N	1	T	|	2	ref2_grp3_p001	163	31	13	grp3
-ref2	33	N	1	G	|	3	ref2_grp3_p001	163	31	13	grp3
-ref2	34	N	1	T	|	4	ref2_grp3_p001	163	31	13	grp3
-ref2	35	N	1	T	|	5	ref2_grp3_p001	163	31	13	grp3
-ref2	36	N	1	T	|	6	ref2_grp3_p001	163	31	13	grp3
-ref2	37	N	1	C	|	7	ref2_grp3_p001	163	31	13	grp3
-ref2	38	N	1	C	|	8	ref2_grp3_p001	163	31	13	grp3
-ref2	39	N	1	T	|	9	ref2_grp3_p001	163	31	13	grp3
-ref2	40	N	1	G	|	10	ref2_grp3_p001	163	31	13	grp3
-ref2	41	N	1	T	|	11	ref2_grp3_p001	163	31	13	grp3
-ref2	42	N	1	G	|	12	ref2_grp3_p001	163	31	13	grp3
-ref2	43	N	1	T	|	13	ref2_grp3_p001	163	31	13	grp3
-ref2	44	N	1	G	|	14	ref2_grp3_p001	163	31	13	grp3
-ref2	45	N	1	A$	|	15	ref2_grp3_p001	163	31	13	grp3
-ref2	46	N	1	^~C	{	1	ref2_grp3_p002	99	46	0	grp3
-ref2	47	N	1	T	{	2	ref2_grp3_p002	99	46	0	grp3
-ref2	48	N	1	G	{	3	ref2_grp3_p002	99	46	0	grp3
-ref2	49	N	1	T	{	4	ref2_grp3_p002	99	46	0	grp3
-ref2	50	N	1	T	{	5	ref2_grp3_p002	99	46	0	grp3
-ref2	51	N	1	T	{	6	ref2_grp3_p002	99	46	0	grp3
-ref2	52	N	1	C	{	7	ref2_grp3_p002	99	46	0	grp3
-ref2	53	N	1	C	{	8	ref2_grp3_p002	99	46	0	grp3
-ref2	54	N	1	T	{	9	ref2_grp3_p002	99	46	0	grp3
-ref2	55	N	1	G	{	10	ref2_grp3_p002	99	46	0	grp3
-ref2	56	N	1	T	{	11	ref2_grp3_p002	99	46	0	grp3
-ref2	57	N	1	G	{	12	ref2_grp3_p002	99	46	0	grp3
-ref2	58	N	1	T	{	13	ref2_grp3_p002	99	46	0	grp3
-ref2	59	N	1	G	{	14	ref2_grp3_p002	99	46	0	grp3
-ref2	60	N	1	A$	{	15	ref2_grp3_p002	99	46	0	grp3
+ref1	1	N	0	*	*	*	*	*	*	*	*	*
+ref1	2	N	0	*	*	*	*	*	*	*	*	*
+ref1	3	N	0	*	*	*	*	*	*	*	*	*
+ref1	4	N	0	*	*	*	*	*	*	*	*	*
+ref1	5	N	0	*	*	*	*	*	*	*	*	*
+ref1	6	N	0	*	*	*	*	*	*	*	*	*
+ref1	7	N	0	*	*	*	*	*	*	*	*	*
+ref1	8	N	0	*	*	*	*	*	*	*	*	*
+ref1	9	N	0	*	*	*	*	*	*	*	*	*
+ref1	10	N	0	*	*	*	*	*	*	*	*	*
+ref1	11	N	0	*	*	*	*	*	*	*	*	*
+ref1	12	N	0	*	*	*	*	*	*	*	*	*
+ref1	13	N	0	*	*	*	*	*	*	*	*	*
+ref1	14	N	0	*	*	*	*	*	*	*	*	*
+ref1	15	N	0	*	*	*	*	*	*	*	*	*
+ref1	16	N	0	*	*	*	*	*	*	*	*	*
+ref1	17	N	0	*	*	*	*	*	*	*	*	*
+ref1	18	N	0	*	*	*	*	*	*	*	*	*
+ref1	19	N	0	*	*	*	*	*	*	*	*	*
+ref1	20	N	0	*	*	*	*	*	*	*	*	*
+ref1	21	N	0	*	*	*	*	*	*	*	*	*
+ref1	22	N	0	*	*	*	*	*	*	*	*	*
+ref1	23	N	0	*	*	*	*	*	*	*	*	*
+ref1	24	N	0	*	*	*	*	*	*	*	*	*
+ref1	25	N	0	*	*	*	*	*	*	*	*	*
+ref1	26	N	0	*	*	*	*	*	*	*	*	*
+ref1	27	N	1	^.g	.	1	ref1_grp2_p001	147	27	36	0	grp2
+ref1	28	N	1	a	.	2	ref1_grp2_p001	147	27	36	0	grp2
+ref1	29	N	2	g^/g	./	3,1	ref1_grp2_p001,ref1_grp1_p002	147,147	27,29	36,38	0,0	grp2,grp1
+ref1	30	N	2	tt	./	4,2	ref1_grp2_p001,ref1_grp1_p002	147,147	27,29	36,38	0,0	grp2,grp1
+ref1	31	N	3	cc^0c	./0	5,3,1	ref1_grp2_p001,ref1_grp1_p002,ref1_grp2_p002	147,147,147	27,29,31	36,38,40	0,0,0	grp2,grp1,grp2
+ref1	32	N	3	ggg	./0	6,4,2	ref1_grp2_p001,ref1_grp1_p002,ref1_grp2_p002	147,147,147	27,29,31	36,38,40	0,0,0	grp2,grp1,grp2
+ref1	33	N	4	aaa^1a	./01	7,5,3,1	ref1_grp2_p001,ref1_grp1_p002,ref1_grp2_p002,ref1_grp1_p003	147,147,147,147	27,29,31,33	36,38,40,42	0,0,0,0	grp2,grp1,grp2,grp1
+ref1	34	N	4	cccc	./01	8,6,4,2	ref1_grp2_p001,ref1_grp1_p002,ref1_grp2_p002,ref1_grp1_p003	147,147,147,147	27,29,31,33	36,38,40,42	0,0,0,0	grp2,grp1,grp2,grp1
+ref1	35	N	5	cccc^2c	./012	9,7,5,3,1	ref1_grp2_p001,ref1_grp1_p002,ref1_grp2_p002,ref1_grp1_p003,ref1_grp2_p003	147,147,147,147,147	27,29,31,33,35	36,38,40,42,44	0,0,0,0,0	grp2,grp1,grp2,grp1,grp2
+ref1	36	N	5	t$tttt	./012	10,8,6,4,2	ref1_grp2_p001,ref1_grp1_p002,ref1_grp2_p002,ref1_grp1_p003,ref1_grp2_p003	147,147,147,147,147	27,29,31,33,35	36,38,40,42,44	0,0,0,0,0	grp2,grp1,grp2,grp1,grp2
+ref1	37	N	5	gggg^3g	/0123	9,7,5,3,1	ref1_grp1_p002,ref1_grp2_p002,ref1_grp1_p003,ref1_grp2_p003,ref1_grp1_p004	147,147,147,147,147	29,31,33,35,37	38,40,42,44,46	0,0,0,0,0	grp1,grp2,grp1,grp2,grp1
+ref1	38	N	5	c$cccc	/0123	10,8,6,4,2	ref1_grp1_p002,ref1_grp2_p002,ref1_grp1_p003,ref1_grp2_p003,ref1_grp1_p004	147,147,147,147,147	29,31,33,35,37	38,40,42,44,46	0,0,0,0,0	grp1,grp2,grp1,grp2,grp1
+ref1	39	N	5	aaaa^4a	01234	9,7,5,3,1	ref1_grp2_p002,ref1_grp1_p003,ref1_grp2_p003,ref1_grp1_p004,ref1_grp2_p004	147,147,147,147,147	31,33,35,37,39	40,42,44,46,48	0,0,0,0,0	grp2,grp1,grp2,grp1,grp2
+ref1	40	N	5	g$gggg	01234	10,8,6,4,2	ref1_grp2_p002,ref1_grp1_p003,ref1_grp2_p003,ref1_grp1_p004,ref1_grp2_p004	147,147,147,147,147	31,33,35,37,39	40,42,44,46,48	0,0,0,0,0	grp2,grp1,grp2,grp1,grp2
+ref1	41	N	5	gggg^5g	12345	9,7,5,3,1	ref1_grp1_p003,ref1_grp2_p003,ref1_grp1_p004,ref1_grp2_p004,ref1_grp1_p005	147,147,147,147,147	33,35,37,39,41	42,44,46,48,50	0,0,0,0,0	grp1,grp2,grp1,grp2,grp1
+ref1	42	N	5	c$cccc	12345	10,8,6,4,2	ref1_grp1_p003,ref1_grp2_p003,ref1_grp1_p004,ref1_grp2_p004,ref1_grp1_p005	147,147,147,147,147	33,35,37,39,41	42,44,46,48,50	0,0,0,0,0	grp1,grp2,grp1,grp2,grp1
+ref1	43	N	5	aaaa^6a	23456	9,7,5,3,1	ref1_grp2_p003,ref1_grp1_p004,ref1_grp2_p004,ref1_grp1_p005,ref1_grp2_p005	147,147,147,147,147	35,37,39,41,43	44,46,48,50,52	0,0,0,0,0	grp2,grp1,grp2,grp1,grp2
+ref1	44	N	5	t$tttt	23456	10,8,6,4,2	ref1_grp2_p003,ref1_grp1_p004,ref1_grp2_p004,ref1_grp1_p005,ref1_grp2_p005	147,147,147,147,147	35,37,39,41,43	44,46,48,50,52	0,0,0,0,0	grp2,grp1,grp2,grp1,grp2
+ref1	45	N	5	gggg^7g	34567	9,7,5,3,1	ref1_grp1_p004,ref1_grp2_p004,ref1_grp1_p005,ref1_grp2_p005,ref1_grp1_p006	147,147,147,147,147	37,39,41,43,45	46,48,50,52,54	0,0,0,0,0	grp1,grp2,grp1,grp2,grp1
+ref1	46	N	5	c$cccc	34567	10,8,6,4,2	ref1_grp1_p004,ref1_grp2_p004,ref1_grp1_p005,ref1_grp2_p005,ref1_grp1_p006	147,147,147,147,147	37,39,41,43,45	46,48,50,52,54	0,0,0,0,0	grp1,grp2,grp1,grp2,grp1
+ref1	47	N	5	aaaa^8a	45678	9,7,5,3,1	ref1_grp2_p004,ref1_grp1_p005,ref1_grp2_p005,ref1_grp1_p006,ref1_grp2_p006	147,147,147,147,147	39,41,43,45,47	48,50,52,54,56	0,0,0,0,0	grp2,grp1,grp2,grp1,grp2
+ref1	48	N	5	a$aaaa	45678	10,8,6,4,2	ref1_grp2_p004,ref1_grp1_p005,ref1_grp2_p005,ref1_grp1_p006,ref1_grp2_p006	147,147,147,147,147	39,41,43,45,47	48,50,52,54,56	0,0,0,0,0	grp2,grp1,grp2,grp1,grp2
+ref1	49	N	4	gggg	5678	9,7,5,3	ref1_grp1_p005,ref1_grp2_p005,ref1_grp1_p006,ref1_grp2_p006	147,147,147,147	41,43,45,47	50,52,54,56	0,0,0,0	grp1,grp2,grp1,grp2
+ref1	50	N	4	c$ccc	5678	10,8,6,4	ref1_grp1_p005,ref1_grp2_p005,ref1_grp1_p006,ref1_grp2_p006	147,147,147,147	41,43,45,47	50,52,54,56	0,0,0,0	grp1,grp2,grp1,grp2
+ref1	51	N	3	ttt	678	9,7,5	ref1_grp2_p005,ref1_grp1_p006,ref1_grp2_p006	147,147,147	43,45,47	52,54,56	0,0,0	grp2,grp1,grp2
+ref1	52	N	3	t$tt	678	10,8,6	ref1_grp2_p005,ref1_grp1_p006,ref1_grp2_p006	147,147,147	43,45,47	52,54,56	0,0,0	grp2,grp1,grp2
+ref1	53	N	2	gg	78	9,7	ref1_grp1_p006,ref1_grp2_p006	147,147	45,47	54,56	0,0	grp1,grp2
+ref1	54	N	2	a$a	78	10,8	ref1_grp1_p006,ref1_grp2_p006	147,147	45,47	54,56	0,0	grp1,grp2
+ref1	55	N	1	g	8	9	ref1_grp2_p006	147	47	56	0	grp2
+ref1	56	N	1	t$	8	10	ref1_grp2_p006	147	47	56	0	grp2
+ref2	1	N	1	^~a	~	1	ref2_grp3_p001	83	1	15	0	grp3
+ref2	2	N	1	t	~	2	ref2_grp3_p001	83	1	15	0	grp3
+ref2	3	N	1	t	~	3	ref2_grp3_p001	83	1	15	0	grp3
+ref2	4	N	1	c	~	4	ref2_grp3_p001	83	1	15	0	grp3
+ref2	5	N	1	t	~	5	ref2_grp3_p001	83	1	15	0	grp3
+ref2	6	N	1	a	~	6	ref2_grp3_p001	83	1	15	0	grp3
+ref2	7	N	1	t	~	7	ref2_grp3_p001	83	1	15	0	grp3
+ref2	8	N	1	a	~	8	ref2_grp3_p001	83	1	15	0	grp3
+ref2	9	N	1	g	~	9	ref2_grp3_p001	83	1	15	0	grp3
+ref2	10	N	1	t	~	10	ref2_grp3_p001	83	1	15	0	grp3
+ref2	11	N	1	g	~	11	ref2_grp3_p001	83	1	15	0	grp3
+ref2	12	N	1	t	~	12	ref2_grp3_p001	83	1	15	0	grp3
+ref2	13	N	1	c	~	13	ref2_grp3_p001	83	1	15	0	grp3
+ref2	14	N	1	a	~	14	ref2_grp3_p001	83	1	15	0	grp3
+ref2	15	N	1	c$	~	15	ref2_grp3_p001	83	1	15	0	grp3
+ref2	16	N	1	^~c	}	1	ref2_grp3_p002	147	16	30	0	grp3
+ref2	17	N	1	t	}	2	ref2_grp3_p002	147	16	30	0	grp3
+ref2	18	N	1	a	}	3	ref2_grp3_p002	147	16	30	0	grp3
+ref2	19	N	1	a	}	4	ref2_grp3_p002	147	16	30	0	grp3
+ref2	20	N	1	a	}	5	ref2_grp3_p002	147	16	30	0	grp3
+ref2	21	N	1	t	}	6	ref2_grp3_p002	147	16	30	0	grp3
+ref2	22	N	1	a	}	7	ref2_grp3_p002	147	16	30	0	grp3
+ref2	23	N	1	g	}	8	ref2_grp3_p002	147	16	30	0	grp3
+ref2	24	N	1	c	}	9	ref2_grp3_p002	147	16	30	0	grp3
+ref2	25	N	1	t	}	10	ref2_grp3_p002	147	16	30	0	grp3
+ref2	26	N	1	t	}	11	ref2_grp3_p002	147	16	30	0	grp3
+ref2	27	N	1	g	}	12	ref2_grp3_p002	147	16	30	0	grp3
+ref2	28	N	1	g	}	13	ref2_grp3_p002	147	16	30	0	grp3
+ref2	29	N	1	c	}	14	ref2_grp3_p002	147	16	30	0	grp3
+ref2	30	N	1	g$	}	15	ref2_grp3_p002	147	16	30	0	grp3
+ref2	31	N	1	^~C	|	1	ref2_grp3_p001	163	31	45	13	grp3
+ref2	32	N	1	T	|	2	ref2_grp3_p001	163	31	45	13	grp3
+ref2	33	N	1	G	|	3	ref2_grp3_p001	163	31	45	13	grp3
+ref2	34	N	1	T	|	4	ref2_grp3_p001	163	31	45	13	grp3
+ref2	35	N	1	T	|	5	ref2_grp3_p001	163	31	45	13	grp3
+ref2	36	N	1	T	|	6	ref2_grp3_p001	163	31	45	13	grp3
+ref2	37	N	1	C	|	7	ref2_grp3_p001	163	31	45	13	grp3
+ref2	38	N	1	C	|	8	ref2_grp3_p001	163	31	45	13	grp3
+ref2	39	N	1	T	|	9	ref2_grp3_p001	163	31	45	13	grp3
+ref2	40	N	1	G	|	10	ref2_grp3_p001	163	31	45	13	grp3
+ref2	41	N	1	T	|	11	ref2_grp3_p001	163	31	45	13	grp3
+ref2	42	N	1	G	|	12	ref2_grp3_p001	163	31	45	13	grp3
+ref2	43	N	1	T	|	13	ref2_grp3_p001	163	31	45	13	grp3
+ref2	44	N	1	G	|	14	ref2_grp3_p001	163	31	45	13	grp3
+ref2	45	N	1	A$	|	15	ref2_grp3_p001	163	31	45	13	grp3
+ref2	46	N	1	^~C	{	1	ref2_grp3_p002	99	46	60	0	grp3
+ref2	47	N	1	T	{	2	ref2_grp3_p002	99	46	60	0	grp3
+ref2	48	N	1	G	{	3	ref2_grp3_p002	99	46	60	0	grp3
+ref2	49	N	1	T	{	4	ref2_grp3_p002	99	46	60	0	grp3
+ref2	50	N	1	T	{	5	ref2_grp3_p002	99	46	60	0	grp3
+ref2	51	N	1	T	{	6	ref2_grp3_p002	99	46	60	0	grp3
+ref2	52	N	1	C	{	7	ref2_grp3_p002	99	46	60	0	grp3
+ref2	53	N	1	C	{	8	ref2_grp3_p002	99	46	60	0	grp3
+ref2	54	N	1	T	{	9	ref2_grp3_p002	99	46	60	0	grp3
+ref2	55	N	1	G	{	10	ref2_grp3_p002	99	46	60	0	grp3
+ref2	56	N	1	T	{	11	ref2_grp3_p002	99	46	60	0	grp3
+ref2	57	N	1	G	{	12	ref2_grp3_p002	99	46	60	0	grp3
+ref2	58	N	1	T	{	13	ref2_grp3_p002	99	46	60	0	grp3
+ref2	59	N	1	G	{	14	ref2_grp3_p002	99	46	60	0	grp3
+ref2	60	N	1	A$	{	15	ref2_grp3_p002	99	46	60	0	grp3

--- a/test/mpileup/mpileup.reg
+++ b/test/mpileup/mpileup.reg
@@ -119,7 +119,7 @@ P 81.out $samtools mpileup --output-BP-5 output-BP.sam
 P 78.out $samtools mpileup --reverse-del mpileup.1.bam
 
 # Extra columns and tags; --output-extra
-P 79.out $samtools mpileup -O --output-extra POS,FLAG,NM,QNAME,RG ../dat/view.001.sam
+P 79.out $samtools mpileup -O --output-extra POS,FLAG,NM,QNAME,RG,ENDPOS ../dat/view.001.sam
 
 # -a and -aa.  See depth.reg too
 P a0.out  $samtools mpileup -Q40 -r 17:1-4200 -f mpileup.ref.fa -a mpileup.1.$fmt


### PR DESCRIPTION
Combined with POS, this gives the left and right extents on the reference for this alignment, meaning we can observe how close to either end this pileup base is.

Fixes #2343