### PR TITLE
Remove the meme of strdup(optarg) in CLI parsing

### DIFF
--- a/bam_addrprg.c
+++ b/bam_addrprg.c
@@ -72,8 +72,6 @@ static void cleanup_opts(parsed_opts_t* opts)
 {
     if (!opts) return;
     free(opts->rg_id);
-    free(opts->output_name);
-    free(opts->input_name);
     free(opts->rg_line);
     if (opts->p.pool) hts_tpool_destroy(opts->p.pool);
     sam_global_args_free(&opts->ga);
@@ -229,6 +227,8 @@ static bool parse_args(int argc, char** argv, parsed_opts_t** opts)
                 kputs(optarg, &rg_line);
                 break;
             case 'R':
+                // NB: Can be allocated in get_rg_id
+                free(retval->rg_id);
                 retval->rg_id = strdup(optarg);
                 break;
             case 'm': {
@@ -243,7 +243,7 @@ static bool parse_args(int argc, char** argv, parsed_opts_t** opts)
                 break;
             }
             case 'o':
-                retval->output_name = strdup(optarg);
+                retval->output_name = optarg;
                 break;
             case 'h':
                 usage(stdout);
@@ -297,7 +297,7 @@ static bool parse_args(int argc, char** argv, parsed_opts_t** opts)
         free(retval->rg_line);
         retval->rg_line = tmp;
     }
-    retval->input_name = strdup(argv[optind+0]);
+    retval->input_name = argv[optind+0];
 
     if (retval->ga.nthreads > 0) {
         if (!(retval->p.pool = hts_tpool_init(retval->ga.nthreads))) {
@@ -312,7 +312,6 @@ static bool parse_args(int argc, char** argv, parsed_opts_t** opts)
 
 static void overwrite_all_func(const state_t* state, bam1_t* file_read)
 {
-    uint8_t* data = (uint8_t*)strdup(state->rg_id);
     int len = strlen(state->rg_id)+1;
     // If the old exists delete it
     uint8_t* old = bam_aux_get(file_read, "RG");
@@ -320,20 +319,17 @@ static void overwrite_all_func(const state_t* state, bam1_t* file_read)
         bam_aux_del(file_read, old);
     }
 
-    bam_aux_append(file_read, "RG", 'Z', len, data);
-    free(data);
+    bam_aux_append(file_read, "RG", 'Z', len, (const uint8_t *)state->rg_id);
 }
 
 static void orphan_only_func(const state_t* state, bam1_t* file_read)
 {
-    uint8_t* data = (uint8_t*)strdup(state->rg_id);
     int len = strlen(state->rg_id)+1;
     // If the old exists don't do anything
     uint8_t* old = bam_aux_get(file_read, "RG");
     if (old == NULL) {
-        bam_aux_append(file_read, "RG",'Z',len,data);
+        bam_aux_append(file_read, "RG",'Z',len, (const uint8_t *)state->rg_id);
     }
-    free(data);
 }
 
 static bool init(const parsed_opts_t* opts, state_t** state_out) {

--- a/bam_cat.c
+++ b/bam_cat.c
@@ -854,7 +854,7 @@ int main_cat(int argc, char *argv[])
                 sam_close(fph);
                 break;
             }
-            case 'o': outfn = strdup(optarg); break;
+            case 'o': outfn = optarg; break;
             case 'b': {
                 // add file names in "optarg" to the list
                 // of files to concatenate
@@ -968,7 +968,6 @@ int main_cat(int argc, char *argv[])
             free(infns[i]);
     }
 
-    free(outfn);
     free(infns);
     free(arg_list);
     if (h)

--- a/bam_plcmd.c
+++ b/bam_plcmd.c
@@ -1207,7 +1207,7 @@ int bam_mpileup(int argc, char *argv[])
             mplp.fai_fname = optarg;
             break;
         case 'd': mplp.max_depth = atoi(optarg); break;
-        case 'r': mplp.reg = strdup(optarg); break;
+        case 'r': mplp.reg = optarg; break;
         case 'l':
                   // In the original version the whole BAM was streamed which is inefficient
                   //  with few BED intervals and big BAMs. Todo: devise a heuristic to determine
@@ -1292,7 +1292,7 @@ int bam_mpileup(int argc, char *argv[])
         }
     }
     if (mplp.rghash) khash_str2int_destroy_free(mplp.rghash);
-    free(mplp.reg); free(mplp.pl_list);
+    free(mplp.pl_list);
     if (mplp.fai) fai_destroy(mplp.fai);
     if (mplp.bed) bed_destroy(mplp.bed);
     if (mplp.auxlist) kl_destroy(auxlist, (klist_t(auxlist) *)mplp.auxlist);

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -1647,7 +1647,7 @@ int bam_merge(int argc, char *argv[])
         case 't': sort_tag = optarg; break;
         case '1': flag |= MERGE_LEVEL1; level = 1; break;
         case 'u': flag |= MERGE_UNCOMP; level = 0; break;
