### PR TITLE
Update samtools checksum version number

### DIFF
--- a/bam_checksum.c
+++ b/bam_checksum.c
@@ -565,7 +565,7 @@ int checksum_report(char *fn, opts *o,
         return checksum_bamseqchksum(o, all, noRG, h);
 
     // headers
-    fprintf(o->fp, "# Checksum 1.0 for file:%s%s\n",
+    fprintf(o->fp, "# Checksum 2.0 for file:%s%s\n",
             o->tabs ? "\t" : " ", fn);
     fprintf(o->fp, "# Aux tags:%s%s\n",
             o->tabs ? "\t" : "          ", o->tag_str);

--- a/bam_checksum.c
+++ b/bam_checksum.c
@@ -857,7 +857,7 @@ static int sums_parse(opts *o, char *fn, sums_t *sums, sums_t *noRG,
         if (strncmp(line.s, "# Checksum", 10) == 0) {
             int major, minor;
             if (sscanf(line.s, "# Checksum %d.%d", &major, &minor) == 2) {
-                if (major != 1 || minor != 0) {
+                if (major != 2 || minor != 0) {
                     fprintf(stderr, "Unsupported checksum output version\n");
                     goto err;
                 }

--- a/test/checksum/chk1.1.expected
+++ b/test/checksum/chk1.1.expected
@@ -1,4 +1,4 @@
-# Checksum 1.0 for file:
+# Checksum 2.0 for file:
 # Aux tags:          BC,FI,QT,RT,TC
 # BAM flags:         PAIRED,READ1,READ2
 

--- a/test/checksum/chk1.3.expected
+++ b/test/checksum/chk1.3.expected
@@ -1,4 +1,4 @@
-# Checksum 1.0 for file:
+# Checksum 2.0 for file:
 # Aux tags:          BC,FI,QT,RT,TC
 # BAM flags:         PAIRED,READ1,READ2
 

--- a/test/checksum/chk1.7.expected
+++ b/test/checksum/chk1.7.expected
@@ -1,4 +1,4 @@
-# Checksum 1.0 for file: merge
+# Checksum 2.0 for file: merge
 # Aux tags:          BC,FI,QT,RT,TC
 # BAM flags:         PAIRED,READ1,READ2
 

--- a/test/checksum/chk2.1.expected
+++ b/test/checksum/chk2.1.expected
@@ -1,4 +1,4 @@
-# Checksum 1.0 for file:
+# Checksum 2.0 for file:
 # Aux tags:          BC,FI,QT,RT,TC
 # BAM flags:         PAIRED,READ1,READ2
 

--- a/test/checksum/chk2.2.expected
+++ b/test/checksum/chk2.2.expected
@@ -1,4 +1,4 @@
-# Checksum 1.0 for file:
+# Checksum 2.0 for file:
 # Aux tags:          *,cF,MD,NM
 # BAM flags:         PAIRED,PROPER_PAIR,UNMAP,MUNMAP,REVERSE,MREVERSE,READ1,READ2,SECONDARY,QCFAIL,DUP,SUPPLEMENTARY
 

--- a/test/checksum/chk2.3.expected
+++ b/test/checksum/chk2.3.expected
@@ -1,4 +1,4 @@
-# Checksum 1.0 for file:
+# Checksum 2.0 for file:
 # Aux tags:          BC,FI,QT,RT,TC
 # BAM flags:         PAIRED,READ1,READ2
 

--- a/test/checksum/chk2.4.expected
+++ b/test/checksum/chk2.4.expected
@@ -1,4 +1,4 @@
-# Checksum 1.0 for file:
+# Checksum 2.0 for file:
 # Aux tags:          *,cF,MD,NM
 # BAM flags:         PAIRED,PROPER_PAIR,UNMAP,MUNMAP,REVERSE,MREVERSE,READ1,READ2,SECONDARY,QCFAIL,DUP,SUPPLEMENTARY
 


### PR DESCRIPTION
For changes made in #2329 . 

There should be some way to discern that the checksum from 1.23.1 and 1.24 other than that this is a checksum failure. These checksums are not compatible, so the version should be updated.

Fixes #2354 (but only if this ends up in a 1.24.1 release  ASAP)