### PR TITLE
Improve checks around khash insertions

### DIFF
--- a/amplicon_stats.c
+++ b/amplicon_stats.c
@@ -518,11 +518,13 @@ static int accumulate_stats(astats_args_t *args, amplicons_t *amps,
             free((void *)kh_key(stats->qend, k));
             kh_del(qname, stats->qend, k);
             //fprintf(stderr, "remove overlap %d to %d\n", (int)start, (int)mstart);
-        } else {
+        } else if (ret > 0) {
             if (!(kh_key(stats->qend, k) = strdup(bam_get_qname(b))))
                 return -1;
 
             kh_value(stats->qend, k) = start | (end << 32);
+        } else {
+            return -1;
         }
     }
     for (i = mstart; i < end && i < len; i++)
@@ -1737,11 +1739,15 @@ int main_ampliconstats(int argc, char **argv) {
         return usage(&oargs, stderr, EXIT_FAILURE);
 
     khash_t(bed_list_hash) *bed_hash = kh_init(bed_list_hash);
+    if (!bed_hash) {
+        print_error_errno("ampliconstats", "Couldn't allocate hash table");
+        return 1;
+    }
     if (load_bed_file_multi_ref(argv[optind], 1, 0, bed_hash, NULL, NULL)) {
         print_error_errno("ampliconstats",
                           "Could not read file \"%s\"", argv[optind]);
+        destroy_bed_hash(bed_hash);
         return 1;
-
     }
 
     khiter_t k, ref_count = 0;

--- a/bam2depth.c
+++ b/bam2depth.c
@@ -602,16 +602,19 @@ static int fastdepth_core(depth_opt *opt, uint32_t nfiles, char **fn,
             if (k == kh_end(overlaps[i])) {
                 // not seen before
                 hts_pos_t endpos = bam_endpos(b[i]);
-
                 // Don't add if mate location is known and can't overlap.
                 if (b[i]->core.mpos == -1 ||
                     (b[i]->core.tid == b[i]->core.mtid &&
                      b[i]->core.mpos <= endpos)) {
-                    k = kh_put(olap_hash, overlaps[i], bam_get_qname(b[i]),
-                               &ret);
-                    if (ret < 0)
+                    char *name_copy = strdup(bam_get_qname(b[i]));
+                    if (!name_copy)
                         return -1;
-                    kh_key(overlaps[i], k) = strdup(bam_get_qname(b[i]));
+
+                    k = kh_put(olap_hash, overlaps[i], name_copy, &ret);
+                    if (ret < 0) {
+                        free(name_copy);
+                        return -1;
+                    }
                     kh_value(overlaps[i], k) = endpos;
                 }
             } else {

--- a/bam_ampliconclip.c
+++ b/bam_ampliconclip.c
@@ -147,6 +147,7 @@ int load_bed_file_multi_ref(char *infile, int get_strand, int sort_by_pos, khash
                 if (hts_resize(char **, num_refs + 1, &ref_list_sz, ref_list, 0) < 0) {
                     fprintf(stderr, "[amplicon] error: unable to allocate memory for ref name list.\n");
                     ret = 1;
+                    free(ref_name);
                     goto error;
                 }
                 (*ref_list)[num_refs++] = ref_name;

--- a/bam_rmdup.c
+++ b/bam_rmdup.c
@@ -92,18 +92,32 @@ static void clear_del_set(khash_t(name) *del_set)
     kh_clear(name, del_set);
 }
 
+static lib_aux_t *add_new_aux(khash_t(lib) *aux, const char *lib)
+{
+    char *p = strdup(lib);
+    khash_t(pos) *best_hash = kh_init(pos);
+    if (!p || !best_hash)
+        goto fail;
+    int ret;
+    khint_t k = kh_put(lib, aux, p, &ret);
+    if (ret < 0)
+        goto fail;
+    lib_aux_t *q = &kh_val(aux, k);
+    q->n_checked = q->n_removed = 0;
+    q->best_hash = best_hash;
+    return q;
+
+ fail:
+    free(p);
+    kh_destroy(pos, best_hash);
+    return NULL;
+}
+
 static lib_aux_t *get_aux(khash_t(lib) *aux, const char *lib)
 {
     khint_t k = kh_get(lib, aux, lib);
     if (k == kh_end(aux)) {
-        int ret;
-        char *p = strdup(lib);
-        lib_aux_t *q;
-        k = kh_put(lib, aux, p, &ret);
-        q = &kh_val(aux, k);
-        q->n_checked = q->n_removed = 0;
-        q->best_hash = kh_init(pos);
-        return q;
+        return add_new_aux(aux, lib);
     } else return &kh_val(aux, k);
 }
 
@@ -177,6 +191,8 @@ int bam_rmdup_core(samFile *in, sam_hdr_t *hdr, samFile *out)
             int ret;
             lib = bam_get_library(hdr, b);
             q = lib? get_aux(aux, lib) : get_aux(aux, "\t");
+            if (!q)
+                goto fail;
             ++q->n_checked;
             k = kh_put(pos, q->best_hash, key, &ret);
             if (ret < 0) goto fail;

--- a/bam_rmdupse.c
+++ b/bam_rmdupse.c
@@ -61,7 +61,13 @@ static lib_aux_t *get_aux(khash_t(lib) *aux, const char *lib)
         int ret;
         char *p = strdup(lib);
         lib_aux_t *q;
+        if (!p)
+            return NULL;
         k = kh_put(lib, aux, p, &ret);
+        if (ret < 0) {
+            free(p);
+            return NULL;
+        }
         q = &kh_val(aux, k);
         q->left = kh_init(best);
         q->rght = kh_init(best);
@@ -81,6 +87,7 @@ static inline int sum_qual(const bam1_t *b)
 static inline elem_t *push_queue(queue_t *queue, const bam1_t *b, int endpos, int score)
 {
     elem_t *p = kl_pushp(q, queue);
+    if (!p) { perror(NULL); exit(EXIT_FAILURE); }
     p->discarded = 0;
     p->endpos = endpos; p->score = score;
     if (p->b == 0) p->b = bam_init1();
@@ -167,6 +174,8 @@ int bam_rmdupse_core(samFile *in, sam_hdr_t *hdr, samFile *out, int force_se)
             int ret;
             lib = bam_get_library(hdr, b);
             q = lib? get_aux(aux, lib) : get_aux(aux, "\t");
+            if (!q)
+                goto fail;
             ++q->n_checked;
             h = (c->flag&BAM_FREVERSE)? q->rght : q->left;
             key = (c->flag&BAM_FREVERSE)? endpos : c->pos;
@@ -185,7 +194,12 @@ int bam_rmdupse_core(samFile *in, sam_hdr_t *hdr, samFile *out, int force_se)
                         }
                     }
                 } // otherwise, discard the alignment
-            } else kh_val(h, k) = push_queue(queue, b, endpos, score);
+            } else if (ret > 0) {
+                kh_val(h, k) = push_queue(queue, b, endpos, score);
+            } else {
+                perror(NULL);
+                goto fail;
+            }
         }
     }
     if (r < -1) {

--- a/reset.c
+++ b/reset.c
@@ -77,7 +77,7 @@ static void usage(FILE *fp)
 /** @param config - pointer to conf_data
 returns nothing
 */
-void update_aux_conf(conf_data *config)
+int update_aux_conf(conf_data *config)
 {
     const char rg[] = "RG";
     const char *default_tags[] = {"AS", "CC", "CG", "CP", "H1", "H2", "HI", "H0", "IH",
@@ -86,11 +86,13 @@ void update_aux_conf(conf_data *config)
     int ret = 0, i = 0;
 
     if (!config)
-        return;
+        return 0;
 
     if (!config->aux_keep && !config->aux_remove) {
         //none of aux tag filter in use, create remove filter
         config->aux_remove = kh_init(aux_exists);
+        if (!config->aux_remove)
+            return -1;
     }
     if (config->aux_keep) {
         //keep set in use, remove RG if present
@@ -107,6 +109,8 @@ void update_aux_conf(conf_data *config)
             iter = kh_get(aux_exists, config->aux_remove, TAGNUM(rg));
             if (iter == kh_end(config->aux_remove)) {
                 kh_put(aux_exists, config->aux_remove, TAGNUM(rg), &ret);
+                if (ret < 0)
+                    return -1;
             }
         }
         //add the default tags if not present in remove set
@@ -115,9 +119,12 @@ void update_aux_conf(conf_data *config)
             iter = kh_get(aux_exists, config->aux_remove, TAGNUM(default_tags[i]));
             if (iter == kh_end(config->aux_remove)) {
                 kh_put(aux_exists, config->aux_remove, TAGNUM(default_tags[i]), &ret);
+                if (ret < 0)
+                    return -1;
             }
         }
     }
+    return 0;
 }
 
 /// removeauxtags - remove aux tags in bam data which are not present in acceptable tag set