-        case 'R': reg = strdup(optarg); break;
+        case 'R': reg = optarg; break;
         case 'l':
             if (!parse_int_value(optarg, &level)) {
                 fprintf(stderr, "Invalid compression level\n");
@@ -1774,7 +1774,6 @@ end:
     }
     free(fn);
     free(fn_idx);
-    free(reg);
     free(arg_list);
     sam_global_args_free(&ga);
     return ret;

--- a/padding.c
+++ b/padding.c
@@ -465,7 +465,7 @@ int main_pad2unpad(int argc, char *argv[])
         case 'S': break;
         case 'C': hts_parse_format(&ga.out, "cram"); break;
         case 's': assert(compress_level == -1); hts_parse_format(&ga.out, "sam"); break;
-        case 'o': fn_out = strdup(optarg); break;
+        case 'o': fn_out = optarg; break;
         case 'u':
             compress_level = 0;
             if (ga.out.format == unknown_format)
@@ -583,7 +583,7 @@ depad_end:
         fprintf(stderr, "[depad] error on closing output file.\n");
         ret = 1;
     }
-    free(fn_fai); free(fn_out);
+    free(fn_fai);
     if (fn_out_idx)
         free(fn_out_idx);
     sam_global_args_free(&ga);

--- a/phase.c
+++ b/phase.c
@@ -633,8 +633,8 @@ int main_phase(int argc, char *argv[])
             case 'F': g.flag &= ~FLAG_FIX_CHIMERA; break;
             case 'e': g.flag |= FLAG_LIST_EXCL; break;
             case 'A': g.flag |= FLAG_DROP_AMBI; break;
-            case 'b': g.pre = strdup(optarg); break;
-            case 'l': fn_list = strdup(optarg); break;
+            case 'b': g.pre = optarg; break;
+            case 'l': fn_list = optarg; break;
             case 1: g.no_pg = 1; break;
             default:  if (parse_sam_global_opt(c, optarg, lopts, &ga) == 0) break;
                       /* else fall-through */
@@ -680,7 +680,6 @@ int main_phase(int argc, char *argv[])
     if (fn_list) { // read the list of sites to phase
         set = loadpos(fn_list, g.fp_hdr);
         if (set == NULL) return 1;
-        free(fn_list);
     } else g.flag &= ~FLAG_LIST_EXCL;
     if (g.pre) { // open BAMs to write
         if (ga.out.format == unknown_format)
@@ -830,7 +829,7 @@ int main_phase(int argc, char *argv[])
             sam_hdr_destroy(g.out_hdr[c]);
             free(g.out_name[c]);
         }
-        free(g.pre); free(g.b);
+        free(g.b);
         if (res) return 1;
     }
     free(g.arg_list);

--- a/sam_view.c
+++ b/sam_view.c
@@ -1028,12 +1028,16 @@ int main_samview(int argc, char *argv[])
         case 'S': break;
         case 'b': out_format = "b"; break;
         case 'C': out_format = "c"; break;
-        case 't': settings.fn_fai = strdup(optarg); break;
+        case 't':
+            // NB: also can come from fai_path(), which mallocs
+            free(settings.fn_fai);
+            settings.fn_fai = strdup(optarg);
+            break;
         case 'h': is_header = 1; break;
         case 'H': is_header_only = 1; break;
         case LONGOPT('H'): is_header = is_header_only = 0; break;
-        case 'o': settings.fn_out = strdup(optarg); break;
-        case 'U': settings.fn_un_out = strdup(optarg); break;
+        case 'o': settings.fn_out = optarg; break;
+        case 'U': settings.fn_un_out = optarg; break;
         case 'X': has_index_file = 1; break;
         case 'f':
             tmp_flag = bam_str2flag(optarg);
@@ -1089,7 +1093,7 @@ int main_samview(int argc, char *argv[])
         case 'u': compress_level = 0; break;
         case '1': compress_level = 1; break;
         case 'l':
-            settings.library = strdup(optarg);
+            settings.library = optarg;
             settings.count_rf |= SAM_RGAUX;
             break;
         case 'p': settings.unmap = 1; break;
@@ -1599,7 +1603,7 @@ view_end:
     if (settings.un_out) check_sam_close("view", settings.un_out, settings.fn_un_out, "file", &ret);
     if (fp_out) fclose(fp_out);
 
-    free(settings.fn_fai); free(settings.fn_out); free(settings.library);  free(settings.fn_un_out);
+    free(settings.fn_fai);
     sam_global_args_free(&ga);
     if ( settings.header ) sam_hdr_destroy(settings.header);
     if (settings.bed) bed_destroy(settings.bed);


### PR DESCRIPTION
There are many pointless strdups, which can lead to minor memory leaks in the case of duplicate arguments or in error handling.

    samtools view -o a.bam -o a.bam b.bam

There are more strdups around, plus definitely cases of broken tidyups on error (I found many in phase.c), but this PR is focused on basic CLI.