### PR TITLE
Improve memory handling when building translation tables for merge

### DIFF
--- a/bam_sort.c
+++ b/bam_sort.c
@@ -969,7 +969,32 @@ static void free_merged_header(merged_header_t *merged_hdr) {
     free(merged_hdr);
 }
 
-static void bam_translate(bam1_t* b, trans_tbl_t* tbl)
+static int warn_missing_tag(const char *tag_type, const char *tag_val,
+                            const char *qname, kh_c2c_t *trans_table) {
+    char *tmp = strdup(tag_val);
+    if (!tmp)
+        return -1;
+    fprintf(stderr,
+            "[bam_translate] %s tag \"%s\" on read \"%s\" encountered "
+            "with no corresponding entry in header, tag lost. "
+            "Unknown tags are only reported once per input file for "
+            "each tag ID.\n",
+            tag_type, tag_val, qname);
+    // Prevent future whinges
+    int in_there = 0;
+    khiter_t k = kh_put(c2c, trans_table, tmp, &in_there);
+    if (in_there > 0) {
+        kh_value(trans_table, k) = NULL;
+    } else {
+        free(tmp); // Was not added
+    }
+    if (in_there < 0)
+        return -1;
+    return 0;
+}
+
+
+static int bam_translate(bam1_t* b, trans_tbl_t* tbl)
 {
     // Update target id if not unmapped tid
     if ( b->core.tid >= 0 ) { b->core.tid = tbl->tid_trans[b->core.tid]; }
@@ -984,28 +1009,15 @@ static void bam_translate(bam1_t* b, trans_tbl_t* tbl)
             char* translate_rg = kh_value(tbl->rg_trans,k);
             bam_aux_del(b, rg);
             if (translate_rg) {
-                bam_aux_append(b, "RG", 'Z', strlen(translate_rg) + 1,
-                               (uint8_t*)translate_rg);
+                if (bam_aux_append(b, "RG", 'Z', strlen(translate_rg) + 1,
+                                   (uint8_t*)translate_rg) < 0)
+                    goto fail;
             }
         } else if (decoded_rg) {
-            char *tmp = strdup(decoded_rg);
-            fprintf(stderr,
-                    "[bam_translate] RG tag \"%s\" on read \"%s\" encountered "
-                    "with no corresponding entry in header, tag lost. "
-                    "Unknown tags are only reported once per input file for "
-                    "each tag ID.\n",
-                    decoded_rg, bam_get_qname(b));
+            if (warn_missing_tag("RG", decoded_rg,
+                                 bam_get_qname(b), tbl->rg_trans) < 0)
+                goto fail;
             bam_aux_del(b, rg);
-            // Prevent future whinges
-            if (tmp) {
-                int in_there = 0;
-                k = kh_put(c2c, tbl->rg_trans, tmp, &in_there);
-                if (in_there > 0) {
-                    kh_value(tbl->rg_trans, k) = NULL;
-                } else {
-                    free(tmp); // Was not added
-                }
-            }
         }
     }
 
@@ -1018,30 +1030,22 @@ static void bam_translate(bam1_t* b, trans_tbl_t* tbl)
             char* translate_pg = kh_value(tbl->pg_trans,k);
             bam_aux_del(b, pg);
             if (translate_pg) {
-                bam_aux_append(b, "PG", 'Z', strlen(translate_pg) + 1,
-                               (uint8_t*)translate_pg);
+                if (bam_aux_append(b, "PG", 'Z', strlen(translate_pg) + 1,
+                                   (uint8_t*)translate_pg) < 0)
+                    goto fail;
             }
         } else if (decoded_pg) {
-            char *tmp = strdup(decoded_pg);
-            fprintf(stderr,
-                    "[bam_translate] PG tag \"%s\" on read \"%s\" encountered "
-                    "with no corresponding entry in header, tag lost. "
-                    "Unknown tags are only reported once per input file for "
-                    "each tag ID.\n",
-                    decoded_pg, bam_get_qname(b));
+            if (warn_missing_tag("PG", decoded_pg,
+                                 bam_get_qname(b), tbl->pg_trans) < 0)
+                goto fail;
             bam_aux_del(b, pg);
-            // Prevent future whinges
-            if (tmp) {
-                int in_there = 0;
-                k = kh_put(c2c, tbl->pg_trans, tmp, &in_there);
-                if (in_there > 0) {
-                    kh_value(tbl->pg_trans, k) = NULL;
-                } else {
-                    free(tmp); // Was not added
-                }
-            }
         }
     }
+    return 0;
+
+ fail:
+    print_error_errno("merge", "Couldn't update RG/PG tags");
+    return -1;
 }
 
 int* rtrans_build(int n, int n_targets, trans_tbl_t* translation_tbl)
