### PR TITLE
Add --norc --noprofile to bash invocations in test.pl

### DIFF
--- a/test/test.pl
+++ b/test/test.pl
@@ -188,7 +188,7 @@ sub _cmd
     my $out;
     my $err;
     my ($err_fh, $err_filename) = tempfile(UNLINK => 1);
-    my $pid = open($kid_io, "-|", 'bash', '-o','pipefail','-c', "($cmd) 2> $err_filename");
+    my $pid = open($kid_io, "-|", 'bash', '--norc', '--noprofile', '-o','pipefail','-c', "($cmd) 2> $err_filename");
     if ( !defined $pid ) { error("Cannot fork: $!"); }
     if ($pid)
     {


### PR DESCRIPTION
One test.pl occurrence managed to get stuck on a cmd("cp ...") call due to it being exanded up to a "cp -i" from my .bashrc.  This isn't reproducible and I do not understand the scenario that triggered it, however we may get more robust behaviour and faster testing by explicitly asking to avoid these configuration files.