### PR TITLE
Check string aux tag types before accessing data

### DIFF
--- a/bam.c
+++ b/bam.c
@@ -38,7 +38,7 @@ const char *bam_get_library(sam_hdr_t *h, const bam1_t *b)
     kstring_t lib = { 0, 0, NULL };
     rg = (char *)bam_aux_get(b, "RG");
 
-    if (!rg)
+    if (!rg || *rg != 'Z')
         return NULL;
     else
         rg++;

--- a/bam_ampliconclip.c
+++ b/bam_ampliconclip.c
@@ -657,7 +657,9 @@ static inline int tag_original_data(bam1_t *orig, kstring_t *oa_tag) {
 
     // if there is an existing OA tag the new one gets appended to it
     if ((old_oa_tag = bam_aux_get(orig, "OA"))) {
-        res |= ksprintf(oa_tag, "%s", bam_aux2Z(old_oa_tag)) < 0;
+        char *old_oa = bam_aux2Z(old_oa_tag);
+        if (old_oa)
+            res |= ksprintf(oa_tag, "%s", old_oa) < 0;
     }
 
     if (orig->core.flag & BAM_FREVERSE)

--- a/bam_color.c
+++ b/bam_color.c
@@ -46,6 +46,7 @@ char bam_aux_getCSi(bam1_t *b, int i)
     if(0 == c) return 0;
 
     cs = bam_aux2Z(c);
+    if (!cs) return 0;
     // adjust for strandedness and leading adaptor
     if(bam_is_rev(b)) {
         i = strlen(cs) - 1 - i;

--- a/bam_consensus.c
+++ b/bam_consensus.c
@@ -1151,6 +1151,8 @@ int nm_init(void *client_data, samFile *fp, sam_hdr_t *h, pileup_t *p) {
     if (!md)
         return 1;
     md = (const uint8_t *)bam_aux2Z(md);
+    if (!md)
+        return 1; // Wrong type
 
     // Handle cost of being near a soft-clip
     uint32_t *cig = bam_get_cigar(b);

--- a/bam_fastq.c
+++ b/bam_fastq.c
@@ -922,7 +922,7 @@ int output_index(bam1_t *b1, bam1_t *b2, bam2fq_state_t *state,
         bc = (char *)bam_aux_get(b1, opts->barcode_tag);
     if (b2 && !bc)
         bc = (char *)bam_aux_get(b2, opts->barcode_tag);
-    if (!bc)
+    if (!bc || *bc != 'Z')
         return 0;
     else
         bc++; // skip Z
@@ -931,7 +931,7 @@ int output_index(bam1_t *b1, bam1_t *b2, bam2fq_state_t *state,
         qt = (char *)bam_aux_get(b1, opts->quality_tag);
     if (b2 && !qt)
         qt = (char *)bam_aux_get(b2, opts->quality_tag);
-    if (qt && strlen(bc) != strlen(qt)-1)
+    if (qt && (*qt != 'Z' || strlen(bc) != strlen(qt)-1))
         qt = NULL;
     else if (qt)
         qt++;

--- a/bam_md.c
+++ b/bam_md.c
@@ -178,7 +178,7 @@ static int bam_fillmd1_core(const char *ref_name, bam1_t *b, char *ref,
                 goto aux_fail;
         } else {
             int is_diff = 0;
-            if (strlen((char*)old_md+1) == str.l) {
+            if (*old_md == 'Z' && strlen((char*)old_md+1) == str.l) {
                 for (i = 0; i < str.l; ++i)
                     if (toupper(old_md[i+1]) != toupper_c(str.s[i]))
                         break;

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -955,7 +955,7 @@ static void bam_translate(bam1_t* b, trans_tbl_t* tbl)
     uint8_t *rg = bam_aux_get(b, "RG");
     if (rg) {
         char* decoded_rg = bam_aux2Z(rg);
-        khiter_t k = kh_get(c2c, tbl->rg_trans, decoded_rg);
+        khiter_t k = decoded_rg ? kh_get(c2c, tbl->rg_trans, decoded_rg) : kh_end(tbl->rg_trans);
         if (k != kh_end(tbl->rg_trans)) {
             char* translate_rg = kh_value(tbl->rg_trans,k);
             bam_aux_del(b, rg);
@@ -963,7 +963,7 @@ static void bam_translate(bam1_t* b, trans_tbl_t* tbl)
                 bam_aux_append(b, "RG", 'Z', strlen(translate_rg) + 1,
                                (uint8_t*)translate_rg);
             }
-        } else {
+        } else if (decoded_rg) {
             char *tmp = strdup(decoded_rg);
             fprintf(stderr,
                     "[bam_translate] RG tag \"%s\" on read \"%s\" encountered "
@@ -985,7 +985,7 @@ static void bam_translate(bam1_t* b, trans_tbl_t* tbl)
     uint8_t *pg = bam_aux_get(b, "PG");
     if (pg) {
         char* decoded_pg = bam_aux2Z(pg);
-        khiter_t k = kh_get(c2c, tbl->pg_trans, decoded_pg);
+        khiter_t k = decoded_pg ? kh_get(c2c, tbl->pg_trans, decoded_pg) : kh_end(tbl->pg_trans);
         if (k != kh_end(tbl->pg_trans)) {
             char* translate_pg = kh_value(tbl->pg_trans,k);
             bam_aux_del(b, pg);
@@ -993,7 +993,7 @@ static void bam_translate(bam1_t* b, trans_tbl_t* tbl)
                 bam_aux_append(b, "PG", 'Z', strlen(translate_pg) + 1,
                                (uint8_t*)translate_pg);
             }
-        } else {
+        } else if (decoded_pg) {
             char *tmp = strdup(decoded_pg);
             fprintf(stderr,
                     "[bam_translate] PG tag \"%s\" on read \"%s\" encountered "

--- a/bam_tview.c
+++ b/bam_tview.c
@@ -338,7 +338,7 @@ static int tv_push_aln(const bam1_t *b, tview_t *tv)
     if ( tv->rg_hash )
     {
         const uint8_t *rg = bam_aux_get(b, "RG");
-        if ( !rg ) return 0; // If we don't have an RG tag exclude read
+        if ( !rg || *rg != 'Z') return 0; // If we don't have an RG tag exclude read
         khiter_t k = kh_get(kh_rg, tv->rg_hash, (const char*)(rg + 1));
         if ( k == kh_end(tv->rg_hash) ) return 0; // if RG tag is not in list of allowed tags exclude read
     }

--- a/doc/samtools-stats.1
+++ b/doc/samtools-stats.1
@@ -465,6 +465,8 @@ based on the tagged field
 (e.g., use
 .B --split RG
 to split into read groups).
+The tag data used must have string type (Z in SAM).
+Splitting on numeric tags is not currently supported.
 
 Categorised statistics are written to files named
 .RI < prefix >_< value >.bamstat,

--- a/sam_view.c
+++ b/sam_view.c
@@ -182,7 +182,7 @@ static int process_aln(const sam_hdr_t *h, bam1_t *b, samview_settings_t* settin
     }
     if (settings->rghash || settings->exclude_no_rg) {
         uint8_t *s = bam_aux_get(b, "RG");
-        if (s) {
+        if (s && *s == 'Z') {
             if (settings->rghash) {
                 khint_t k = kh_get(str, settings->rghash, (char*)(s + 1));
                 if ((k == kh_end(settings->rghash)) != settings->rghash_discard)

--- a/stats.c
+++ b/stats.c
@@ -1216,7 +1216,7 @@ void collect_stats(bam1_t *bam_line, stats_t *stats, khash_t(qn2pair) *read_pair
     if ( stats->rg_hash )
     {
         const uint8_t *rg = bam_aux_get(bam_line, "RG");
-        if ( !rg ) return;  // certain read groups were requested but this record has none
+        if ( !rg || *rg != 'Z') return;  // certain read groups were requested but this record has none
         khint_t k = kh_get(rg, stats->rg_hash, (const char*)(rg + 1));
         if ( k == kh_end((kh_rg_t *)stats->rg_hash) ) return;
     }
@@ -2469,29 +2469,35 @@ static stats_t* get_curr_split_stats(bam1_t* bam_line, khash_t(c2stats)* split_h
     if(tag_val == 0){
         error("Tag '%s' not found in bam_line.\n", info->split_tag);
     }
-    char* split_name = strdup(bam_aux2Z(tag_val));
 
-    // New stats object, under split
+    char* split_name = bam_aux2Z(tag_val);
+    if (!split_name)
+        error("Tag '%s' on read %s is type '%c', not 'Z' (string).\n",
+              info->split_tag, bam_get_qname(bam_line), *tag_val);
+
     khiter_t k = kh_get(c2stats, split_hash, split_name);
     if(k == kh_end(split_hash)){
+        // New stats object, under split
+        char *dup_name = strdup(split_name);
+        if (!dup_name)
+            error("Couldn't allocate name for split");
         curr_stats = stats_init(); // mallocs new instance
         if (!curr_stats) {
             error("Couldn't allocate split stats");
         }
         init_stat_structs(curr_stats, info, NULL, targets);
-        curr_stats->split_name = split_name;
+        curr_stats->split_name = dup_name;
 
         // Record index in hash
         int ret = 0;
         khiter_t iter = kh_put(c2stats, split_hash, split_name, &ret);
         if( ret < 0 ){
-            error("Failed to insert key '%s' into split_hash", split_name);
+            error("Failed to insert key '%s' into split_hash", dup_name);
         }
         kh_val(split_hash, iter) = curr_stats; // store pointer to stats
     }
     else{
         curr_stats = kh_value(split_hash, k);
-        free(split_name); // don't need to hold on to this if it wasn't new
     }
     return curr_stats;
 }


### PR DESCRIPTION
Following 681b50ea, add more checks on aux tag types to ensure that the stored data is a NUL-terminated string before accessing it.

In most cases tags with unexpected types are simply ignored as if they don't exist.  An exception is samtools stats, which already reports an error if the tag it expects to split on is not present, so now it also does if the tag has the wrong type. The stats code is also made more efficient so that it doesn't try to `strdup()` the tag value unless it needs to add a new hash entry.

The stats man page is updated to note that the tag used for the `-S` option must have a string type.