@@ -575,7 +582,10 @@ int main_reset(int argc, char *argv[])
     }
 
     //update aux tag configuration
-    update_aux_conf(&resetconf);
+    if (update_aux_conf(&resetconf) < 0) {
+        fprintf(stderr, "Couldn't set up configuration\n");
+        goto exit;
+    }
     //set output file format based on name
     sam_open_mode(outmode + 1, outname, NULL);
 

--- a/sam_view.c
+++ b/sam_view.c
@@ -297,7 +297,7 @@ static int populate_lookup_from_file(const char *subcmd, strhash_t lookup, char 
         char *d = strdup(buf);
         if (d != NULL) {
             kh_put(str, lookup, d, &ret);
-            if (ret == 0) free(d); /* Duplicate */
+            if (ret <= 0) free(d); /* Duplicate or not added */
         } else {
             ret = -1;
         }

--- a/stats_isize.c
+++ b/stats_isize.c
@@ -89,8 +89,12 @@ static void sparse_set_f(isize_data_t data, int at, isize_insert_t field, uint64
             rec->isize_inward = 0;
             rec->isize_outward = 0;
             rec->isize_other = 0;
-            int stupid = 0;
-            khint_t it = kh_put(m32, h, at, & stupid);
+            int added = 0;
+            khint_t it = kh_put(m32, h, at, &added);
+            if (added < 0) {
+                fprintf(stderr, "Failed to add sparse insert size table entry");
+                exit(1);
+            }
             kh_value(h, it) = rec;
             a->max = max(at, a->max);
         } else {


### PR DESCRIPTION
Add checks to ensure entries have been correctly inserted into hash tables.  Ensure that an error is reported in some way if not, and where necessary that any data structures are tidied up so they are not left in a half-constructed state and memory leaks are prevented.