### PR TITLE
Improve error reporting in samtools dict

### DIFF
--- a/dict.c
+++ b/dict.c
@@ -39,40 +39,44 @@ KSEQ_INIT(gzFile, gzread)
 
 typedef struct _args_t
 {
-    char *output_fname, *alt_fname;
-    char *assembly, *species, *uri;
+    const char *output_fname, *alt_fname;
+    const char *assembly, *species, *uri;
     int  alias, header;
     khash_t(str) *is_alt;
 }
 args_t;
 
-static void write_dict(const char *fn, args_t *args)
+static int write_dict(const char *fn, args_t *args)
 {
-    hts_md5_context *md5;
-    int l, i, k;
+    hts_md5_context *md5 = NULL;
+    int l, i, k, retval = 1;
     gzFile fp;
-    kseq_t *seq;
+    kseq_t *seq = NULL;
     unsigned char digest[16];
     char hex[33];
 
     fp = strcmp(fn, "-") ? gzopen(fn, "r") : gzdopen(fileno(stdin), "r");
     if (fp == 0) {
         print_error_errno("dict", "Cannot open %s", fn);
-        exit(1);
+        return 1;
     }
     FILE *out = stdout;
     if (args->output_fname) {
         out = fopen(args->output_fname, "w");
         if (out == NULL) {
           print_error_errno("dict", "Cannot open %s for writing", args->output_fname);
-          exit(1);
+          goto bailout;
         }
     }
 
     if (!(md5 = hts_md5_init()))
-        exit(1);
+        goto bailout;
 
     seq = kseq_init(fp);
+    if (!seq) {
+        print_error_errno("dict", "Couldn't allocate sequence reader");
+        goto bailout;
+    }
     if (args->header) fprintf(out, "@HD\tVN:1.0\tSO:unsorted\n");
     while ((l = kseq_read(seq)) >= 0) {
         for (i = k = 0; i < seq->seq.l; ++i) {
@@ -108,33 +112,47 @@ static void write_dict(const char *fn, args_t *args)
 #else
             char *real_path = realpath(fn, NULL);
 #endif
-            fprintf(out, "\tUR:file://%s", real_path);
-            free(real_path);
+            if (real_path) {
+                fprintf(out, "\tUR:file://%s", real_path);
+                free(real_path);
+            }
         }
         if (args->assembly) fprintf(out, "\tAS:%s", args->assembly);
         if (args->species) fprintf(out, "\tSP:%s", args->species);
         fprintf(out, "\n");
     }
+    fflush(out);
+    if (ferror(out)) {
+        print_error_errno("dict", "Error writing to \"%s\"",
+                          args->output_fname ? args->output_fname : "stdout");
+        goto bailout;
+    }
+    retval = 0;
+
+ bailout:
+
     kseq_destroy(seq);
     hts_md5_destroy(md5);
 
     if (args->output_fname) fclose(out);
     gzclose(fp);
+    return retval;
 }
 
