### PR TITLE
Move checksum version to 2.0

### DIFF
--- a/bam_checksum.c
+++ b/bam_checksum.c
@@ -737,13 +737,13 @@ int checksum(sam_global_args *ga, opts *o, version_number *ver, char *fn) {
                 u32_to_le(b->core.mtid,  mate);
                 u64_to_le(b->core.mpos,  mate+4);
                 u64_to_le(b->core.isize, mate+12);
-                c.mate = hts_crc32(c.seq, mate, 20);
+                c.mate = hts_crc32(c.seq, mate, sizeof(mate));
             } else {
                 // this replicates the mistake in checksum v1.0
                 uint8_t mate[4+8+8];
                 u32_to_le(b->core.mtid,  mate);
                 u64_to_le(b->core.mpos,  mate+4);
-                c.mate = hts_crc32(c.seq, mate, 12);
+                c.mate = hts_crc32(c.seq, mate, 12); // mistake was here
             }
         }
 

--- a/bam_checksum.c
+++ b/bam_checksum.c
@@ -732,11 +732,19 @@ int checksum(sam_global_args *ga, opts *o, version_number *ver, char *fn) {
 
         // flag + seq + rnext + pnext + tlen
         if (o->check_mate) {
-            uint8_t mate[4+8+8];
-            u32_to_le(b->core.mtid,  mate);
-            u64_to_le(b->core.mpos,  mate+4);
-            u64_to_le(b->core.isize, mate+12);
-            c.mate = hts_crc32(c.seq, mate, 20);
+            if (ver->major >= 2) {
+                uint8_t mate[4+8+8];
+                u32_to_le(b->core.mtid,  mate);
+                u64_to_le(b->core.mpos,  mate+4);
+                u64_to_le(b->core.isize, mate+12);
+                c.mate = hts_crc32(c.seq, mate, 20);
+            } else {
+                // this replicates the mistake in checksum v1.0
+                uint8_t mate[4+8+8];
+                u32_to_le(b->core.mtid,  mate);
+                u64_to_le(b->core.mpos,  mate+4);
+                c.mate = hts_crc32(c.seq, mate, 12);
+            }
         }
 
         // flag + seq + mapq + cigar
@@ -1183,7 +1191,7 @@ void usage_exit(FILE *fp, int ret) {
   -O, --in-order              Use order-specific checksumming [off]\n\
   -P, --check-pos             Also checksum CHR / POS [off]\n\
   -C, --check-cigar           Also checksum MAPQ / CIGAR [off]\n\
-  -M, --check_mate            Also checksum PNEXT / RNEXT / TLEN [off]\n\
+  -M, --check-mate            Also checksum PNEXT / RNEXT / TLEN [off]\n\
   -z, --sanitize FLAGS        Perform sanity checks and fix records [off]\n\
   -N, --count INT             Stop after INT number of records [0]\n\
   -o, --output FILE           Write report to FILE [stdout]\n\
@@ -1192,7 +1200,8 @@ void usage_exit(FILE *fp, int ret) {
   -a, --all                   Check all: -PCMOc -b 0xfff -f0 -F0 -z all,cigarx\n\
   -T, --tabs                  Format output as tab delimited text\n\
   -m, --merge FILE            Merge checksum output (-o opt) files\n\
-  -B, --bamseqchksum          Report in bamseqchksum format\n");
+  -B, --bamseqchksum          Report in bamseqchksum format\n\
+  -V  --version-1             Use version 1 checksums\n");
     fprintf(fp, "\nGlobal options:\n");
     sam_global_opt_help(fp, "-.---@--");
     exit(ret);
@@ -1290,7 +1299,7 @@ int main_checksum(int argc, char **argv) {
         usage_exit(stdout, EXIT_SUCCESS);
 
     int c;
-    while ((c = getopt_long(argc, argv, "@:f:F:t:cPCMOb:z:aN:vqo:TmB1",
+    while ((c = getopt_long(argc, argv, "@:f:F:t:cPCMOb:z:aN:vqo:TmBV",
                             lopts, NULL)) >= 0) {
         switch (c) {
         case 'O':
@@ -1378,7 +1387,7 @@ int main_checksum(int argc, char **argv) {
             }
             break;
 
-        case '1':
+        case 'V':
             version.major = 1;
             version.minor = 0;
             break;

--- a/bam_checksum.c
+++ b/bam_checksum.c
@@ -73,6 +73,11 @@ typedef struct {
     int compat;    // compatibility with bamseqchksum format
 } opts;
 
+typedef struct {
+    int major;
+    int minor;
+} version_number;
+
 /* ----------------------------------------------------------------------
  * Utility functions.  Possible candidates for moving to htslib?
  */
@@ -559,14 +564,14 @@ int checksum_bamseqchksum(opts *o, sums_t *all, sums_t *noRG, khash_t(chk) *h){
     return 0;
 }
 
-int checksum_report(char *fn, opts *o,
+int checksum_report(char *fn, opts *o, version_number *ver,
                     sums_t *all, sums_t *noRG, khash_t(chk) *h) {
     if (o->compat)
         return checksum_bamseqchksum(o, all, noRG, h);
 
     // headers
-    fprintf(o->fp, "# Checksum 1.0 for file:%s%s\n",
-            o->tabs ? "\t" : " ", fn);
+    fprintf(o->fp, "# Checksum %d.%d for file:%s%s\n",
+            ver->major, ver->minor, o->tabs ? "\t" : " ", fn);
     fprintf(o->fp, "# Aux tags:%s%s\n",
             o->tabs ? "\t" : "          ", o->tag_str);
     char *s=bam_flag2str(o->flag_mask);
@@ -613,7 +618,7 @@ int checksum_report(char *fn, opts *o,
     return 0;
 }
 
-int checksum(sam_global_args *ga, opts *o, char *fn) {
+int checksum(sam_global_args *ga, opts *o, version_number *ver, char *fn) {
     samFile *fp = NULL;
     sam_hdr_t *hdr = NULL;
     bam1_t *b = bam_init1();
@@ -797,7 +802,7 @@ int checksum(sam_global_args *ga, opts *o, char *fn) {
     fp = NULL;
 
     // Report hashes
-    if (checksum_report(fn, o, &h32, &noRG, h) < 0)
+    if (checksum_report(fn, o, ver, &h32, &noRG, h) < 0)
         goto err;
 
     ret = 0;
@@ -834,7 +839,7 @@ int checksum(sam_global_args *ga, opts *o, char *fn) {
  */
 
 // Process an individual file, aggregating to s, noRG and h
-static int sums_parse(opts *o, char *fn, sums_t *sums, sums_t *noRG,
+static int sums_parse(opts *o, version_number *ver, char *fn, sums_t *sums, sums_t *noRG,
                       khash_t(chk) *h) {
     int ret = -1, minfields = 8;    //samtools style chksum
     typedef enum hdrtype {HDR_NF, HDR_SAMCHKSUM, HDR_BAMBAMCHKSUM} hdrtype;
@@ -857,8 +862,10 @@ static int sums_parse(opts *o, char *fn, sums_t *sums, sums_t *noRG,
         if (strncmp(line.s, "# Checksum", 10) == 0) {
             int major, minor;
             if (sscanf(line.s, "# Checksum %d.%d", &major, &minor) == 2) {
-                if (major != 1 || minor != 0) {
-                    fprintf(stderr, "Unsupported checksum output version\n");
+                if (major != ver->major || minor != ver->minor) {
+                    fprintf(stderr, "Not current checksum output version:"
+                     "found %d.%d, expected %d.%d\n", major, minor,
+                     ver->major, ver->minor);
                     goto err;
                 }
             }
@@ -1124,7 +1131,7 @@ static int sums_parse(opts *o, char *fn, sums_t *sums, sums_t *noRG,
 }
 
 // Combine multiple checksum files together and report the merged stats
-int combine(opts *o, int argc, char **argv) {
+int combine(opts *o, version_number *ver, int argc, char **argv) {
     int ret = -1;
     sums_t s, noRG;
     sums_init(&s);
@@ -1136,12 +1143,12 @@ int combine(opts *o, int argc, char **argv) {
     if (!h)
         goto err;
     for (int i = 0; i < argc; i++) {
-        if (sums_parse(o, argv[i], &s, &noRG, h) < 0) {
+        if (sums_parse(o, ver, argv[i], &s, &noRG, h) < 0) {
             fprintf(stderr, "Failed to parse checksum file '%s'\n", argv[i]);
             goto err;
         }
     }
-    checksum_report("merge", o, &s, &noRG, h);
+    checksum_report("merge", o, ver, &s, &noRG, h);
 
     ret = 0;
  err:
@@ -1270,14 +1277,20 @@ int main_checksum(int argc, char **argv) {
         {"tabs",          no_argument,       NULL, 'T'},
         {"merge",         no_argument,       NULL, 'm'},
         {"bamseqchksum",  no_argument,       NULL, 'B'},
+        {"version-1",     no_argument,       NULL, 'V'},
         {NULL, 0, NULL, 0}
+    };
+
+    version_number version = {
+        .major = 2,
+        .minor = 0,
     };
 
     if (argc == 1 && isatty(STDIN_FILENO))
         usage_exit(stdout, EXIT_SUCCESS);
 
     int c;
-    while ((c = getopt_long(argc, argv, "@:f:F:t:cPCMOb:z:aN:vqo:TmB",
+    while ((c = getopt_long(argc, argv, "@:f:F:t:cPCMOb:z:aN:vqo:TmB1",
                             lopts, NULL)) >= 0) {
         switch (c) {
         case 'O':
@@ -1365,6 +1378,11 @@ int main_checksum(int argc, char **argv) {
             }
             break;
 
+        case '1':
+            version.major = 1;
+            version.minor = 0;
+            break;
+
         default:
             if (parse_sam_global_opt(c, optarg, lopts, &ga) == 0)
                 break;
@@ -1381,13 +1399,13 @@ int main_checksum(int argc, char **argv) {
 
     int ret = 0;
     if (opts.merge) {
-        ret = combine(&opts, argc - optind, argv+optind);
+        ret = combine(&opts, &version, argc - optind, argv+optind);
     } else {
         if (argc-optind) {
             while (optind < argc)
-                ret |= checksum(&ga, &opts, argv[optind++]) < 0;
+                ret |= checksum(&ga, &opts, &version, argv[optind++]) < 0;
         } else {
-            ret = checksum(&ga, &opts, "-") < 0;
+            ret = checksum(&ga, &opts, &version, "-") < 0;
         }
     }
 

--- a/doc/samtools-checksum.1
+++ b/doc/samtools-checksum.1
@@ -313,6 +313,12 @@ order-specific checksums (\fB-OO\fR) has been used.
 Increase verbosity.  At level 1 or higher this also shows rows that
 have zero count values, which can aid machine parsing.
 
+.TP
+.BR -V "," --version-1
+Checksums in version 1.0 were incorrectly calculated if the \fB-M\fR 
+(\fB--check-mate\fR) flag was set.  Version 2.0 fixed this issue but made
+previous checksums invalid.  This option replicates version 1.0 behaviour.
+
 .SH EXAMPLES
 .IP o 2
 To check that an aligned and position sorted file contains the same

--- a/test/checksum/chk1.1.expected
+++ b/test/checksum/chk1.1.expected
@@ -1,4 +1,4 @@
-# Checksum 1.0 for file:
+# Checksum 2.0 for file:
 # Aux tags:          BC,FI,QT,RT,TC
 # BAM flags:         PAIRED,READ1,READ2
 

--- a/test/checksum/chk1.3.expected
+++ b/test/checksum/chk1.3.expected
@@ -1,4 +1,4 @@
-# Checksum 1.0 for file:
+# Checksum 2.0 for file:
 # Aux tags:          BC,FI,QT,RT,TC
 # BAM flags:         PAIRED,READ1,READ2
 

--- a/test/checksum/chk1.7.expected
+++ b/test/checksum/chk1.7.expected
@@ -1,4 +1,4 @@
-# Checksum 1.0 for file: merge
+# Checksum 2.0 for file: merge
 # Aux tags:          BC,FI,QT,RT,TC
 # BAM flags:         PAIRED,READ1,READ2
 

--- a/test/checksum/chk2.1.expected
+++ b/test/checksum/chk2.1.expected
@@ -1,4 +1,4 @@
-# Checksum 1.0 for file:
+# Checksum 2.0 for file:
 # Aux tags:          BC,FI,QT,RT,TC
 # BAM flags:         PAIRED,READ1,READ2
 

--- a/test/checksum/chk2.2.expected
+++ b/test/checksum/chk2.2.expected
@@ -1,4 +1,4 @@
-# Checksum 1.0 for file:
+# Checksum 2.0 for file:
 # Aux tags:          *,cF,MD,NM
 # BAM flags:         PAIRED,PROPER_PAIR,UNMAP,MUNMAP,REVERSE,MREVERSE,READ1,READ2,SECONDARY,QCFAIL,DUP,SUPPLEMENTARY
 

--- a/test/checksum/chk2.3.expected
+++ b/test/checksum/chk2.3.expected
@@ -1,4 +1,4 @@
-# Checksum 1.0 for file:
+# Checksum 2.0 for file:
 # Aux tags:          BC,FI,QT,RT,TC
 # BAM flags:         PAIRED,READ1,READ2
 

--- a/test/checksum/chk2.4.expected
+++ b/test/checksum/chk2.4.expected
@@ -1,4 +1,4 @@
-# Checksum 1.0 for file:
+# Checksum 2.0 for file:
 # Aux tags:          *,cF,MD,NM
 # BAM flags:         PAIRED,PROPER_PAIR,UNMAP,MUNMAP,REVERSE,MREVERSE,READ1,READ2,SECONDARY,QCFAIL,DUP,SUPPLEMENTARY
 

--- a/test/checksum/chk2.5.expected
+++ b/test/checksum/chk2.5.expected
@@ -1,0 +1,9 @@
+# Checksum 1.0 for file:
+# Aux tags:          *,cF,MD,NM
+# BAM flags:         PAIRED,PROPER_PAIR,UNMAP,MUNMAP,REVERSE,MREVERSE,READ1,READ2,SECONDARY,QCFAIL,DUP,SUPPLEMENTARY
+
+# Group    QC          count  flag+seq  +name     +qual     +aux      +chr/pos  +cigar    +mate     combined
+all        all           144  1f3b08b2  0bea7b40  5c8378af  718a93ab  08c04081  2a0d534a  5c4f1280  2f750c72
+-          all            13  5301e7ef  40e64b8d  5dd9326e  4e8a56b4  127a7d6e  5454448e  0dac7c0c  53960b34
+ERR013140  all            71  284ddd75  7e138598  266ada9b  54ebc7e0  4d154504  73ae51d8  5321dabd  3b4b46b6
+ERR156632  all            60  2d77e435  040aad2d  718aa362  53a65f1d  5cf6e893  4af8689e  62ae9dd1  12a34431

--- a/test/test.pl
+++ b/test/test.pl
@@ -4171,6 +4171,9 @@ sub test_checksum
     # merge b/w different type, with -B, works fine
     test_cmd($opts, out=>"checksum/chk1.8.expected", cmd=>"$$opts{bin}/samtools $chk -B -m $$opts{path}/checksum/chk1.1.expected $$opts{path}/checksum/chk1.4.expected");
 
+    # check the version 1 checksum still works
+    test_cmd($opts, out=>"checksum/chk2.5.expected", cmd=>"$$opts{bin}/samtools $chk -a -V $$opts{path}/checksum/chk2.cram | sed 's/\\(# Checksum[^:]*:\\).*/\\1/'");
+
 
 }
 


### PR DESCRIPTION
Checksum calculations differed between samtools v1.24 and previous
releases.  In earlier releases, the "--check-mate" option produced incorrect
checksums.  This was fixed in v1.24 but made already existing checksums
invalid.

Therefore, the fixed checksum is now designated Checksum 2.0 while the
previous one is left at Checksum 1.0 in order differentiate the versions.

A new "--version-1" option will set samtools checksum to version 1.0
behaviour for backwards compatibility.

Should fix https://github.com/samtools/samtools/issues/2354.