### PR TITLE
Fix memory leaks when samtools view CLI bails.

### DIFF
--- a/sam_view.c
+++ b/sam_view.c
@@ -1047,7 +1047,8 @@ int main_samview(int argc, char *argv[])
 
             if (tmp_flag < 0) {
                 print_error("view", "Unknown flag '%s'", optarg);
-                return 1;
+                ret = 1;
+                goto view_end;
             }
 
             settings.flag_on |= tmp_flag;
@@ -1058,7 +1059,8 @@ int main_samview(int argc, char *argv[])
 
             if (tmp_flag < 0) {
                 print_error("view", "Unknown flag '%s'", optarg);
-                return 1;
+                ret = 1;
+                goto view_end;
             }
 
             settings.flag_off |= tmp_flag;
@@ -1069,7 +1071,8 @@ int main_samview(int argc, char *argv[])
 
             if (tmp_flag < 0) {
                 print_error("view", "Unknown flag '%s'", optarg);
-                return 1;
+                ret = 1;
+                goto view_end;
             }
 
             settings.flag_anyon |= tmp_flag;
@@ -1080,7 +1083,8 @@ int main_samview(int argc, char *argv[])
 
             if (tmp_flag < 0) {
                 print_error("view", "Unknown flag '%s'", optarg);
-                return 1;
+                ret = 1;
+                goto view_end;
             }
 
             settings.flag_alloff |= tmp_flag;
@@ -1243,7 +1247,8 @@ int main_samview(int argc, char *argv[])
         case 'e':
             if (!(settings.filter = hts_filter_init(optarg))) {
                 print_error("main_samview", "Couldn't initialise filter");
-                return 1;
+                ret = 1;
+                goto view_end;
             }
             settings.count_rf = INT_MAX; // no way to know what we need
             break;
@@ -1252,7 +1257,8 @@ int main_samview(int argc, char *argv[])
 
             if (tmp_flag < 0) {
                 print_error("view", "Unknown flag '%s'", optarg);
-                return 1;
+                ret = 1;
+                goto view_end;
             }
 
             settings.remove_flag |= tmp_flag;
@@ -1263,7 +1269,8 @@ int main_samview(int argc, char *argv[])
 
             if (tmp_flag < 0) {
                 print_error("view", "Unknown flag '%s'", optarg);
-                return 1;
+                ret = 1;
+                goto view_end;
             }
 
             settings.add_flag |= tmp_flag;
@@ -1302,7 +1309,8 @@ int main_samview(int argc, char *argv[])
     if (settings.is_count && settings.fetch_pairs)
     {
         print_error("view","The options -P and -c cannot be combined\n");
-        return 1;
+        ret = 1;
+        goto view_end;
     }
     if (settings.fn_fai == 0 && ga.reference) settings.fn_fai = fai_path(ga.reference);
     if (is_header_only) is_header = 1;
@@ -1518,7 +1526,8 @@ int main_samview(int argc, char *argv[])
         nregs = argc - optind - 1;
     } else if ( has_index_file && argc-optind < 2) {
         print_error("view", "Incorrect number of arguments for -X option. Aborting.");
-        return 1;
+        ret = 1;
+        goto view_end;
     }
     if (regs)
         settings.count_rf |= SAM_POS | SAM_RNAME | SAM_CIGAR;
@@ -1529,7 +1538,8 @@ int main_samview(int argc, char *argv[])
         if ( !settings.hts_idx )
         {
             print_error("view", "Random alignment retrieval only works for indexed SAM.gz, BAM or CRAM files.");
-            return 1;
+            ret = 1;
+            goto view_end;
         }
     }
 


### PR DESCRIPTION
Minimal impact.  It's just a "nice to have" thing to enable fuzz detection of memory leaks in actual running code.