-static void read_alt_file(khash_t(str) *is_alt, const char *fname)
+static int read_alt_file(khash_t(str) *is_alt, const char *fname)
 {
     htsFile *fp = hts_open(fname, "r");
     if (fp == NULL) {
         print_error_errno("dict", "Cannot open %s", fname);
-        exit(1);
+        return -1;
     }
 
     // .alt files are in a SAM-like format, but we don't use sam_read1()
     // as these files may not have a complete set of @SQ headers.
 
     kstring_t str = KS_INITIALIZE;
-    while (hts_getline(fp, KS_SEP_LINE, &str) >= 0) {
+    int r;
+    while ((r = hts_getline(fp, KS_SEP_LINE, &str)) >= 0) {
         if (str.l == 0 || str.s[0] == '@') continue;
 
         char *tab = strchr(str.s, '\t');
@@ -142,12 +160,22 @@ static void read_alt_file(khash_t(str) *is_alt, const char *fname)
 
         int ret;
         char *seqname = strdup(str.s);
+        if (!seqname) { r = -2; break; }
         kh_put(str, is_alt, seqname, &ret);
-        if (ret == 0) free(seqname); // Already present
+        if (ret <= 0) free(seqname); // Already present or not added
+        if (ret < 0) { r = -2; break; }
+    }
+
+    if (r < -1) {
+        print_error_errno("dict", "Error reading \"%s\"", fname);
+        ks_free(&str);
+        hts_close(fp);
+        return -1;
     }
 
     ks_free(&str);
     hts_close(fp);
+    return 0;
 }
 
 static int dict_usage(void)
@@ -169,8 +197,17 @@ static int dict_usage(void)
 
 int dict_main(int argc, char *argv[])
 {
-    args_t *args = (args_t*) calloc(1,sizeof(args_t));
-    args->header = 1;
+    int retval = 1;
+    args_t args = {
+        NULL, // output_fname
+        NULL, // alt_fname
+        NULL, // assembly
+        NULL, // species
+        NULL, // uri
+        0, // alias
+        1, // header
+        NULL // is_alt
+    };
 
     static const struct option loptions[] =
     {
@@ -190,13 +227,13 @@ int dict_main(int argc, char *argv[])
     {
         switch (c)
         {
-            case 'A': args->alias = 1; break;
-            case 'a': args->assembly = optarg; break;
-            case 'l': args->alt_fname = optarg; break;
-            case 's': args->species = optarg; break;
-            case 'u': args->uri = optarg; break;
-            case 'o': args->output_fname = optarg; break;
-            case 'H': args->header = 0; break;
+            case 'A': args.alias = 1; break;
+            case 'a': args.assembly = optarg; break;
+            case 'l': args.alt_fname = optarg; break;
+            case 's': args.species = optarg; break;
+            case 'u': args.uri = optarg; break;
+            case 'o': args.output_fname = optarg; break;
+            case 'H': args.header = 0; break;
             case 'h': return dict_usage();
             default: return dict_usage();
         }
@@ -210,20 +247,26 @@ int dict_main(int argc, char *argv[])
     }
     else fname = argv[optind];
 
-    if (args->alt_fname) {
-        args->is_alt = kh_init(str);
-        read_alt_file(args->is_alt, args->alt_fname);
+    if (args.alt_fname) {
+        args.is_alt = kh_init(str);
+        if (!args.is_alt) {
+            print_error_errno("dict", "Couldn't allocate alt names table");
+            goto out;
+        }
+        if (read_alt_file(args.is_alt, args.alt_fname) < 0)
+            goto out;
     }
 
-    write_dict(fname, args);
+    retval = write_dict(fname, &args);
 
-    if (args->is_alt) {
+ out:
+
+    if (args.is_alt) {
         khint_t k;
-        for (k = 0; k < kh_end(args->is_alt); ++k)
-            if (kh_exist(args->is_alt, k)) free((char *) kh_key(args->is_alt, k));
-        kh_destroy(str, args->is_alt);
+        for (k = 0; k < kh_end(args.is_alt); ++k)
+            if (kh_exist(args.is_alt, k)) free((char *) kh_key(args.is_alt, k));
+        kh_destroy(str, args.is_alt);
     }
 
-    free(args);
-    return 0;
+    return retval;
 }

--- a/dict.c
+++ b/dict.c
@@ -199,14 +199,14 @@ int dict_main(int argc, char *argv[])
 {
     int retval = 1;
     args_t args = {
-        NULL, // output_fname
-        NULL, // alt_fname
-        NULL, // assembly
-        NULL, // species
-        NULL, // uri
-        0, // alias
-        1, // header
-        NULL // is_alt
+        .output_fname = NULL,
+        .alt_fname = NULL,
+        .assembly = NULL,
+        .species = NULL,
+        .uri = NULL,
+        .alias = 0,
+        .header = 1,
+        .is_alt = NULL
     };
 
     static const struct option loptions[] =


### PR DESCRIPTION
Be less optimistic about memory allocations working.

Change `args` in `dict_main()` to be on the stack so it is automatically cleaned up on exit, and make pointers to command-line arguments const.

Keep the return value from `hts_getline()` so that it's possible to tell if it reported a file read error.

Check `ferror()` on the output so at least some write errors can be detected.

Propagate errors up to `main()` via function return values instead of relying on `exit()` to bail out when things go wrong.