### PR TITLE
Strip UR tags from header SQ lines

### DIFF
--- a/doc/samtools-view.1
+++ b/doc/samtools-view.1
@@ -602,6 +602,9 @@ Combine with \fBall,cigarx\fR to perform the "=" and "X" replacement too.
 .TP
 .B --no-PG
 Do not add a @PG line to the header of the output file.
+.TP
+.B --remove-ur
+Remove all the UR tags from @SQ lines in the header.
 
 .SH EXAMPLES
 .IP o 2

--- a/doc/samtools.1
+++ b/doc/samtools.1
@@ -491,7 +491,7 @@ samtools consensus
 .I in.bam
 
 Generate consensus from a SAM, BAM or CRAM file based on the contents
-of the alignment records.  The consensus is written either as FASTA, 
+of the alignment records.  The consensus is written either as FASTA,
 FASTQ, or a pileup oriented format.
 
 The default output for FASTA and FASTQ formats include one base per
@@ -1058,6 +1058,11 @@ The \fBlevel\fR listed is only the default value, and will not be set
 if it has been explicitly changed already.  Additionally
 \fBbases_per_slice\fR is set to \fB500*seqs_per_slice\fR unless previously
 explicitly set.
+
+.TP
+.BI remove_ur= 0|1
+CRAM output only; defaults to 0.  Remove all the UR tags from SQ lines in the
+header.
 
 .TP
 .B fastq_name2

--- a/sam_view.c
+++ b/sam_view.c
@@ -1364,7 +1364,7 @@ int main_samview(int argc, char *argv[])
 
     if (settings.remove_ur) {
         if (sam_hdr_remove_tag_all(settings.header, "SQ", "UR") < 0) {
-            fprintf(stderr, "[main_samview] unable to remove UR tags.\n");
+            fprintf(stderr, "[main_samview] unable to remove UR tags from input.\n");
             ret = 1;
             goto view_end;
         }
@@ -1427,6 +1427,11 @@ int main_samview(int argc, char *argv[])
                 ret = 1;
                 goto view_end;
             }
+        }
+
+        if (settings.remove_ur) {
+            // stop cram from writing out any UR tags
+            hts_set_opt(settings.out, CRAM_OPT_RM_UR, 1);
         }
 
         if (ga.write_index || is_header ||

--- a/sam_view.c
+++ b/sam_view.c
@@ -96,6 +96,7 @@ typedef struct samview_settings {
     int sanitize;
     int count_rf; // CRAM_OPT_REQUIRED_FIELDS for view -c
     int exclude_no_rg;
+    int remove_ur;
 } samview_settings_t;
 
 // Copied from htslib/sam.c.
@@ -946,6 +947,7 @@ int main_samview(int argc, char *argv[])
         {"use-index", no_argument, NULL, 'M'},
         {"with-header", no_argument, NULL, 'h'},
         {"sanitize", required_argument, NULL, 'z'},
+        {"remove-ur", no_argument, NULL, LONGOPT('U')},
         {NULL, 0, NULL, 0}
     };
 
@@ -1281,6 +1283,9 @@ int main_samview(int argc, char *argv[])
             }
             break;
 
+        case LONGOPT('U'):
+            settings.remove_ur = 1; break;
+
         default:
             if (parse_sam_global_opt(c, optarg, lopts, &ga) != 0)
                 return usage(stderr, EXIT_FAILURE, 0);
@@ -1355,6 +1360,14 @@ int main_samview(int argc, char *argv[])
     }
     if (settings.rghash) {
         sam_hdr_remove_lines(settings.header, "RG", "ID", settings.rghash);
+    }
+
+    if (settings.remove_ur) {
+        if (sam_hdr_remove_tag_all(settings.header, "SQ", "UR") < 0) {
+            fprintf(stderr, "[main_samview] unable to remove UR tags.\n");
+            ret = 1;
+            goto view_end;
+        }
     }
 
     // Compute the subsampling seed and record the parameters in a @CO
@@ -1650,6 +1663,7 @@ static int usage(FILE *fp, int exit_status, int is_long_help)
 "  -p, --unmap                Set flag to UNMAP on reads not selected\n"
 "                             then write to output file.\n"
 "  -P, --fetch-pairs          Retrieve complete pairs even when outside of region\n"
+"      --remove-ur            Remove the UR tags from SQ header lines.\n"
 "\n"
 "Input options:\n"
 "  -t, --fai-reference FILE   FILE listing reference names and lengths\n"

--- a/test/test.pl
+++ b/test/test.pl
@@ -1973,16 +1973,6 @@ sub test_view
 
     my $out = "$$opts{tmp}/view";
 
-    # test UR removal, do this first so a file with UR is created
-    # for later tests.
-    my $bam_with_ur_out = sprintf("%s.test%03d.bam", $out, $test);
-    run_view_test($opts,
-                  msg => "$test: SAM -> BAM -> SAM",
-                  args => ['-b', '--remove-ur', $sam_with_ur, '--no-PG'],
-                  out => $bam_with_ur_out,
-                  compare_sam => $sam_no_ur);
-    $test++;
-
     # SAM -> BAM -> SAM
     my $bam_with_ur_out = sprintf("%s.test%03d.bam", $out, $test);
     run_view_test($opts,
@@ -2129,6 +2119,14 @@ sub test_view
                   out => sprintf("%s.test%03d.sam", $out, $test),
                   stdin => $cram_with_ur_out,
                   compare => $sam_with_ur);
+    $test++;
+
+    my $bam_with_no_ur_out = sprintf("%s.test%03d.bam", $out, $test);
+    run_view_test($opts,
+                  msg => "$test: SAM -> BAM -> SAM",
+                  args => ['-b', '--remove-ur', $sam_with_ur, '--no-PG'],
+                  out => $bam_with_no_ur_out,
+                  compare_sam => $sam_no_ur);
     $test++;
 
 

--- a/test/test.pl
+++ b/test/test.pl
@@ -1973,6 +1973,16 @@ sub test_view
 
     my $out = "$$opts{tmp}/view";
 
+    # test UR removal, do this first so a file with UR is created
+    # for later tests.
+    my $bam_with_ur_out = sprintf("%s.test%03d.bam", $out, $test);
+    run_view_test($opts,
+                  msg => "$test: SAM -> BAM -> SAM",
+                  args => ['-b', '--remove-ur', $sam_with_ur, '--no-PG'],
+                  out => $bam_with_ur_out,
+                  compare_sam => $sam_no_ur);
+    $test++;
+
     # SAM -> BAM -> SAM
     my $bam_with_ur_out = sprintf("%s.test%03d.bam", $out, $test);
     run_view_test($opts,


### PR DESCRIPTION
The new `--remove-ur` option will delete all the UR tags from SQ lines in the header. This commit depends https://github.com/samtools/htslib/pull/2056.  This should fix #2327.