@@ -1429,7 +1433,8 @@ int bam_merge_core2(SamOrder sam_order, char* sort_tag, const char *out, const c
         if (!h->entry.bam_record) goto mem_fail;
         res = iter[i] ? sam_itr_next(fp[i], iter[i], h->entry.bam_record) : sam_read1(fp[i], hdr[i], h->entry.bam_record);
         if (res >= 0) {
-            bam_translate(h->entry.bam_record, translation_tbl + i);
+            if (bam_translate(h->entry.bam_record, translation_tbl + i) < 0)
+                goto fail;
             h->tid = h->entry.bam_record->core.tid;
             h->pos = (uint64_t)(h->entry.bam_record->core.pos + 1);
             h->rev = bam_is_rev(h->entry.bam_record);
@@ -1499,7 +1504,8 @@ int bam_merge_core2(SamOrder sam_order, char* sort_tag, const char *out, const c
             return -1;
         }
         if ((j = (iter[heap->i]? sam_itr_next(fp[heap->i], iter[heap->i], b) : sam_read1(fp[heap->i], hdr[heap->i], b))) >= 0) {
-            bam_translate(b, translation_tbl + heap->i);
+            if (bam_translate(b, translation_tbl + heap->i) < 0)
+                goto fail;
             heap->tid = b->core.tid;
             heap->pos = (uint64_t)(b->core.pos + 1);
             heap->rev = bam_is_rev(b);

--- a/bam_sort.c
+++ b/bam_sort.c
@@ -554,6 +554,10 @@ static klist_t(hdrln) * trans_rg_pg(bool is_rg, sam_hdr_t *translate,
     int num_ids, i;
     const char *rec_type = is_rg ? "RG" : "PG";
     klist_t(hdrln) *hdr_lines;
+    kstring_t orig_id = { 0, 0, NULL };        // ID in original header
+    kstring_t transformed_id = { 0, 0, NULL }; // ID in output header
+    kstring_t new_hdr_line = { 0, 0, NULL };
+    char *empty = NULL;
 
     hdr_lines = kl_init(hdrln);
 
@@ -563,11 +567,11 @@ static klist_t(hdrln) * trans_rg_pg(bool is_rg, sam_hdr_t *translate,
         goto fail;
 
     for (i = 0; i < num_ids; i++) {
-        kstring_t orig_id = { 0, 0, NULL };        // ID in original header
-        kstring_t transformed_id = { 0, 0, NULL }; // ID in output header
         char *map_value;    // Value to store in id_map
         bool id_changed;    // Have we changed the ID?
         bool not_found_in_output; // ID isn't in the output header (yet)
+
+        orig_id.l = transformed_id.l = 0;
 
         if (sam_hdr_find_tag_pos(translate, rec_type, i, "ID", &orig_id) < 0)
             goto fail;
@@ -608,7 +612,8 @@ static klist_t(hdrln) * trans_rg_pg(bool is_rg, sam_hdr_t *translate,
         // Does this line need to go into our output header?
         if (not_found_in_output) {
             // Take matched line and replace ID with transformed_id
-            kstring_t new_hdr_line = { 0, 0, NULL };
+            new_hdr_line.l = 0;
+
             if (sam_hdr_find_line_id(translate, rec_type,
                                      "ID", ks_str(&orig_id), &new_hdr_line) < 0){
                 goto fail;
@@ -644,6 +649,8 @@ static klist_t(hdrln) * trans_rg_pg(bool is_rg, sam_hdr_t *translate,
 
             // append line to output linked list
             char** ln = kl_pushp(hdrln, hdr_lines);
+            if (!ln)
+                goto memfail;
             *ln = ks_release(&new_hdr_line);  // Give away to linked list
 
             // Need to add it to known_ids set
@@ -651,55 +658,72 @@ static klist_t(hdrln) * trans_rg_pg(bool is_rg, sam_hdr_t *translate,
             iter = kh_put(cset, known_ids, ks_str(&transformed_id), &in_there);
             if (in_there < 0) goto memfail;
             assert(in_there > 0);  // Should not already be in the map
-            map_value = ks_release(&transformed_id);
+            map_value = ks_release(&transformed_id); // Now owned by hash table
         } else {
             // Use existing string in id_map
             assert(kh_exist(known_ids, iter));
             map_value = kh_key(known_ids, iter);
-            free(ks_release(&transformed_id));
         }
 
         // Insert it into our translation map
         int in_there = 0;
-        iter = kh_put(c2c, id_map, ks_release(&orig_id), &in_there);
+        iter = kh_put(c2c, id_map, ks_str(&orig_id), &in_there);
+        if (in_there < 0)
+            goto memfail;
+        ks_release(&orig_id); // Now owned by hash table
         kh_value(id_map, iter) = map_value;
     }
 
     // If there are no RG lines in the file and we are overriding add one
     if (is_rg && override && hdr_lines->size == 0) {
-        kstring_t new_id = {0, 0, NULL};
-        kstring_t line = {0, 0, NULL};
-        kstring_t empty = {0, 0, NULL};
         int in_there = 0;
         char** ln;
 
         // Get the new ID
-        if (gen_unique_id(override, known_ids, false, &new_id))
+        transformed_id.l = 0;
+        if (gen_unique_id(override, known_ids, false, &transformed_id))
             goto memfail;
 
         // Make into a header line and add to linked list
-        ksprintf(&line, "@RG\tID:%s", ks_str(&new_id));
+        new_hdr_line.l = 0;
+        if (ksprintf(&new_hdr_line, "@RG\tID:%s", ks_str(&transformed_id)) < 0)
+            goto memfail;
         ln = kl_pushp(hdrln, hdr_lines);
-        *ln = ks_release(&line);
+        if (!ln)
+            goto memfail;
+        *ln = ks_release(&new_hdr_line);
 
         // Put into known_ids set
-        iter = kh_put(cset, known_ids, ks_str(&new_id), &in_there);
+        iter = kh_put(cset, known_ids, ks_str(&transformed_id), &in_there);
         if (in_there < 0) goto memfail;
         assert(in_there > 0);  // Should be a new entry
+        char *new_id = ks_release(&transformed_id); // Now owned by hash table
 
         // Put into translation map (key is empty string)
-        if (kputs("", &empty) == EOF) goto memfail;
-        iter = kh_put(c2c, id_map, ks_release(&empty), &in_there);
+        if ((empty = strdup("")) == NULL) goto memfail;
+        iter = kh_put(c2c, id_map, empty, &in_there);
         if (in_there < 0) goto memfail;
         assert(in_there > 0);  // Should be a new entry
-        kh_value(id_map, iter) = ks_release(&new_id);
+        empty = NULL; // Now owned by hash table
+        kh_value(id_map, iter) = new_id;
     }
+
+    // Ensure these are cleaned up.  In theory only orig_id should contain
+    // anything, and then only if the last ID was already in known_ids, but
+    // no harm in checking the others.
+    ks_free(&orig_id);
+    ks_free(&transformed_id);
+    ks_free(&new_hdr_line);
 
     return hdr_lines;
 
  memfail:
     perror(__func__);
  fail:
+    ks_free(&orig_id);
+    ks_free(&transformed_id);
+    ks_free(&new_hdr_line);
+    free(empty);
     if (hdr_lines) kl_destroy(hdrln, hdr_lines);
     return NULL;
 }
@@ -976,7 +1000,11 @@ static void bam_translate(bam1_t* b, trans_tbl_t* tbl)
             if (tmp) {
                 int in_there = 0;
                 k = kh_put(c2c, tbl->rg_trans, tmp, &in_there);
-                if (in_there > 0) kh_value(tbl->rg_trans, k) = NULL;
+                if (in_there > 0) {
+                    kh_value(tbl->rg_trans, k) = NULL;
+                } else {
+                    free(tmp); // Was not added
+                }
             }
         }
     }
@@ -1006,7 +1034,11 @@ static void bam_translate(bam1_t* b, trans_tbl_t* tbl)
             if (tmp) {
                 int in_there = 0;
                 k = kh_put(c2c, tbl->pg_trans, tmp, &in_there);
-                if (in_there > 0) kh_value(tbl->pg_trans, k) = NULL;
+                if (in_there > 0) {
+                    kh_value(tbl->pg_trans, k) = NULL;
+                } else {
+                    free(tmp); // Was not added
+                }
             }
         }
     }
@@ -2644,6 +2676,8 @@ static int build_minhash_index(char *fn, int kmer, int window, int no_squash) {
             hashf = minhash(b, kmer, window, &pos, &end, NULL, 1, 0,
                             no_squash);
             k = kh_put(kmer, kmer_h, hashf, &ret);
+            if (ret < 0)
+                goto err;
             kh_value(kmer_h, k) = tpos+pos + (((uint64_t)!ret)<<UNIQ_BIT);
             pos = MAX(last_pos+kmer, pos+1);
             //pos++;  Slower, but indexes a bit better?


### PR DESCRIPTION
Check that hash table insertions and kstring functions worked.

Ensure pointer ownership is transferred correctly when setting hash table keys.

Clean up kstrings on failure to avoid leaking them.